### PR TITLE
Do not check for multiscale if path is dataset

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/N5Helpers.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/N5Helpers.java
@@ -110,7 +110,7 @@ public class N5Helpers
 		 * based on groupd content (the old way) TODO conider removing as
 		 * multi-scale declaration by attribute becomes part of the N5 spec.
 		 */
-		if ( !isMultiScale )
+		if ( !isMultiScale && !n5.datasetExists( dataset ) )
 		{
 			final String[] groups = n5.list( dataset );
 			isMultiScale = groups.length > 0;


### PR DESCRIPTION
`N5HDF5Reader.list( String path )` throws unchecked exception if `path` is dataset. Therefore, check if `path` is a dataset before listing contents.