### PR TITLE
Force project directory

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/Paintera.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/Paintera.java
@@ -69,9 +69,9 @@ public class Paintera extends Application
 	{
 		NO_PROJECT_SPECIFIED( 1, "No Paintera project specified" );
 		;
-		private final int code;
+		public final int code;
 
-		private final String description;
+		public final String description;
 
 		private Error( final int code, final String description )
 		{

--- a/src/main/java/org/janelia/saalfeldlab/paintera/Paintera.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/Paintera.java
@@ -114,7 +114,7 @@ public class Paintera extends Application
 
 		final String projectDir = Optional
 				.ofNullable( painteraArgs.project() )
-				.orElseGet( new ProjectDirectoryNotSpecifiedDialog()
+				.orElseGet( new ProjectDirectoryNotSpecifiedDialog( painteraArgs.defaultToTempDirectory() )
 						.showDialog( "No project directory specified on command line. You can specify a project directory or start Paintera without specifying a project directory." )::get );
 
 		final PainteraBaseView baseView = new PainteraBaseView(

--- a/src/main/java/org/janelia/saalfeldlab/paintera/Paintera.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/Paintera.java
@@ -65,8 +65,36 @@ public class Paintera extends Application
 
 	public static final String PAINTERA_KEY = "paintera";
 
+	public enum Error
+	{
+		NO_PROJECT_SPECIFIED( 1, "No Paintera project specified" );
+		;
+		private final int code;
+
+		private final String description;
+
+		private Error( final int code, final String description )
+		{
+			this.code = code;
+			this.description = description;
+		}
+	}
+
 	@Override
 	public void start( final Stage stage ) throws Exception
+	{
+		try
+		{
+			startImpl( stage );
+		}
+		catch ( final ProjectDirectoryNotSpecified e )
+		{
+			LOG.error( Error.NO_PROJECT_SPECIFIED.description );
+			System.exit( Error.NO_PROJECT_SPECIFIED.code );
+		}
+	}
+
+	public void startImpl( final Stage stage ) throws Exception
 	{
 
 		final Parameters parameters = getParameters();

--- a/src/main/java/org/janelia/saalfeldlab/paintera/PainteraCommandLineArgs.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/PainteraCommandLineArgs.java
@@ -51,6 +51,9 @@ public class PainteraCommandLineArgs implements Callable< Boolean >
 	@Option( names = "--print-error-codes", paramLabel = "PRINT_ERROR_CODES", required = false, description = "List all error codes and exit." )
 	private Boolean printErrorCodes;
 
+	@Option( names = "--default-to-temp-directory", paramLabel = "DEFAULT_TO_TEMP_DIRECTORY", required = false, description = "Default to temporary directory instead of showing dialog when PROJECT is not specified." )
+	private Boolean defaultToTempDirectory;
+
 	@Override
 	public Boolean call() throws Exception
 	{
@@ -79,6 +82,8 @@ public class PainteraCommandLineArgs implements Callable< Boolean >
 			}
 			return false;
 		}
+
+		defaultToTempDirectory = defaultToTempDirectory == null ? false : defaultToTempDirectory;
 
 		return true;
 	}
@@ -113,6 +118,11 @@ public class PainteraCommandLineArgs implements Callable< Boolean >
 	public double[] screenScales()
 	{
 		return this.screenScales.clone();
+	}
+
+	public boolean defaultToTempDirectory()
+	{
+		return this.defaultToTempDirectory;
 	}
 
 	private static double[] createScreenScales( final int numScreenScales, final double highestScreenScale, final double screenScaleFactor ) throws ZeroLengthScreenScales

--- a/src/main/java/org/janelia/saalfeldlab/paintera/PainteraCommandLineArgs.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/PainteraCommandLineArgs.java
@@ -48,6 +48,9 @@ public class PainteraCommandLineArgs implements Callable< Boolean >
 	@Parameters( index = "0", paramLabel = "PROJECT", arity = "0..1", description = "Optional project N5 root (N5 or HDF5)." )
 	private String project;
 
+	@Option( names = "--print-error-codes", paramLabel = "PRINT_ERROR_CODES", required = false, description = "List all error codes and exit." )
+	private Boolean printErrorCodes;
+
 	@Override
 	public Boolean call() throws Exception
 	{
@@ -64,6 +67,17 @@ public class PainteraCommandLineArgs implements Callable< Boolean >
 		if ( screenScales != null )
 		{
 			checkScreenScales( screenScales );
+		}
+
+		printErrorCodes = printErrorCodes == null ? false : printErrorCodes;
+		if ( printErrorCodes )
+		{
+			LOG.info( "Error codes:" );
+			for ( final Paintera.Error error : Paintera.Error.values() )
+			{
+				LOG.info( "{} -- {}", error.code, error.description );
+			}
+			return false;
 		}
 
 		return true;

--- a/src/main/java/org/janelia/saalfeldlab/paintera/ProjectDirectoryNotSpecified.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/ProjectDirectoryNotSpecified.java
@@ -1,0 +1,6 @@
+package org.janelia.saalfeldlab.paintera;
+
+public class ProjectDirectoryNotSpecified extends Exception
+{
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/ProjectDirectoryNotSpecifiedDialog.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/ProjectDirectoryNotSpecifiedDialog.java
@@ -24,8 +24,19 @@ public class ProjectDirectoryNotSpecifiedDialog
 
 	private static final Logger LOG = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
 
+	private final boolean defaultToTempDirectory;
+
+	public ProjectDirectoryNotSpecifiedDialog( final boolean defaultToTempDirectory )
+	{
+		super();
+		this.defaultToTempDirectory = defaultToTempDirectory;
+	}
+
 	public Optional< String > showDialog( final String contentText ) throws ProjectDirectoryNotSpecified
 	{
+
+		if ( this.defaultToTempDirectory ) { return Optional.of( tmpDir() ); }
+
 		final StringProperty projectDirectory = new SimpleStringProperty( null );
 
 		final ButtonType specifyProject = new ButtonType( "Specify Project", ButtonData.OTHER );

--- a/src/main/java/org/janelia/saalfeldlab/paintera/ProjectDirectoryNotSpecifiedDialog.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/ProjectDirectoryNotSpecifiedDialog.java
@@ -1,0 +1,96 @@
+package org.janelia.saalfeldlab.paintera;
+
+import java.io.File;
+import java.lang.invoke.MethodHandles;
+import java.util.Optional;
+
+import org.janelia.saalfeldlab.paintera.data.mask.TmpDirectoryCreator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.event.ActionEvent;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonBar.ButtonData;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.Dialog;
+import javafx.scene.control.Tooltip;
+import javafx.stage.DirectoryChooser;
+
+public class ProjectDirectoryNotSpecifiedDialog
+{
+
+	private static final Logger LOG = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
+
+	public Optional< String > showDialog( final String contentText ) throws ProjectDirectoryNotSpecified
+	{
+		final StringProperty projectDirectory = new SimpleStringProperty( null );
+
+		final ButtonType specifyProject = new ButtonType( "Specify Project", ButtonData.OTHER );
+		final ButtonType noProject = new ButtonType( "No Project", ButtonData.OK_DONE );
+
+		final Dialog< String > dialog = new Dialog<>();
+		dialog.setResultConverter( bt -> {
+			return ButtonType.CANCEL.equals( bt )
+					? null
+					: noProject.equals( bt )
+							? tmpDir()
+							: projectDirectory.get();
+		} );
+
+		dialog.getDialogPane().getButtonTypes().setAll( specifyProject, noProject, ButtonType.CANCEL );
+		dialog.setTitle( "Paintera" );
+		dialog.setHeaderText( "Specify Project Directory" );
+		dialog.setContentText( contentText );
+
+		final Node lookupProjectButton = dialog.getDialogPane().lookupButton( specifyProject );
+		if ( lookupProjectButton instanceof Button )
+		{
+			( ( Button ) lookupProjectButton ).setTooltip( new Tooltip( "Look up project directory." ) );
+		}
+		Optional
+				.ofNullable( dialog.getDialogPane().lookupButton( noProject ) )
+				.filter( b -> b instanceof Button )
+				.map( b -> ( Button ) b )
+				.ifPresent( b -> b.setTooltip( new Tooltip( "Create temporary project in /tmp." ) ) );
+		Optional
+				.ofNullable( dialog.getDialogPane().lookupButton( ButtonType.CANCEL ) )
+				.filter( b -> b instanceof Button )
+				.map( b -> ( Button ) b )
+				.ifPresent( b -> b.setTooltip( new Tooltip( "Do not start Paintera." ) ) );
+
+		lookupProjectButton.addEventFilter( ActionEvent.ACTION, event -> {
+			final DirectoryChooser chooser = new DirectoryChooser();
+			final Optional< String > d = Optional.ofNullable( chooser.showDialog( dialog.getDialogPane().getScene().getWindow() ) ).map( File::getAbsolutePath );
+			if ( d.isPresent() )
+			{
+				projectDirectory.set( d.get() );
+			}
+			else
+			{
+				// consume on cancel, so that parent dialog does not get closed.
+				event.consume();
+			}
+		} );
+
+		dialog.setResizable( true );
+
+		final Optional< String > returnVal = dialog.showAndWait();
+
+		if ( !returnVal.isPresent() ) { throw new ProjectDirectoryNotSpecified(); }
+
+		return returnVal;
+
+	}
+
+	private static String tmpDir()
+	{
+		// TODO read tmp directory and prefix from ~/.paintera/config if present
+		final String tmpDir = new TmpDirectoryCreator( null, "paintera-project-" ).get();
+		LOG.info( "Using temporary project directory {}", tmpDir );
+		return tmpDir;
+	}
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/data/mask/TmpDirectoryCreator.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/data/mask/TmpDirectoryCreator.java
@@ -1,13 +1,19 @@
 package org.janelia.saalfeldlab.paintera.data.mask;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileAttribute;
 import java.util.function.Supplier;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class TmpDirectoryCreator implements Supplier< String >
 {
+
+	private static Logger LOG = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
 
 	private final Path dir;
 
@@ -28,7 +34,9 @@ public class TmpDirectoryCreator implements Supplier< String >
 	{
 		try
 		{
-			return dir == null ? Files.createTempDirectory( prefix, attrs ).toString() : Files.createTempDirectory( dir, prefix, attrs ).toString();
+			final String tmpDir = dir == null ? Files.createTempDirectory( prefix, attrs ).toString() : Files.createTempDirectory( dir, prefix, attrs ).toString();
+			LOG.debug( "Created tmp dir {}", tmpDir );
+			return tmpDir;
 		}
 		catch ( final IOException e )
 		{


### PR DESCRIPTION
If no project is specified on command line, show dialog with options to
 1. specify proejct directory,
 2. use temporary project directory, or
 3. cancel (quit).

added options:

| Option | Effect |
| -------- | --- |
| `--default-to-temp-directory` | chooses (2) by default |
| `--print-error-codes` | print all Paintera error codes |
