### PR TITLE
Update meshes on paint

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Usage: Paintera [-h] [--height=HEIGHT] [--width=WIDTH]
 | `Ctrl` + `Shift` + `C` | Show ARGB stream seed spinner |
 | `V` | Toggle visibility of current source |
 | `Shift` + `V` | Toggle visibility of not-selected ids in current source (if label source) |
+| `R` | Clear mesh caches and refresh meshes (if current source is label source) |
 
 
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars.java
@@ -14,6 +14,7 @@ import org.janelia.saalfeldlab.fx.ui.ResizeOnLeftSide;
 import org.janelia.saalfeldlab.fx.util.InvokeOnJavaFXApplicationThread;
 import org.janelia.saalfeldlab.paintera.config.CrosshairConfig;
 import org.janelia.saalfeldlab.paintera.config.CrosshairConfigNode;
+import org.janelia.saalfeldlab.paintera.config.NavigationConfigNode;
 import org.janelia.saalfeldlab.paintera.config.OrthoSliceConfig;
 import org.janelia.saalfeldlab.paintera.config.OrthoSliceConfigNode;
 import org.janelia.saalfeldlab.paintera.control.navigation.CoordinateDisplayListener;
@@ -73,6 +74,8 @@ public class BorderPaneWithStatusBars
 	private final Label valueStatus;
 
 	private final ResizeOnLeftSide resizeSideBar;
+
+	private final NavigationConfigNode navigationConfigNode = new NavigationConfigNode();
 
 	private final CrosshairConfig crosshairConfig = new CrosshairConfig();
 
@@ -194,6 +197,7 @@ public class BorderPaneWithStatusBars
 		sourcesContents.setExpanded( false );
 
 		final VBox settingsContents = new VBox(
+				this.navigationConfigNode.getContents(),
 				new CrosshairConfigNode( crosshairConfig ).getContents(),
 				new OrthoSliceConfigNode( orthoSliceConfig ).getContents() );
 		final TitledPane settings = new TitledPane( "settings", settingsContents );
@@ -292,6 +296,11 @@ public class BorderPaneWithStatusBars
 				focusTR,
 				focusBL );
 
+	}
+
+	public NavigationConfigNode navigationConfigNode()
+	{
+		return this.navigationConfigNode;
 	}
 
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/Paintera.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/Paintera.java
@@ -15,7 +15,9 @@ import org.janelia.saalfeldlab.n5.N5Writer;
 import org.janelia.saalfeldlab.paintera.SaveProject.ProjectUndefined;
 import org.janelia.saalfeldlab.paintera.composition.ARGBCompositeAlphaYCbCr;
 import org.janelia.saalfeldlab.paintera.composition.CompositeCopy;
+import org.janelia.saalfeldlab.paintera.config.CrosshairConfig;
 import org.janelia.saalfeldlab.paintera.config.NavigationConfig;
+import org.janelia.saalfeldlab.paintera.config.OrthoSliceConfig;
 import org.janelia.saalfeldlab.paintera.control.assignment.FragmentSegmentAssignmentState;
 import org.janelia.saalfeldlab.paintera.control.selection.SelectedIds;
 import org.janelia.saalfeldlab.paintera.data.DataSource;
@@ -31,6 +33,7 @@ import org.janelia.saalfeldlab.paintera.state.SourceState;
 import org.janelia.saalfeldlab.paintera.stream.HighlightingStreamConverter;
 import org.janelia.saalfeldlab.paintera.stream.ModalGoldenAngleSaturatedHighlightingARGBStream;
 import org.janelia.saalfeldlab.paintera.viewer3d.Viewer3DFX;
+import org.janelia.saalfeldlab.util.Colors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,6 +45,7 @@ import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.input.KeyCode;
+import javafx.scene.paint.Color;
 import javafx.stage.Stage;
 import net.imglib2.Volatile;
 import net.imglib2.converter.ARGBColorConverter;
@@ -88,9 +92,27 @@ public class Paintera extends Application
 
 		final PainteraDefaultHandlers defaultHandlers = new PainteraDefaultHandlers( baseView, keyTracker, paneWithStatus );
 
+		// TODO (de-)seraizlie config
 		final NavigationConfig navigationConfig = new NavigationConfig();
 		paneWithStatus.navigationConfigNode().bind( navigationConfig );
 		navigationConfig.bindNavigationToConfig( defaultHandlers.navigation() );
+
+		final CrosshairConfig crosshairConfig = new CrosshairConfig();
+		paneWithStatus.crosshairConfigNode().bind( crosshairConfig );
+		crosshairConfig.bindCrosshairsToConfig( paneWithStatus.crosshairs().values() );
+		crosshairConfig.setOnFocusColor( Colors.CREMI );
+		crosshairConfig.setOutOfFocusColor( Color.WHITE.deriveColor( 0, 1, 1, 0.5 ) );
+
+		final OrthoSliceConfig orthoSliceConfig = new OrthoSliceConfig(
+				baseView.orthogonalViews().topLeft().viewer().visibleProperty(),
+				baseView.orthogonalViews().topRight().viewer().visibleProperty(),
+				baseView.orthogonalViews().bottomLeft().viewer().visibleProperty(),
+				baseView.sourceInfo().hasSources() );
+		paneWithStatus.orthoSliceConfigNode().bind( orthoSliceConfig );
+		orthoSliceConfig.bindOrthoSlicesToConifg(
+				paneWithStatus.orthoSlices().get( baseView.orthogonalViews().topLeft() ),
+				paneWithStatus.orthoSlices().get( baseView.orthogonalViews().topRight() ),
+				paneWithStatus.orthoSlices().get( baseView.orthogonalViews().bottomLeft() ) );
 
 		// populate everything
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/Paintera.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/Paintera.java
@@ -15,6 +15,7 @@ import org.janelia.saalfeldlab.n5.N5Writer;
 import org.janelia.saalfeldlab.paintera.SaveProject.ProjectUndefined;
 import org.janelia.saalfeldlab.paintera.composition.ARGBCompositeAlphaYCbCr;
 import org.janelia.saalfeldlab.paintera.composition.CompositeCopy;
+import org.janelia.saalfeldlab.paintera.config.NavigationConfig;
 import org.janelia.saalfeldlab.paintera.control.assignment.FragmentSegmentAssignmentState;
 import org.janelia.saalfeldlab.paintera.control.selection.SelectedIds;
 import org.janelia.saalfeldlab.paintera.data.DataSource;
@@ -85,8 +86,11 @@ public class Paintera extends Application
 				baseView,
 				painteraArgs::project );
 
-		@SuppressWarnings( "unused" )
 		final PainteraDefaultHandlers defaultHandlers = new PainteraDefaultHandlers( baseView, keyTracker, paneWithStatus );
+
+		final NavigationConfig navigationConfig = new NavigationConfig();
+		paneWithStatus.navigationConfigNode().bind( navigationConfig );
+		navigationConfig.bindNavigationToConfig( defaultHandlers.navigation() );
 
 		// populate everything
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/PainteraBaseView.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/PainteraBaseView.java
@@ -15,6 +15,7 @@ import org.janelia.saalfeldlab.paintera.composition.CompositeProjectorPreMultipl
 import org.janelia.saalfeldlab.paintera.data.DataSource;
 import org.janelia.saalfeldlab.paintera.data.mask.MaskedSource;
 import org.janelia.saalfeldlab.paintera.meshes.InterruptibleFunction;
+import org.janelia.saalfeldlab.paintera.meshes.InterruptibleFunctionAndCache;
 import org.janelia.saalfeldlab.paintera.meshes.cache.CacheUtils;
 import org.janelia.saalfeldlab.paintera.meshes.cache.UniqueLabelListLabelMultisetCacheLoader;
 import org.janelia.saalfeldlab.paintera.state.GlobalTransformManager;
@@ -221,13 +222,13 @@ public class PainteraBaseView
 		return this.generalPurposeExecutorService;
 	}
 
-	public static < D, T > InterruptibleFunction< Long, Interval[] >[] generateLabelBlocksForLabelCache(
+	public static < D, T > InterruptibleFunctionAndCache< Long, Interval[] >[] generateLabelBlocksForLabelCache(
 			final DataSource< D, T > spec )
 	{
 		return generateLabelBlocksForLabelCache( spec, scaleFactorsFromAffineTransforms( spec ) );
 	}
 
-	public static < D, T > InterruptibleFunction< Long, Interval[] >[] generateLabelBlocksForLabelCache(
+	public static < D, T > InterruptibleFunctionAndCache< Long, Interval[] >[] generateLabelBlocksForLabelCache(
 			final DataSource< D, T > spec,
 			final double[][] scalingFactors )
 	{
@@ -248,7 +249,7 @@ public class PainteraBaseView
 		return generateLabelBlocksForLabelCacheGeneric( spec, scalingFactors, collectLabels( spec.getDataType() ) );
 	}
 
-	private static < D, T > InterruptibleFunction< Long, Interval[] >[] generateLabelBlocksForLabelCacheGeneric(
+	private static < D, T > InterruptibleFunctionAndCache< Long, Interval[] >[] generateLabelBlocksForLabelCacheGeneric(
 			final DataSource< D, T > spec,
 			final double[][] scalingFactors,
 			final BiConsumer< D, TLongHashSet > collectLabels )
@@ -262,7 +263,7 @@ public class PainteraBaseView
 				collectLabels,
 				CacheUtils::toCacheSoftRefLoaderCache );
 
-		final InterruptibleFunction< Long, Interval[] >[] blocksForLabelCache = CacheUtils.blocksForLabelCachesLongKeys(
+		final InterruptibleFunctionAndCache< Long, Interval[] >[] blocksForLabelCache = CacheUtils.blocksForLabelCachesLongKeys(
 				spec,
 				uniqueLabelLoaders,
 				blockSizes,
@@ -273,7 +274,7 @@ public class PainteraBaseView
 
 	}
 
-	private static < T > InterruptibleFunction< Long, Interval[] >[] generateBlocksForLabelCacheLabelMultisetTypeCachedImg(
+	private static < T > InterruptibleFunctionAndCache< Long, Interval[] >[] generateBlocksForLabelCacheLabelMultisetTypeCachedImg(
 			final DataSource< LabelMultisetType, T > spec,
 			final double[][] scalingFactors )
 	{
@@ -295,7 +296,7 @@ public class PainteraBaseView
 			blockSizes[ level ] = IntStream.range( 0, grid.numDimensions() ).map( grid::cellDimension ).toArray();
 		}
 
-		final InterruptibleFunction< Long, Interval[] >[] blocksForLabelCache = CacheUtils.blocksForLabelCachesLongKeys(
+		final InterruptibleFunctionAndCache< Long, Interval[] >[] blocksForLabelCache = CacheUtils.blocksForLabelCachesLongKeys(
 				spec,
 				uniqueLabelLoaders,
 				blockSizes,

--- a/src/main/java/org/janelia/saalfeldlab/paintera/PainteraCommandLineArgs.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/PainteraCommandLineArgs.java
@@ -111,7 +111,7 @@ public class PainteraCommandLineArgs implements Callable< Boolean >
 		{
 			screenScales[ i ] = screenScaleFactor * screenScales[ i - 1 ];
 		}
-		LOG.warn( "Retruning screen scales {}", screenScales );
+		LOG.debug( "Returning screen scales {}", screenScales );
 		return screenScales;
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/PainteraDefaultHandlers.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/PainteraDefaultHandlers.java
@@ -378,4 +378,9 @@ public class PainteraDefaultHandlers
 				column, row );
 	}
 
+	public Navigation navigation()
+	{
+		return this.navigation;
+	}
+
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/PainteraDefaultHandlers.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/PainteraDefaultHandlers.java
@@ -17,6 +17,7 @@ import org.janelia.saalfeldlab.fx.ortho.OrthogonalViews;
 import org.janelia.saalfeldlab.fx.ortho.OrthogonalViews.ViewerAndTransforms;
 import org.janelia.saalfeldlab.fx.ortho.ResizableGridPane2x2;
 import org.janelia.saalfeldlab.fx.ortho.ViewerAxis;
+import org.janelia.saalfeldlab.paintera.control.CurrentSourceRefreshMeshes;
 import org.janelia.saalfeldlab.paintera.control.CurrentSourceVisibilityToggle;
 import org.janelia.saalfeldlab.paintera.control.FitToInterval;
 import org.janelia.saalfeldlab.paintera.control.Merges;
@@ -222,6 +223,9 @@ public class PainteraDefaultHandlers
 			}
 		} );
 		EventFX.KEY_PRESSED( "maximize bottom row", e -> isRowMaximized.set( !isRowMaximized.get() ), e -> keyTracker.areOnlyTheseKeysDown( KeyCode.M, KeyCode.SHIFT ) ).installInto( paneWithStatus.getPane() );
+
+		final CurrentSourceRefreshMeshes meshRefresher = new CurrentSourceRefreshMeshes( sourceInfo.currentState()::get );
+		EventFX.KEY_PRESSED( "refresh meshes", e -> meshRefresher.refresh(), e -> keyTracker.areOnlyTheseKeysDown( KeyCode.R ) ).installInto( paneWithStatus.getPane() );
 
 		// TODO does MouseEvent.getPickResult make the coordinate tracker
 		// obsolete?

--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/Config.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/Config.java
@@ -1,0 +1,23 @@
+package org.janelia.saalfeldlab.paintera.config;
+
+public class Config
+{
+
+	public final NavigationConfig navigation;
+
+	public final OrthoSliceConfig orthoSlices;
+
+	public final CrosshairConfig crosshairs;
+
+	public Config(
+			final NavigationConfig navigation,
+			final OrthoSliceConfig orthoSlices,
+			final CrosshairConfig crosshairs )
+	{
+		super();
+		this.navigation = navigation;
+		this.orthoSlices = orthoSlices;
+		this.crosshairs = crosshairs;
+	}
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/CrosshairConfig.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/CrosshairConfig.java
@@ -1,5 +1,10 @@
 package org.janelia.saalfeldlab.paintera.config;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.janelia.saalfeldlab.paintera.ui.Crosshair;
+
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -76,5 +81,22 @@ public class CrosshairConfig
 	public ObservableBooleanValue wasChanged()
 	{
 		return this.wasChanged();
+	}
+
+	public void bindCrosshairsToConfig( final Collection< Crosshair > crosshairs )
+	{
+		crosshairs.stream().forEach( this::bindCrosshairToConfig );
+	}
+
+	public void bindCrosshairsToConfig( final Crosshair... crosshairs )
+	{
+		this.bindCrosshairsToConfig( Arrays.asList( crosshairs ) );
+	}
+
+	public void bindCrosshairToConfig( final Crosshair crosshair )
+	{
+		crosshair.highlightColorProperty().bind( this.onFocusColor );
+		crosshair.regularColorProperty().bind( this.outOfFocusColor );
+		crosshair.isVisibleProperty().bind( this.showCrosshairs );
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/CrosshairConfigNode.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/CrosshairConfigNode.java
@@ -15,22 +15,21 @@ public class CrosshairConfigNode
 
 	private final TitledPane contents;
 
-	public CrosshairConfigNode( final CrosshairConfig config )
+	private final CheckBox showCrosshairs = new CheckBox();
+
+	private final ColorPicker onFocusColorPicker = new ColorPicker();
+
+	private final ColorPicker outOfFocusColorPicker = new ColorPicker();
+
+	public CrosshairConfigNode()
 	{
 		super();
 
-		final CheckBox showCrosshairs = new CheckBox();
-		showCrosshairs.selectedProperty().bindBidirectional( config.showCrosshairsProperty() );
-
 		final GridPane grid = new GridPane();
 
-		final ColorPicker onFocusColorPicker = new ColorPicker();
-		onFocusColorPicker.valueProperty().bindBidirectional( config.onFocusColorProperty() );
 		onFocusColorPicker.setMaxWidth( 40 );
 		onFocusColorPicker.getCustomColors().addAll( Colors.cremi( 1.0 ), Colors.cremi( 0.5 ) );
 
-		final ColorPicker outOfFocusColorPicker = new ColorPicker();
-		outOfFocusColorPicker.valueProperty().bindBidirectional( config.outOfFocusColorProperty() );
 		outOfFocusColorPicker.setMaxWidth( 40 );
 		outOfFocusColorPicker.getCustomColors().addAll( Colors.cremi( 1.0 ), Colors.cremi( 0.5 ) );
 
@@ -49,6 +48,13 @@ public class CrosshairConfigNode
 		contents.setGraphic( showCrosshairs );
 		contents.setExpanded( false );
 
+	}
+
+	public void bind( final CrosshairConfig config )
+	{
+		showCrosshairs.selectedProperty().bindBidirectional( config.showCrosshairsProperty() );
+		onFocusColorPicker.valueProperty().bindBidirectional( config.onFocusColorProperty() );
+		outOfFocusColorPicker.valueProperty().bindBidirectional( config.outOfFocusColorProperty() );
 	}
 
 	public Node getContents()

--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/CrosshairConfigNode.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/CrosshairConfigNode.java
@@ -45,7 +45,7 @@ public class CrosshairConfigNode
 		GridPane.setHgrow( onFocusLabel, Priority.ALWAYS );
 		GridPane.setHgrow( offFocusLabel, Priority.ALWAYS );
 
-		contents = new TitledPane( "crosshair", grid );
+		contents = new TitledPane( "Crosshair", grid );
 		contents.setGraphic( showCrosshairs );
 		contents.setExpanded( false );
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/NavigationConfig.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/NavigationConfig.java
@@ -1,0 +1,23 @@
+package org.janelia.saalfeldlab.paintera.config;
+
+import org.janelia.saalfeldlab.paintera.control.Navigation;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+
+public class NavigationConfig
+{
+
+	private final BooleanProperty allowRotations = new SimpleBooleanProperty( true );
+
+	public BooleanProperty allowRotationsProperty()
+	{
+		return this.allowRotations;
+	}
+
+	public void bindNavigationToConfig( final Navigation navigation )
+	{
+		navigation.allowRotationsProperty().bind( this.allowRotations );
+	}
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/NavigationConfigNode.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/NavigationConfigNode.java
@@ -1,0 +1,46 @@
+package org.janelia.saalfeldlab.paintera.config;
+
+import javafx.scene.Node;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.TitledPane;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+
+public class NavigationConfigNode
+{
+
+	private final TitledPane contents = new TitledPane( "Navigation", null );
+
+	private final CheckBox allowRotationsCheckBox = new CheckBox();
+
+	public NavigationConfigNode()
+	{
+		final GridPane grid = new GridPane();
+		contents.setContent( grid );
+		contents.setExpanded( false );
+
+		int row = 0;
+		{
+			final Label label = new Label( "Rotations" );
+			final Region spacer = new Region();
+			grid.add( label, 0, row );
+			grid.add( spacer, 1, row );
+			grid.add( allowRotationsCheckBox, 2, row );
+			GridPane.setHgrow( spacer, Priority.ALWAYS );
+			++row;
+		}
+	}
+
+	public void bind( final NavigationConfig config )
+	{
+		allowRotationsCheckBox.selectedProperty().bindBidirectional( config.allowRotationsProperty() );
+	}
+
+	public Node getContents()
+	{
+		return contents;
+	}
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/OrthoSliceConfig.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/OrthoSliceConfig.java
@@ -17,29 +17,25 @@ public class OrthoSliceConfig
 
 	private final BooleanProperty showBottomLeft = new SimpleBooleanProperty( true );
 
-	private final OrthoSliceFX topLeft;
+	final ObservableBooleanValue isTopLeftVisible;
 
-	private final OrthoSliceFX topRight;
+	final ObservableBooleanValue isTopRightVisible;
 
-	private final OrthoSliceFX bottomLeft;
+	final ObservableBooleanValue isBottomLeftVisible;
+
+	private final ObservableBooleanValue hasSources;
 
 	public OrthoSliceConfig(
-			final OrthoSliceFX topLeft,
-			final OrthoSliceFX topRight,
-			final OrthoSliceFX bottomLeft,
 			final ObservableBooleanValue isTopLeftVisible,
 			final ObservableBooleanValue isTopRightVisible,
 			final ObservableBooleanValue isBottomLeftVisible,
 			final ObservableBooleanValue hasSources )
 	{
 		super();
-		this.topLeft = topLeft;
-		this.topRight = topRight;
-		this.bottomLeft = bottomLeft;
-
-		this.topLeft.isVisibleProperty().bind( showTopLeft.and( enable ).and( hasSources ).and( isTopLeftVisible ) );
-		this.topRight.isVisibleProperty().bind( showTopRight.and( enable ).and( hasSources ).and( isTopRightVisible ) );
-		this.bottomLeft.isVisibleProperty().bind( showBottomLeft.and( enable ).and( hasSources ).and( isBottomLeftVisible ) );
+		this.isTopLeftVisible = isTopLeftVisible;
+		this.isTopRightVisible = isTopRightVisible;
+		this.isBottomLeftVisible = isBottomLeftVisible;
+		this.hasSources = hasSources;
 	}
 
 	public BooleanProperty enableProperty()
@@ -60,6 +56,16 @@ public class OrthoSliceConfig
 	public BooleanProperty showBottomLeftProperty()
 	{
 		return this.showBottomLeft;
+	}
+
+	public void bindOrthoSlicesToConifg(
+			final OrthoSliceFX topLeft,
+			final OrthoSliceFX topRight,
+			final OrthoSliceFX bottomLeft )
+	{
+		topLeft.isVisibleProperty().bind( showTopLeft.and( enable ).and( hasSources ).and( isTopLeftVisible ) );
+		topRight.isVisibleProperty().bind( showTopRight.and( enable ).and( hasSources ).and( isTopRightVisible ) );
+		bottomLeft.isVisibleProperty().bind( showBottomLeft.and( enable ).and( hasSources ).and( isBottomLeftVisible ) );
 	}
 
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/OrthoSliceConfigNode.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/OrthoSliceConfigNode.java
@@ -12,26 +12,23 @@ public class OrthoSliceConfigNode
 
 	private final TitledPane contents;
 
-	public OrthoSliceConfigNode( final OrthoSliceConfig config )
+	private final CheckBox topLeftCheckBox = new CheckBox();
+
+	private final CheckBox topRightCheckBox = new CheckBox();
+
+	private final CheckBox bottomLeftCheckBox = new CheckBox();
+
+	private final CheckBox showOrthoViews = new CheckBox();
+
+	public OrthoSliceConfigNode()
 	{
 		super();
-
-		final CheckBox showOrthoViews = new CheckBox();
-		showOrthoViews.selectedProperty().bindBidirectional( config.enableProperty() );
 
 		final GridPane grid = new GridPane();
 
 		final Label topLeftLabel = new Label( "top left" );
 		final Label topRightLabel = new Label( "top right" );
 		final Label bottomLeftLabel = new Label( "bottom left" );
-
-		final CheckBox topLeftCheckBox = new CheckBox();
-		final CheckBox topRightCheckBox = new CheckBox();
-		final CheckBox bottomLeftCheckBox = new CheckBox();
-
-		topLeftCheckBox.selectedProperty().bindBidirectional( config.showTopLeftProperty() );
-		topRightCheckBox.selectedProperty().bindBidirectional( config.showTopRightProperty() );
-		bottomLeftCheckBox.selectedProperty().bindBidirectional( config.showBottomLeftProperty() );
 
 		grid.add( topLeftLabel, 0, 0 );
 		grid.add( topRightLabel, 0, 1 );
@@ -49,6 +46,14 @@ public class OrthoSliceConfigNode
 		contents.setGraphic( showOrthoViews );
 		contents.setExpanded( false );
 
+	}
+
+	public void bind( final OrthoSliceConfig config )
+	{
+		showOrthoViews.selectedProperty().bindBidirectional( config.enableProperty() );
+		topLeftCheckBox.selectedProperty().bindBidirectional( config.showTopLeftProperty() );
+		topRightCheckBox.selectedProperty().bindBidirectional( config.showTopRightProperty() );
+		bottomLeftCheckBox.selectedProperty().bindBidirectional( config.showBottomLeftProperty() );
 	}
 
 	public Node getContents()

--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/OrthoSliceConfigNode.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/OrthoSliceConfigNode.java
@@ -45,7 +45,7 @@ public class OrthoSliceConfigNode
 		GridPane.setHgrow( topRightLabel, Priority.ALWAYS );
 		GridPane.setHgrow( bottomLeftLabel, Priority.ALWAYS );
 
-		contents = new TitledPane( "orthoviews", grid );
+		contents = new TitledPane( "Ortho-Views", grid );
 		contents.setGraphic( showOrthoViews );
 		contents.setExpanded( false );
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/CurrentSourceRefreshMeshes.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/CurrentSourceRefreshMeshes.java
@@ -1,0 +1,34 @@
+package org.janelia.saalfeldlab.paintera.control;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.janelia.saalfeldlab.paintera.state.LabelSourceState;
+import org.janelia.saalfeldlab.paintera.state.SourceState;
+
+public class CurrentSourceRefreshMeshes
+{
+
+	private final Supplier< SourceState< ?, ? > > currentState;
+
+	public CurrentSourceRefreshMeshes( final Supplier< SourceState< ?, ? > > currentState )
+	{
+		super();
+		this.currentState = currentState;
+	}
+
+	public void refresh()
+	{
+		Optional
+				.ofNullable( currentState.get() )
+				.filter( state -> state instanceof LabelSourceState< ?, ? > )
+				.map( state -> ( LabelSourceState< ?, ? > ) state )
+				.ifPresent( this::refresh );
+	}
+
+	private void refresh( final LabelSourceState< ?, ? > state )
+	{
+		state.refreshMeshes();
+	}
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/Navigation.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/Navigation.java
@@ -317,7 +317,9 @@ public class Navigation implements ToOnEnterOnExit
 					rotate.initialize();
 				}
 				else
+				{
 					abortDrag();
+				}
 			}
 
 			@Override
@@ -327,6 +329,11 @@ public class Navigation implements ToOnEnterOnExit
 			}
 		};
 
+	}
+
+	public BooleanProperty allowRotationsProperty()
+	{
+		return this.allowRotations;
 	}
 
 	private static final EventFX< KeyEvent > keyRotationHandler(
@@ -356,7 +363,9 @@ public class Navigation implements ToOnEnterOnExit
 				name,
 				event -> {
 					if ( allowRotations.getAsBoolean() )
+					{
 						rotate.rotate( rotationCenterX.getAsDouble(), rotationCenterY.getAsDouble() );
+					}
 				},
 				predicate );
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/data/mask/MaskedSource.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/data/mask/MaskedSource.java
@@ -307,9 +307,7 @@ public class MaskedSource< D extends Type< D >, T extends Type< T > > implements
 
 				final TLongSet paintedBlocksAtHighestResolution = this.scaleBlocksToLevel( affectedBlocks, maskInfo.level, 0 );
 
-				System.out.println( 1 );
 				this.affectedBlocksByLabel[ maskInfo.level ].computeIfAbsent( maskInfo.value.getIntegerLong(), key -> new TLongHashSet() ).addAll( affectedBlocks );
-				System.out.println( 2 );
 				LOG.warn( "Added affected block: {}", affectedBlocksByLabel[ maskInfo.level ] );
 				this.affectedBlocks.addAll( paintedBlocksAtHighestResolution );
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/data/mask/MaskedSource.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/data/mask/MaskedSource.java
@@ -448,9 +448,6 @@ public class MaskedSource< D extends Type< D >, T extends Type< T > > implements
 					try
 					{
 						this.persistCanvas.accept( canvas, affectedBlocks );
-					}
-					finally
-					{
 						clearCanvases();
 						for ( int level = 0; level < this.getNumMipmapLevels(); ++level )
 						{
@@ -459,6 +456,9 @@ public class MaskedSource< D extends Type< D >, T extends Type< T > > implements
 							LOG.debug( "Invalidating all for viewer source for level={}", level );
 							invalidateAllIfCachedImg( this.source.getSource( 0, level ) );
 						}
+					}
+					finally
+					{
 						synchronized ( this )
 						{
 							this.isPersisting.set( false );

--- a/src/main/java/org/janelia/saalfeldlab/paintera/data/mask/MaskedSource.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/data/mask/MaskedSource.java
@@ -703,7 +703,7 @@ public class MaskedSource< D extends Type< D >, T extends Type< T > > implements
 				throw new RuntimeException( "Non-integer relative scales: " + Arrays.toString( relativeScales ) );
 			}
 			final TLongSet affectedBlocksAtHigherLevel = this.scaleBlocksToLevel( paintedBlocksAtPaintedScale, paintedLevel, level );
-			this.affectedBlocksByLabel[ level ].get( label.getIntegerLong() ).addAll( affectedBlocksAtHigherLevel );
+			this.affectedBlocksByLabel[ level ].computeIfAbsent( label.getIntegerLong(), key -> new TLongHashSet() ).addAll( affectedBlocksAtHigherLevel );
 
 			// downsample
 			final int[] steps = DoubleStream.of( relativeScales ).mapToInt( d -> ( int ) d ).toArray();
@@ -722,7 +722,7 @@ public class MaskedSource< D extends Type< D >, T extends Type< T > > implements
 			LOG.debug( "Upsampling for level={}", level );
 			final TLongSet affectedBlocksAtLowerLevel = this.scaleBlocksToLevel( paintedBlocksAtPaintedScale, paintedLevel, level );
 			final double[] currentRelativeScaleFromTargetToPainted = DataSource.getRelativeScales( this, 0, level, paintedLevel );
-			this.affectedBlocksByLabel[ level ].get( label.getIntegerLong() ).addAll( affectedBlocksAtLowerLevel );
+			this.affectedBlocksByLabel[ level ].computeIfAbsent( label.getIntegerLong(), key -> new TLongHashSet() ).addAll( affectedBlocksAtLowerLevel );
 
 			final Interval paintedIntervalAtTargetLevel = scaleIntervalToLevel( intervalAtPaintedScale, paintedLevel, level );
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/data/mask/MaskedSourceDeserializer.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/data/mask/MaskedSourceDeserializer.java
@@ -3,6 +3,7 @@ package org.janelia.saalfeldlab.paintera.data.mask;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Type;
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.function.BiConsumer;
 import java.util.function.IntFunction;
@@ -15,6 +16,7 @@ import org.janelia.saalfeldlab.paintera.state.SourceState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.reflect.TypeToken;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
@@ -29,15 +31,15 @@ public class MaskedSourceDeserializer implements JsonDeserializer< MaskedSource<
 
 	private static final Logger LOG = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
 
-	private static final String UNDERLYING_SOURCE_CLASS_KEY = "sourceClass";
+	private static final String UNDERLYING_SOURCE_CLASS_KEY = MaskedSourceSerializer.UNDERLYING_SOURCE_CLASS_KEY;
 
-	private static final String UNDERLYING_SOURCE_KEY = "source";
+	private static final String UNDERLYING_SOURCE_KEY = MaskedSourceSerializer.UNDERLYING_SOURCE_KEY;
 
-	private static final String CURRENT_CACHE_DIR_KEY = "cacheDir";
+	private static final String CURRENT_CACHE_DIR_KEY = MaskedSourceSerializer.CURRENT_CACHE_DIR_KEY;
 
-	private static final String PERSIST_CANVAS_CLASS_KEY = "persistCanvasClass";
+	private static final String PERSIST_CANVAS_CLASS_KEY = MaskedSourceSerializer.PERSIST_CANVAS_CLASS_KEY;
 
-	private static final String PERSIST_CANVAS_KEY = "persistCanvas";
+	private static final String PERSIST_CANVAS_KEY = MaskedSourceSerializer.PERSIST_CANVAS_KEY;
 
 	private final Supplier< String > currentProjectDirectory;
 
@@ -71,9 +73,20 @@ public class MaskedSourceDeserializer implements JsonDeserializer< MaskedSource<
 			final String initialCanvasPath = map.get( CURRENT_CACHE_DIR_KEY ).getAsString();
 
 			final DataSource< ?, ? > masked = Masks.mask( source, initialCanvasPath, canvasCacheDirUpdate, mergeCanvasIntoBackground, propagationExecutor );
-			return masked instanceof MaskedSource< ?, ? >
+			MaskedSource< ?, ? > returnVal = masked instanceof MaskedSource< ?, ? >
 					? ( MaskedSource< ?, ? > ) masked
 					: null;
+
+			if ( returnVal != null )
+			{
+				Type mapType = new TypeToken< HashMap< Long, long[] >[] >(){}.getType();
+				long[] blocks = context.deserialize( map.get( MaskedSourceSerializer.DIRTY_BLOCKS_KEY ), long[].class );
+				HashMap< Long, long []>[] blocksById = context.deserialize( map.get( MaskedSourceSerializer.DIRTY_BLOCKS_BY_ID_KEY ), mapType );
+				returnVal.affectBlocks( blocks, blocksById );
+			}
+
+			return returnVal;
+
 		}
 		catch ( final ClassNotFoundException e )
 		{

--- a/src/main/java/org/janelia/saalfeldlab/paintera/data/mask/MaskedSourceSerializer.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/data/mask/MaskedSourceSerializer.java
@@ -14,17 +14,21 @@ import com.google.gson.JsonSerializer;
 public class MaskedSourceSerializer implements JsonSerializer< MaskedSource< ?, ? > >
 {
 
-	private static final Logger LOG = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
+	public static final Logger LOG = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
 
-	private static final String UNDERLYING_SOURCE_CLASS_KEY = "sourceClass";
+	public static final String UNDERLYING_SOURCE_CLASS_KEY = "sourceClass";
 
-	private static final String UNDERLYING_SOURCE_KEY = "source";
+	public static final String UNDERLYING_SOURCE_KEY = "source";
 
-	private static final String CURRENT_CACHE_DIR_KEY = "cacheDir";
+	public static final String CURRENT_CACHE_DIR_KEY = "cacheDir";
 
-	private static final String PERSIST_CANVAS_CLASS_KEY = "persistCanvasClass";
+	public static final String PERSIST_CANVAS_CLASS_KEY = "persistCanvasClass";
 
-	private static final String PERSIST_CANVAS_KEY = "persistCanvas";
+	public static final String PERSIST_CANVAS_KEY = "persistCanvas";
+
+	public static final String DIRTY_BLOCKS_KEY = "dirtyBlocks";
+
+	public static final String DIRTY_BLOCKS_BY_ID_KEY = "dirtyBlocksById";
 
 	@Override
 	public JsonElement serialize( final MaskedSource< ?, ? > src, final Type type, final JsonSerializationContext context )
@@ -38,6 +42,8 @@ public class MaskedSourceSerializer implements JsonSerializer< MaskedSource< ?, 
 //		map.addProperty( CURRENT_CACHE_DIR_KEY, Paths.get( currentProjectDirectory.get() ).relativize( Paths.get( src.currentCanvasDirectory() ) ).toString() );
 		map.addProperty( PERSIST_CANVAS_CLASS_KEY, src.getPersister().getClass().getName() );
 		map.add( PERSIST_CANVAS_KEY, context.serialize( src.getPersister(), src.getPersister().getClass() ) );
+		map.add( DIRTY_BLOCKS_KEY, context.serialize( src.getAffectedBlocks() ) );
+		map.add( DIRTY_BLOCKS_BY_ID_KEY, context.serialize( src.getAffectedBlocksById() ) );
 		return map;
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/meshes/InterruptibleFunction.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/meshes/InterruptibleFunction.java
@@ -1,5 +1,6 @@
 package org.janelia.saalfeldlab.paintera.meshes;
 
+import java.util.Arrays;
 import java.util.function.Function;
 
 public interface InterruptibleFunction< T, R > extends Function< T, R >, Interruptible< T >
@@ -29,6 +30,15 @@ public interface InterruptibleFunction< T, R > extends Function< T, R >, Interru
 	public static < T, R > InterruptibleFunction< T, R > fromFunction( final Function< T, R > function )
 	{
 		return fromFunctionAndInterruptible( function, t -> {} );
+	}
+
+	@SuppressWarnings( "unchecked" )
+	public static < T, R > InterruptibleFunction< T, R >[] fromFunction( final Function< T, R >[] functions )
+	{
+		return Arrays
+				.stream( functions )
+				.map( InterruptibleFunction::fromFunction )
+				.toArray( InterruptibleFunction[]::new );
 	}
 
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/meshes/MeshManager.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/meshes/MeshManager.java
@@ -33,4 +33,6 @@ public interface MeshManager< T >
 
 	public long[] containedFragments( T t );
 
+	public void refreshMeshes();
+
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/meshes/MeshManagerSimple.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/meshes/MeshManagerSimple.java
@@ -63,6 +63,9 @@ public class MeshManagerSimple< T > implements MeshManager< T >
 
 	private final Function< T, long[] > getIds;
 
+	// TODO actually do something
+	private final Runnable refreshMeshes = () -> {};
+
 	public MeshManagerSimple(
 			final InterruptibleFunction< T, Interval[] >[] blockListCache,
 			final InterruptibleFunction< ShapeKey< T >, Pair< float[], float[] > >[] meshCache,
@@ -111,9 +114,7 @@ public class MeshManagerSimple< T > implements MeshManager< T >
 
 		for ( final T neuron : neurons.keySet() )
 		{
-			if ( neuron.equals( id ) ) {
-				return;
-			}
+			if ( neuron.equals( id ) ) { return; }
 		}
 
 		LOG.debug( "Adding mesh for segment {} (composed of ids={}).", id, getIds.apply( id ) );
@@ -215,6 +216,12 @@ public class MeshManagerSimple< T > implements MeshManager< T >
 	public long[] containedFragments( final T id )
 	{
 		return getIds.apply( id );
+	}
+
+	@Override
+	public void refreshMeshes()
+	{
+		this.refreshMeshes.run();
 	}
 
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/meshes/MeshManagerWithAssignment.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/meshes/MeshManagerWithAssignment.java
@@ -70,6 +70,8 @@ public class MeshManagerWithAssignment implements MeshManager< Long >
 
 	private final ExecutorService workers;
 
+	private final Runnable refreshMeshes;
+
 	public MeshManagerWithAssignment(
 			final DataSource< ?, ? > source,
 			final InterruptibleFunction< Long, Interval[] >[] blockListCache,
@@ -81,6 +83,7 @@ public class MeshManagerWithAssignment implements MeshManager< Long >
 			final ObservableIntegerValue meshSimplificationIterations,
 			final ObservableDoubleValue smoothingLambda,
 			final ObservableIntegerValue smooothingIterations,
+			final Runnable refreshMeshes,
 			final ExecutorService managers,
 			final ExecutorService workers )
 	{
@@ -92,6 +95,7 @@ public class MeshManagerWithAssignment implements MeshManager< Long >
 		this.assignment = assignment;
 		this.fragmentsInSelectedSegments = fragmentsInSelectedSegments;
 		this.stream = stream;
+		this.refreshMeshes = refreshMeshes;
 
 		this.meshSimplificationIterations.set( Math.max( meshSimplificationIterations.get(), 0 ) );
 		meshSimplificationIterations.addListener( ( obs, oldv, newv ) -> {
@@ -143,9 +147,7 @@ public class MeshManagerWithAssignment implements MeshManager< Long >
 
 		for ( final MeshGenerator< Long > neuron : neurons.values() )
 		{
-			if ( neuron.getId() == id ) {
-				return;
-			}
+			if ( neuron.getId() == id ) { return; }
 		}
 
 		LOG.debug( "Adding mesh for segment {}.", id );
@@ -246,6 +248,12 @@ public class MeshManagerWithAssignment implements MeshManager< Long >
 	public long[] containedFragments( final Long id )
 	{
 		return assignment.getFragments( id ).toArray();
+	}
+
+	@Override
+	public void refreshMeshes()
+	{
+		this.refreshMeshes.run();
 	}
 
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceState.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceState.java
@@ -213,11 +213,11 @@ public class LabelSourceState< D, T >
 			final int[] blockSize = new int[ imgDim.length ];
 			grid.cellDimensions( blockSize );
 			functions[ level ] = id -> {
-				LOG.warn( "Getting blocks at level={} for id={}", fLevel, id );
+				LOG.debug( "Getting blocks at level={} for id={}", fLevel, id );
 				final long[] blockMin = new long[ grid.numDimensions() ];
 				final long[] blockMax = new long[ grid.numDimensions() ];
 				final TLongSet indexedBlocks = source.getModifiedBlocks( fLevel, id );
-				LOG.warn( "Received modified blocks at level={} for id={}: {}", fLevel, id, indexedBlocks );
+				LOG.debug( "Received modified blocks at level={} for id={}: {}", fLevel, id, indexedBlocks );
 				final Interval[] intervals = new Interval[ indexedBlocks.size() ];
 				final TLongIterator blockIt = indexedBlocks.iterator();
 				for ( int i = 0; blockIt.hasNext(); ++i )
@@ -228,7 +228,7 @@ public class LabelSourceState< D, T >
 					Arrays.setAll( blockMax, d -> Math.min( blockMin[ d ] + blockSize[ d ], imgDim[ d ] ) - 1 );
 					intervals[ i ] = new FinalInterval( blockMin, blockMax );
 				}
-				LOG.warn( "Returning {} intervals", intervals.length );
+				LOG.debug( "Returning {} intervals", intervals.length );
 				return intervals;
 			};
 		}
@@ -243,7 +243,7 @@ public class LabelSourceState< D, T >
 	{
 		assert f1.length == f2.length;
 
-		LOG.warn( "Combining two functions {} and {}", f1, f2 );
+		LOG.debug( "Combining two functions {} and {}", f1, f2 );
 
 		@SuppressWarnings( "unchecked" )
 		final InterruptibleFunction< T, U >[] f = new InterruptibleFunction[ f1.length ];
@@ -270,7 +270,7 @@ public class LabelSourceState< D, T >
 			final Set< HashWrapper< Interval > > intervals = new HashSet<>();
 			Arrays.stream( t ).map( HashWrapper::interval ).forEach( intervals::add );
 			Arrays.stream( u ).map( HashWrapper::interval ).forEach( intervals::add );
-			LOG.warn( "Combined {} and {} to {}", t, u, intervals );
+			LOG.debug( "Combined {} and {} to {}", t, u, intervals );
 			return intervals.stream().map( HashWrapper::getData ).toArray( Interval[]::new );
 		}
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceState.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceState.java
@@ -128,6 +128,7 @@ public class LabelSourceState< D, T >
 				new SimpleIntegerProperty(),
 				new SimpleDoubleProperty(),
 				new SimpleIntegerProperty(),
+				this::refreshMeshes,
 				meshManagerExecutors,
 				meshWorkersExecutors );
 		final MeshInfos< TLongHashSet > meshInfos = new MeshInfos<>( selectedSegments, assignment, meshManager, assignment::getFragments, dataSource.getNumMipmapLevels() );
@@ -183,6 +184,16 @@ public class LabelSourceState< D, T >
 				.stream( this.meshCaches )
 				.forEach( UncheckedCache::invalidateAll );
 		this.clearBlockCaches.run();
+	}
+
+	public void refreshMeshes()
+	{
+		this.invalidateAll();
+		final long[] selection = this.selectedIds.getActiveIds();
+		final long lastSelection = this.selectedIds.getLastSelection();
+		this.selectedIds.deactivateAll();
+		this.selectedIds.activate( selection );
+		this.selectedIds.activateAlso( lastSelection );
 	}
 
 	private static Function< Long, Interval[] >[] blockCacheForMaskedSource(

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceState.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceState.java
@@ -1,7 +1,12 @@
 package org.janelia.saalfeldlab.paintera.state;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.LongFunction;
 
@@ -11,8 +16,10 @@ import org.janelia.saalfeldlab.paintera.control.assignment.FragmentSegmentAssign
 import org.janelia.saalfeldlab.paintera.control.selection.SelectedIds;
 import org.janelia.saalfeldlab.paintera.control.selection.SelectedSegments;
 import org.janelia.saalfeldlab.paintera.data.DataSource;
+import org.janelia.saalfeldlab.paintera.data.mask.MaskedSource;
 import org.janelia.saalfeldlab.paintera.id.IdService;
 import org.janelia.saalfeldlab.paintera.id.ToIdConverter;
+import org.janelia.saalfeldlab.paintera.meshes.Interruptible;
 import org.janelia.saalfeldlab.paintera.meshes.InterruptibleFunction;
 import org.janelia.saalfeldlab.paintera.meshes.InterruptibleFunctionAndCache;
 import org.janelia.saalfeldlab.paintera.meshes.MeshInfos;
@@ -23,25 +30,34 @@ import org.janelia.saalfeldlab.paintera.meshes.cache.BlocksForLabelDelegate;
 import org.janelia.saalfeldlab.paintera.meshes.cache.CacheUtils;
 import org.janelia.saalfeldlab.paintera.meshes.cache.SegmentMaskGenerators;
 import org.janelia.saalfeldlab.paintera.stream.HighlightingStreamConverter;
+import org.janelia.saalfeldlab.util.HashWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import gnu.trove.iterator.TLongIterator;
+import gnu.trove.set.TLongSet;
 import gnu.trove.set.hash.TLongHashSet;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.scene.Group;
+import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
 import net.imglib2.cache.UncheckedCache;
 import net.imglib2.converter.Converter;
+import net.imglib2.img.cell.CellGrid;
 import net.imglib2.type.logic.BoolType;
 import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.util.Pair;
 
 public class LabelSourceState< D, T >
-extends
-MinimalSourceState< D, T, DataSource< D, T >, HighlightingStreamConverter< T > >
-implements
-HasMeshes< TLongHashSet >,
-HasMeshCache< TLongHashSet >
+		extends
+		MinimalSourceState< D, T, DataSource< D, T >, HighlightingStreamConverter< T > >
+		implements
+		HasMeshes< TLongHashSet >,
+		HasMeshCache< TLongHashSet >
 {
+
+	private static final Logger LOG = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
 
 	private final LongFunction< Converter< D, BoolType > > maskForLabel;
 
@@ -58,6 +74,8 @@ HasMeshCache< TLongHashSet >
 	private final MeshManager< TLongHashSet > meshManager;
 
 	private final MeshInfos< TLongHashSet > meshInfos;
+
+	private final Runnable clearBlockCaches;
 
 	private final InterruptibleFunctionAndCache< ShapeKey< TLongHashSet >, Pair< float[], float[] > >[] meshCaches;
 
@@ -84,14 +102,21 @@ HasMeshCache< TLongHashSet >
 
 		final SelectedSegments selectedSegments = new SelectedSegments( selectedIds, assignment );
 
-		final InterruptibleFunction< Long, Interval[] >[] blockCaches = PainteraBaseView.generateLabelBlocksForLabelCache( dataSource );
+		final InterruptibleFunctionAndCache< Long, Interval[] >[] backgroundBlockCaches = PainteraBaseView.generateLabelBlocksForLabelCache( dataSource );
+		this.clearBlockCaches = () -> Arrays.stream( backgroundBlockCaches ).forEach( UncheckedCache::invalidateAll );
+
+		final InterruptibleFunction< Long, Interval[] >[] blockCaches = dataSource instanceof MaskedSource< ?, ? >
+				? combineInterruptibleFunctions( backgroundBlockCaches, InterruptibleFunction.fromFunction( blockCacheForMaskedSource( ( MaskedSource< ?, ? > ) dataSource ) ), new IntervalsCombiner() )
+				: backgroundBlockCaches;
 
 		final BlocksForLabelDelegate< TLongHashSet, Long >[] delegateBlockCaches = BlocksForLabelDelegate.delegate( blockCaches, ids -> Arrays.stream( ids.toArray() ).mapToObj( id -> id ).toArray( Long[]::new ), meshWorkersExecutors );
 
-		this.meshCaches = CacheUtils.segmentMeshCacheLoaders(
+		final InterruptibleFunctionAndCache< ShapeKey< TLongHashSet >, Pair< float[], float[] > >[] meshCaches = CacheUtils.segmentMeshCacheLoaders(
 				dataSource,
 				segmentMaskGenerator,
 				CacheUtils::toCacheSoftRefLoaderCache );
+		this.meshCaches = meshCaches;
+
 		final MeshManagerWithAssignmentForSegments meshManager = new MeshManagerWithAssignmentForSegments(
 				dataSource,
 				delegateBlockCaches,
@@ -155,8 +180,88 @@ HasMeshCache< TLongHashSet >
 	public void invalidateAll()
 	{
 		Arrays
-		.stream( this.meshCaches )
-		.forEach( UncheckedCache::invalidateAll );
+				.stream( this.meshCaches )
+				.forEach( UncheckedCache::invalidateAll );
+		this.clearBlockCaches.run();
 	}
 
+	private static Function< Long, Interval[] >[] blockCacheForMaskedSource(
+			final MaskedSource< ?, ? > source )
+	{
+
+		final int numLevels = source.getNumMipmapLevels();
+
+		@SuppressWarnings( "unchecked" )
+		final Function< Long, Interval[] >[] functions = new Function[ numLevels ];
+
+		for ( int level = 0; level < numLevels; ++level )
+		{
+			final int fLevel = level;
+			final CellGrid grid = source.getCellGrid( 0, level );
+			final long[] imgDim = grid.getImgDimensions();
+			final int[] blockSize = new int[ imgDim.length ];
+			grid.cellDimensions( blockSize );
+			functions[ level ] = id -> {
+				LOG.warn( "Getting blocks at level={} for id={}", fLevel, id );
+				final long[] blockMin = new long[ grid.numDimensions() ];
+				final long[] blockMax = new long[ grid.numDimensions() ];
+				final TLongSet indexedBlocks = source.getModifiedBlocks( fLevel, id );
+				LOG.warn( "Received modified blocks at level={} for id={}: {}", fLevel, id, indexedBlocks );
+				final Interval[] intervals = new Interval[ indexedBlocks.size() ];
+				final TLongIterator blockIt = indexedBlocks.iterator();
+				for ( int i = 0; blockIt.hasNext(); ++i )
+				{
+					final long blockIndex = blockIt.next();
+					grid.getCellGridPositionFlat( blockIndex, blockMin );
+					Arrays.setAll( blockMin, d -> blockMin[ d ] * blockSize[ d ] );
+					Arrays.setAll( blockMax, d -> Math.min( blockMin[ d ] + blockSize[ d ], imgDim[ d ] ) - 1 );
+					intervals[ i ] = new FinalInterval( blockMin, blockMax );
+				}
+				LOG.warn( "Returning {} intervals", intervals.length );
+				return intervals;
+			};
+		}
+
+		return functions;
+	}
+
+	private static < T, U, V, W > InterruptibleFunction< T, U >[] combineInterruptibleFunctions(
+			final InterruptibleFunction< T, V >[] f1,
+			final InterruptibleFunction< T, W >[] f2,
+			final BiFunction< V, W, U > combiner )
+	{
+		assert f1.length == f2.length;
+
+		LOG.warn( "Combining two functions {} and {}", f1, f2 );
+
+		@SuppressWarnings( "unchecked" )
+		final InterruptibleFunction< T, U >[] f = new InterruptibleFunction[ f1.length ];
+		for ( int i = 0; i < f.length; ++i )
+		{
+			final InterruptibleFunction< T, V > ff1 = f1[ i ];
+			final InterruptibleFunction< T, W > ff2 = f2[ i ];
+			final List< Interruptible< T > > interrupts = Arrays.asList( ff1, ff2 );
+			f[ i ] = InterruptibleFunction.fromFunctionAndInterruptible(
+					t -> combiner.apply( ff1.apply( t ), ff2.apply( t ) ),
+					t -> interrupts.forEach( interrupt -> interrupt.interruptFor( t ) ) );
+		}
+		return f;
+	}
+
+	private static class IntervalsCombiner implements BiFunction< Interval[], Interval[], Interval[] >
+	{
+
+		private static final Logger LOG = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
+
+		@Override
+		public Interval[] apply( final Interval[] t, final Interval[] u )
+		{
+			final Set< HashWrapper< Interval > > intervals = new HashSet<>();
+			Arrays.stream( t ).map( HashWrapper::interval ).forEach( intervals::add );
+			Arrays.stream( u ).map( HashWrapper::interval ).forEach( intervals::add );
+			LOG.warn( "Combined {} and {} to {}", t, u, intervals );
+			return intervals.stream().map( HashWrapper::getData ).toArray( Interval[]::new );
+		}
+
+	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/ui/source/mesh/MeshPane.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/ui/source/mesh/MeshPane.java
@@ -93,7 +93,10 @@ public class MeshPane implements BindUnbindAndNodeSupplier, ListChangeListener< 
 		this.cullFaceChoice = new ComboBox<>( FXCollections.observableArrayList( CullFace.values() ) );
 		this.cullFaceChoice.setValue( CullFace.FRONT );
 
-		managerSettingsPane = new VBox( new Label( "Defaults" ), setupManagerSliderGrid(), meshesPane );
+		final Button refresh = new Button( "Refresh meshes" );
+		refresh.setOnAction( event -> manager.refreshMeshes() );
+
+		managerSettingsPane = new VBox( new Label( "Defaults" ), setupManagerSliderGrid(), refresh, meshesPane );
 
 		this.meshInfos.readOnlyInfos().addListener( this );
 
@@ -157,16 +160,14 @@ public class MeshPane implements BindUnbindAndNodeSupplier, ListChangeListener< 
 
 				@SuppressWarnings( "unchecked" )
 				final InterruptibleFunction< TLongHashSet, Interval[] >[][] blockListCaches = Stream
-				.generate( manager::blockListCache )
-				.limit( meshInfos.readOnlyInfos().size() )
-				.toArray( InterruptibleFunction[][]::new );
+						.generate( manager::blockListCache )
+						.limit( meshInfos.readOnlyInfos().size() )
+						.toArray( InterruptibleFunction[][]::new );
 
 				final InterruptibleFunction< ShapeKey< TLongHashSet >, Pair< float[], float[] > >[][] meshCaches = Stream
 						.generate( manager::meshCache )
 						.limit( meshInfos.readOnlyInfos().size() )
 						.toArray( InterruptibleFunction[][]::new );
-
-
 
 				parameters.getMeshExporter().exportMesh(
 						blockListCaches,
@@ -193,7 +194,7 @@ public class MeshPane implements BindUnbindAndNodeSupplier, ListChangeListener< 
 		contents.add( opacitySlider.slider(), 1, row );
 		contents.add( opacitySlider.textField(), 2, row );
 		opacitySlider.slider().setShowTickLabels( true );
-		opacitySlider.slider().setTooltip( new Tooltip( "Mesh opacity")  );
+		opacitySlider.slider().setTooltip( new Tooltip( "Mesh opacity" ) );
 		++row;
 
 		contents.add( new Label( "Scale" ), 0, row );
@@ -217,11 +218,11 @@ public class MeshPane implements BindUnbindAndNodeSupplier, ListChangeListener< 
 		smoothingIterationsSlider.slider().setTooltip( new Tooltip( "Default for smoothing iterations." ) );
 		++row;
 
-		contents.add( new Label("Draw Mode"), 0, row );
+		contents.add( new Label( "Draw Mode" ), 0, row );
 		contents.add( drawModeChoice, 2, row );
 		++row;
 
-		contents.add( new Label("CullFace "), 0, row );
+		contents.add( new Label( "CullFace " ), 0, row );
 		contents.add( cullFaceChoice, 2, row );
 		++row;
 


### PR DESCRIPTION
Addresses 3/5 of the bullet points in #1:
 - [x] add button to UI to trigger mesh refresh
 - [x] automatically clear background block caches on merge into background
 - [x] (de-)serialize modified blocks

The other bullet points cannot be addressed before the imglib2-cache feature `invalidateMatching( Predicate< K > )` is implemented, therfore closes #1