### PR TITLE
Use keySet instead of values in MeshManagerSimple.removeAllMeshes

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/meshes/MeshManagerSimple.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/meshes/MeshManagerSimple.java
@@ -142,10 +142,10 @@ public class MeshManagerSimple< N, T > implements MeshManager< N, T >
 	@Override
 	public void removeMesh( final N id )
 	{
-		Optional.ofNullable( this.neurons.remove( id ) ).ifPresent( this::removeMesh );
+		Optional.ofNullable( this.neurons.remove( id ) ).ifPresent( this::disable );
 	}
 
-	private void removeMesh( final MeshGenerator< T > mesh )
+	private void disable( final MeshGenerator< T > mesh )
 	{
 		mesh.isEnabledProperty().set( false );
 	}
@@ -183,8 +183,8 @@ public class MeshManagerSimple< N, T > implements MeshManager< N, T >
 	@Override
 	public void removeAllMeshes()
 	{
-		final ArrayList< MeshGenerator< T > > generatorsCopy = new ArrayList<>( unmodifiableMeshMap().values() );
-		generatorsCopy.forEach( this::removeMesh );
+		final ArrayList< N > keysCopy = new ArrayList<>( unmodifiableMeshMap().keySet() );
+		keysCopy.forEach( this::removeMesh );
 	}
 
 	@Override


### PR DESCRIPTION
 - In the (private) method `MeshManagerSimple.removeMesh( MeshGenerator )`, the generator is not removed from the map. In subsequent calls to `MeshManager.addMesh`, no new mesh is added (because the entry is already present). Instead, call `MeshManagerSimple.removeMesh( N )`.
 - Rename `MeshManagerSimple.removeMesh( MeshGenerator )` to `MeshManagerSimple.disable( MeshGenerator )` to reduce ambiguity

Fixes #54