### PR TITLE
Commit dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Usage: Paintera [-h] [--height=HEIGHT] [--width=WIDTH]
 | `Space` wheel | change brush size |
 | `F` | Flood-fill with id that was last toggled active (if any) |
 | `N` | Select new, previously unused id |
-| `Ctrl` + `C` | Commit current canvas into background |
+| `Ctrl` + `C` | Show dialog to commit canvas and/or assignments |
 | `C` | Increment ARGB stream seed by one |
 | `Shift` + `C` | Decrement ARGB stream seed by one |
 | `Ctrl` + `Shift` + `C` | Show ARGB stream seed spinner |

--- a/src/main/java/org/janelia/saalfeldlab/paintera/CommitDialog.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/CommitDialog.java
@@ -1,0 +1,87 @@
+package org.janelia.saalfeldlab.paintera;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.janelia.saalfeldlab.paintera.control.CommitChanges;
+import org.janelia.saalfeldlab.paintera.control.CommitChanges.Commitable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.Dialog;
+import javafx.scene.layout.VBox;
+
+public class CommitDialog implements Function< Collection< CommitChanges.Commitable >, Optional< Set< CommitChanges.Commitable > > >
+{
+
+	private static final Logger LOG = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
+
+	private final String headerText;
+
+	private final String contentText;
+
+	public CommitDialog()
+	{
+		this(
+				"Commit to backend.",
+				"Select properties to commit to backend:" );
+	}
+
+	public CommitDialog( final String headerText, final String contentText )
+	{
+		super();
+		this.headerText = headerText;
+		this.contentText = contentText;
+	}
+
+	@Override
+	public Optional< Set< Commitable > > apply( final Collection< Commitable > commitableOptions )
+	{
+		final List< Commitable > commitables = new ArrayList<>( commitableOptions );
+		Collections.sort( commitables );
+
+		LOG.warn( "Selecting from commitables: {}", commitables );
+
+		final Map< Commitable, CheckBox > checkBoxesMap = new HashMap<>();
+		final List< CheckBox > checkBoxes = new ArrayList<>();
+
+		commitables.forEach( c -> {
+			final CheckBox checkBox = new CheckBox( c.toString() );
+			checkBox.setSelected( true );
+			checkBoxes.add( checkBox );
+			checkBoxesMap.put( c, checkBox );
+		} );
+
+		final Dialog< Set< Commitable > > dialog = new Dialog<>();
+
+		dialog.setTitle( "Paintera" );
+		dialog.setHeaderText( "Commit to backend." );
+		dialog.setContentText( "Select properties to commit to backend:" );
+		dialog.setResizable( true );
+
+		dialog.getDialogPane().setContent( new VBox( checkBoxes.toArray( new CheckBox[ checkBoxes.size() ] ) ) );
+
+		dialog.getDialogPane().getButtonTypes().setAll( ButtonType.OK, ButtonType.CANCEL );
+		dialog.setResultConverter( bt -> {
+			if ( ButtonType.OK.equals( bt ) ) { return commitables
+					.stream()
+					.filter( c -> checkBoxesMap.get( c ).isSelected() )
+					.collect( Collectors.toSet() ); }
+			return null;
+		} );
+
+		return dialog.showAndWait();
+	}
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/CommitDialog.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/CommitDialog.java
@@ -51,7 +51,7 @@ public class CommitDialog implements Function< Collection< CommitChanges.Commita
 		final List< Commitable > commitables = new ArrayList<>( commitableOptions );
 		Collections.sort( commitables );
 
-		LOG.warn( "Selecting from commitables: {}", commitables );
+		LOG.debug( "Selecting from commitables: {}", commitables );
 
 		final Map< Commitable, CheckBox > checkBoxesMap = new HashMap<>();
 		final List< CheckBox > checkBoxes = new ArrayList<>();

--- a/src/main/java/org/janelia/saalfeldlab/paintera/Paintera.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/Paintera.java
@@ -20,10 +20,12 @@ import org.janelia.saalfeldlab.paintera.config.CoordinateConfigNode;
 import org.janelia.saalfeldlab.paintera.config.CrosshairConfig;
 import org.janelia.saalfeldlab.paintera.config.NavigationConfig;
 import org.janelia.saalfeldlab.paintera.config.OrthoSliceConfig;
+import org.janelia.saalfeldlab.paintera.control.CommitChanges;
 import org.janelia.saalfeldlab.paintera.control.assignment.FragmentSegmentAssignmentState;
 import org.janelia.saalfeldlab.paintera.control.lock.LockedSegmentsOnlyLocal;
 import org.janelia.saalfeldlab.paintera.control.selection.SelectedIds;
 import org.janelia.saalfeldlab.paintera.data.DataSource;
+import org.janelia.saalfeldlab.paintera.data.mask.CannotPersist;
 import org.janelia.saalfeldlab.paintera.data.mask.Masks;
 import org.janelia.saalfeldlab.paintera.data.mask.TmpDirectoryCreator;
 import org.janelia.saalfeldlab.paintera.data.n5.CommitCanvasN5;
@@ -259,6 +261,20 @@ public class Paintera extends Application
 					}
 				},
 				e -> keyTracker.areOnlyTheseKeysDown( KeyCode.CONTROL, KeyCode.S ) ).installInto( paneWithStatus.getPane() );
+
+		EventFX.KEY_PRESSED( "commit", e -> {
+			LOG.warn( "Showing commit dialog" );
+			e.consume();
+			try
+			{
+				CommitChanges.commit( new CommitDialog(), baseView.sourceInfo().currentState().get() );
+			}
+			catch ( final CannotPersist e1 )
+			{
+				LOG.error( "Unnable to persist canvas {}", e1 );
+			}
+		},
+				e -> keyTracker.areOnlyTheseKeysDown( KeyCode.CONTROL, KeyCode.C ) ).installInto( paneWithStatus.getPane() );
 
 		keyTracker.installInto( scene );
 		scene.addEventFilter( MouseEvent.ANY, mouseTracker );

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/CommitChanges.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/CommitChanges.java
@@ -1,0 +1,96 @@
+package org.janelia.saalfeldlab.paintera.control;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.janelia.saalfeldlab.paintera.data.mask.CannotPersist;
+import org.janelia.saalfeldlab.paintera.data.mask.MaskedSource;
+import org.janelia.saalfeldlab.paintera.state.LabelSourceState;
+import org.janelia.saalfeldlab.paintera.state.SourceState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CommitChanges
+{
+
+	public enum Commitable
+	{
+		CANVAS,
+		FRAGMENT_SEGMENT_ASSIGNMENTS;
+
+		public static Set< Commitable > asSet()
+		{
+			return setOf( Commitable.values() );
+		}
+
+		public static Set< Commitable > setOf( final Commitable... commitables )
+		{
+			return new HashSet<>( Arrays.asList( commitables ) );
+		}
+
+	}
+
+	private static final Logger LOG = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
+
+	public static void commit(
+			final Function< Collection< Commitable >, Optional< Set< Commitable > > > getCommitablesToCommit,
+			final SourceState< ?, ? > currentState ) throws CannotPersist
+	{
+		commit( getCommitablesToCommit, currentState, Optional.empty() );
+	}
+
+	public static void commit(
+			final Function< Collection< Commitable >, Optional< Set< Commitable > > > getCommitablesToCommit,
+			final SourceState< ?, ? > currentState,
+			final Optional< Set< Commitable > > filteredCommitableOptions ) throws CannotPersist
+	{
+		LOG.debug( "Commiting for state {}", currentState );
+		if ( currentState == null || !( currentState instanceof LabelSourceState< ?, ? > ) )
+		{
+			LOG.debug( "Invalid current state (null or not {}): {}", LabelSourceState.class, currentState );
+			return;
+		}
+		final LabelSourceState< ?, ? > state = ( LabelSourceState< ?, ? > ) currentState;
+		final boolean isMasked = state.getDataSource() instanceof MaskedSource< ?, ? >;
+		final Set< Commitable > commitableOptions = filteredCommitableOptions.orElseGet( Commitable::asSet );
+		if ( !isMasked )
+		{
+			commitableOptions.remove( Commitable.CANVAS );
+		}
+
+		final Optional< Set< Commitable > > commitables = getCommitablesToCommit.apply( commitableOptions );
+
+		if ( !commitables.isPresent() )
+		{
+			LOG.debug( "Not commiting anything." );
+			return;
+		}
+
+		for ( final Commitable commitable : commitables.get() )
+		{
+			switch ( commitable )
+			{
+			case CANVAS:
+				if ( isMasked )
+				{
+					// TODO Should this be handled here instead of throwing
+					// exception?
+					( ( MaskedSource< ?, ? > ) state.getDataSource() ).persistCanvas();
+				}
+				break;
+			case FRAGMENT_SEGMENT_ASSIGNMENTS:
+			{
+				state.assignment().persist();
+				break;
+			}
+			}
+
+		}
+	}
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/CommitChanges.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/CommitChanges.java
@@ -71,6 +71,7 @@ public class CommitChanges
 			return;
 		}
 
+		LOG.debug( "Commiting {}", commitables.get() );
 		for ( final Commitable commitable : commitables.get() )
 		{
 			switch ( commitable )

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/Paint.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/Paint.java
@@ -17,8 +17,6 @@ import org.janelia.saalfeldlab.paintera.control.paint.Paint2D;
 import org.janelia.saalfeldlab.paintera.control.paint.RestrictPainting;
 import org.janelia.saalfeldlab.paintera.control.paint.SelectNextId;
 import org.janelia.saalfeldlab.paintera.control.selection.SelectedIds;
-import org.janelia.saalfeldlab.paintera.data.mask.CannotPersist;
-import org.janelia.saalfeldlab.paintera.data.mask.MaskedSource;
 import org.janelia.saalfeldlab.paintera.state.GlobalTransformManager;
 import org.janelia.saalfeldlab.paintera.state.LabelSourceState;
 import org.janelia.saalfeldlab.paintera.state.SourceInfo;
@@ -142,24 +140,6 @@ public class Paint implements ToOnEnterOnExit
 
 					final SelectNextId nextId = new SelectNextId( sourceInfo );
 					iars.add( EventFX.KEY_PRESSED( "next id", event -> nextId.getNextId(), event -> keyTracker.areOnlyTheseKeysDown( KeyCode.N ) ) );
-
-					iars.add( EventFX.KEY_PRESSED( "merge canvas", event -> {
-						final Source< ? > cs = currentSource.get();
-						if ( cs instanceof MaskedSource< ?, ? > )
-						{
-							LOG.debug( "Merging canvas for source {}", cs );
-							final MaskedSource< ?, ? > mcs = ( MaskedSource< ?, ? > ) cs;
-							try
-							{
-								mcs.persistCanvas();
-							}
-							catch ( final CannotPersist e )
-							{
-								LOG.warn( "Could not persist canvas. Try again later." );
-							}
-						}
-						event.consume();
-					}, event -> keyTracker.areOnlyTheseKeysDown( KeyCode.CONTROL, KeyCode.C ) ) );
 
 					this.mouseAndKeyHandlers.put( t, iars );
 				}


### PR DESCRIPTION
Instead of having separate keys to commit canvas and assignment (and potentially other things like annotations), use `ctrl` + `C` to pop-up dialog for user to selcet which properties to commit.
Also, pop-up dialog to commit canvas for every state with `MaskedSource` data that has uncommited canvas on exit (uncommited canvases will be lost on exit).