### PR TITLE
Set rotation speed in ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ Usage: Paintera [-h] [--height=HEIGHT] [--width=WIDTH]
 | right click | toggle id under cursor if current source is label source (append to current selection) |
 | `Shift` left click | Merge id under cursor with id that was last toggled active (if any) |
 | `Shift` right click | Split id under cursor from id that was last toggled active (if any) |
-| `Space` left drag | Paint with id that was last toggled active (if any) |
-| `Space` right drag | Erase within canvas only |
-| `Shift` + `Space` right drag | Paint background label |
+| `Space` left click/drag | Paint with id that was last toggled active (if any) |
+| `Space` right click/drag | Erase within canvas only |
+| `Shift` + `Space` right click/drag | Paint background label |
 | `Space` wheel | change brush size |
-| `F` | Flood-fill with id that was last toggled active (if any) |
+| `Shift` + `F` + left click | Flood-fill with id that was last toggled active (if any) |
 | `N` | Select new, previously unused id |
 | `Ctrl` + `C` | Show dialog to commit canvas and/or assignments |
 | `C` | Increment ARGB stream seed by one |

--- a/src/main/java/org/janelia/saalfeldlab/fx/event/EventFX.java
+++ b/src/main/java/org/janelia/saalfeldlab/fx/event/EventFX.java
@@ -52,7 +52,9 @@ public abstract class EventFX< E extends Event > implements EventHandler< E >, I
 	public void handle( final E e )
 	{
 		if ( eventFilter.test( e ) )
+		{
 			actOn( e );
+		}
 	}
 
 	public static EventFX< KeyEvent > KEY_PRESSED( final String name, final Consumer< KeyEvent > eventHandler, final Predicate< KeyEvent > eventFilter )
@@ -105,7 +107,11 @@ public abstract class EventFX< E extends Event > implements EventHandler< E >, I
 
 		private final Consumer< E > eventHandler;
 
-		public EventFXWithConsumer( final String name, final EventType< E > eventType, final Consumer< E > eventHandler, final Predicate< E > eventFilter )
+		public EventFXWithConsumer(
+				final String name,
+				final EventType< E > eventType,
+				final Consumer< E > eventHandler,
+				final Predicate< E > eventFilter )
 		{
 			super( name, eventType, eventFilter );
 			this.eventHandler = eventHandler;
@@ -114,6 +120,7 @@ public abstract class EventFX< E extends Event > implements EventHandler< E >, I
 		@Override
 		public void actOn( final E event )
 		{
+			event.consume();
 			eventHandler.accept( event );
 		}
 

--- a/src/main/java/org/janelia/saalfeldlab/fx/event/MouseClickFX.java
+++ b/src/main/java/org/janelia/saalfeldlab/fx/event/MouseClickFX.java
@@ -31,7 +31,7 @@ public class MouseClickFX implements InstallAndRemove< Node >
 		this.onReleaseConsumer = onReleaseConsumer;
 		this.eventFilter = eventFilters;
 		this.onPress = EventFX.MOUSE_PRESSED( name, this::press, this.eventFilter );
-		this.onRelease = EventFX.MOUSE_RELEASED( name, this::release, event -> true );
+		this.onRelease = EventFX.MOUSE_RELEASED( name, this::release, event -> isEvent );
 	}
 
 	private double startX;
@@ -60,14 +60,13 @@ public class MouseClickFX implements InstallAndRemove< Node >
 
 	private void release( final MouseEvent event )
 	{
-		if ( isEvent )
+		final double x = event.getX();
+		final double y = event.getY();
+		final double dX = x - startX;
+		final double dY = y - startY;
+		if ( dX * dX + dY * dY <= tolerance * tolerance )
 		{
-			final double x = event.getX();
-			final double y = event.getY();
-			final double dX = x - startX;
-			final double dY = y - startY;
-			if ( dX * dX + dY * dY <= tolerance * tolerance )
-				onReleaseConsumer.accept( event );
+			onReleaseConsumer.accept( event );
 		}
 		isEvent = false;
 	}

--- a/src/main/java/org/janelia/saalfeldlab/fx/ui/DoubleField.java
+++ b/src/main/java/org/janelia/saalfeldlab/fx/ui/DoubleField.java
@@ -1,0 +1,98 @@
+package org.janelia.saalfeldlab.fx.ui;
+
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.SimpleDoubleProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.event.Event;
+import javafx.event.EventHandler;
+import javafx.scene.control.TextField;
+import javafx.util.StringConverter;
+
+public class DoubleField
+{
+	private final TextField field = new TextField();
+
+	private final StringProperty valueAsString = new SimpleStringProperty();
+
+	private final DoubleProperty value = new SimpleDoubleProperty();
+
+	public DoubleField( final double initialValue )
+	{
+
+		valueAsString.addListener( ( obs, oldv, newv ) -> this.field.setText( newv ) );
+
+		valueAsString.bindBidirectional( value, new StringConverter< Number >()
+		{
+			@Override
+			public String toString( final Number value )
+			{
+				return value.toString();
+			}
+
+			@Override
+			public Double fromString( final String string )
+			{
+				try
+				{
+					return Double.valueOf( string );
+				}
+				catch ( NumberFormatException | NullPointerException e )
+				{
+					return value.get();
+				}
+			}
+		} );
+
+		this.value.set( initialValue );
+
+		this.field.setOnAction( wrapAsEventHandler( this::submitText ) );
+		this.field.focusedProperty().addListener( ( obs, oldv, newv ) -> submitText( !newv ) );
+
+	}
+
+	public TextField textField()
+	{
+		return this.field;
+	}
+
+	public DoubleProperty valueProperty()
+	{
+		return this.value;
+	}
+
+	private static < E extends Event > EventHandler< E > wrapAsEventHandler( final Runnable r )
+	{
+		return wrapAsEventHandler( r, true );
+	}
+
+	private static < E extends Event > EventHandler< E > wrapAsEventHandler( final Runnable r, final boolean consume )
+	{
+		return e -> {
+			if ( consume )
+			{
+				e.consume();
+			}
+			r.run();
+		};
+	}
+
+	private void submitText()
+	{
+		submitText( true );
+	}
+
+	private void submitText( final boolean submit )
+	{
+		if ( !submit ) { return; }
+		try
+		{
+			final double val = Double.valueOf( textField().getText() );
+			value.set( val );
+		}
+		catch ( NumberFormatException | NullPointerException e )
+		{
+			this.field.setText( this.valueAsString.get() );
+		}
+	}
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/Paintera.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/Paintera.java
@@ -19,6 +19,7 @@ import org.janelia.saalfeldlab.paintera.SaveProject.ProjectUndefined;
 import org.janelia.saalfeldlab.paintera.composition.ARGBCompositeAlphaYCbCr;
 import org.janelia.saalfeldlab.paintera.composition.CompositeCopy;
 import org.janelia.saalfeldlab.paintera.config.CoordinateConfigNode;
+import org.janelia.saalfeldlab.paintera.config.NavigationConfigNode;
 import org.janelia.saalfeldlab.paintera.config.OrthoSliceConfig;
 import org.janelia.saalfeldlab.paintera.control.CommitChanges;
 import org.janelia.saalfeldlab.paintera.control.assignment.FragmentSegmentAssignmentState;
@@ -158,7 +159,9 @@ public class Paintera extends Application
 				projectDir,
 				gridConstraintsManager );
 
-		final CoordinateConfigNode coordinateConfigNode = paneWithStatus.navigationConfigNode().coordinateConfigNode();
+		final NavigationConfigNode navigationConfigNode = paneWithStatus.navigationConfigNode();
+
+		final CoordinateConfigNode coordinateConfigNode = navigationConfigNode.coordinateConfigNode();
 		coordinateConfigNode.listen( baseView.manager() );
 
 		// populate everything

--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/NavigationConfig.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/NavigationConfig.java
@@ -1,6 +1,7 @@
 package org.janelia.saalfeldlab.paintera.config;
 
 import org.janelia.saalfeldlab.paintera.control.Navigation;
+import org.janelia.saalfeldlab.paintera.control.navigation.ButtonRotationSpeedConfig;
 
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -10,6 +11,8 @@ public class NavigationConfig
 
 	private final SimpleBooleanProperty allowRotations = new SimpleBooleanProperty( true );
 
+	private final ButtonRotationSpeedConfig buttonRotationSpeeds = new ButtonRotationSpeedConfig();
+
 	public BooleanProperty allowRotationsProperty()
 	{
 		return this.allowRotations;
@@ -18,6 +21,11 @@ public class NavigationConfig
 	public void bindNavigationToConfig( final Navigation navigation )
 	{
 		navigation.allowRotationsProperty().bind( this.allowRotations );
+	}
+
+	public ButtonRotationSpeedConfig buttonRotationSpeeds()
+	{
+		return this.buttonRotationSpeeds;
 	}
 
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/NavigationConfig.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/NavigationConfig.java
@@ -21,11 +21,20 @@ public class NavigationConfig
 	public void bindNavigationToConfig( final Navigation navigation )
 	{
 		navigation.allowRotationsProperty().bind( this.allowRotations );
+		navigation.bindTo( this.buttonRotationSpeeds );
 	}
 
 	public ButtonRotationSpeedConfig buttonRotationSpeeds()
 	{
 		return this.buttonRotationSpeeds;
+	}
+
+	public void set( final NavigationConfig that )
+	{
+		this.allowRotations.set( that.allowRotations.get() );
+		this.buttonRotationSpeeds.slow.set( that.buttonRotationSpeeds.slow.get() );
+		this.buttonRotationSpeeds.fast.set( that.buttonRotationSpeeds.fast.get() );
+		this.buttonRotationSpeeds.regular.set( that.buttonRotationSpeeds.regular.get() );
 	}
 
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/NavigationConfigNode.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/NavigationConfigNode.java
@@ -1,12 +1,13 @@
 package org.janelia.saalfeldlab.paintera.config;
 
+import org.janelia.saalfeldlab.fx.ui.DoubleField;
+
 import javafx.scene.Node;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.TitledPane;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Priority;
-import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 
 public class NavigationConfigNode
@@ -16,35 +17,33 @@ public class NavigationConfigNode
 
 	private final CheckBox allowRotationsCheckBox = new CheckBox();
 
+	private final DoubleField keyRotationRegular = new DoubleField( 0.0 );
+
+	private final DoubleField keyRotationFast = new DoubleField( 0.0 );
+
+	private final DoubleField keyRotationSlow = new DoubleField( 0.0 );
+
 	private final CoordinateConfigNode coordinateConfig;
 
 	public NavigationConfigNode()
 	{
 		this.coordinateConfig = new CoordinateConfigNode();
 		final VBox vbox = new VBox();
-		final GridPane grid = new GridPane();
 
 		vbox.getChildren().add( this.coordinateConfig.getContents() );
-		vbox.getChildren().add( grid );
+		vbox.getChildren().add( rotationsConfig() );
 
 		contents.setContent( vbox );
 		contents.setExpanded( false );
 
-		int row = 0;
-		{
-			final Label label = new Label( "Rotations" );
-			final Region spacer = new Region();
-			grid.add( label, 0, row );
-			grid.add( spacer, 1, row );
-			grid.add( allowRotationsCheckBox, 2, row );
-			GridPane.setHgrow( spacer, Priority.ALWAYS );
-			++row;
-		}
 	}
 
 	public void bind( final NavigationConfig config )
 	{
 		allowRotationsCheckBox.selectedProperty().bindBidirectional( config.allowRotationsProperty() );
+		keyRotationRegular.valueProperty().bindBidirectional( config.buttonRotationSpeeds().regular );
+		keyRotationSlow.valueProperty().bindBidirectional( config.buttonRotationSpeeds().slow );
+		keyRotationFast.valueProperty().bindBidirectional( config.buttonRotationSpeeds().fast );
 	}
 
 	public Node getContents()
@@ -55,6 +54,52 @@ public class NavigationConfigNode
 	public CoordinateConfigNode coordinateConfigNode()
 	{
 		return this.coordinateConfig;
+	}
+
+	private Node rotationsConfig()
+	{
+		final VBox contents = new VBox();
+		final TitledPane rotations = new TitledPane( "Rotations", contents );
+		rotations.setExpanded( false );
+		rotations.setGraphic( allowRotationsCheckBox );
+		rotations.collapsibleProperty().bind( allowRotationsCheckBox.selectedProperty() );
+
+		{
+			final GridPane grid = new GridPane();
+			final TitledPane keyRotations = new TitledPane( "Key Rotation Speeds", grid );
+			keyRotations.setExpanded( false );
+			int row = 0;
+			final double doubleFieldWith = 60;
+
+			{
+				final Label label = new Label( "Slow" );
+				GridPane.setHgrow( label, Priority.ALWAYS );
+				keyRotationSlow.textField().setMaxWidth( doubleFieldWith );
+				grid.add( label, 0, row );
+				grid.add( keyRotationSlow.textField(), 1, row );
+				++row;
+			}
+
+			{
+				final Label label = new Label( "Regular" );
+				GridPane.setHgrow( label, Priority.ALWAYS );
+				keyRotationRegular.textField().setMaxWidth( doubleFieldWith );
+				grid.add( label, 0, row );
+				grid.add( keyRotationRegular.textField(), 1, row );
+				++row;
+			}
+
+			{
+				final Label label = new Label( "Fast" );
+				GridPane.setHgrow( label, Priority.ALWAYS );
+				keyRotationFast.textField().setMaxWidth( doubleFieldWith );
+				grid.add( label, 0, row );
+				grid.add( keyRotationFast.textField(), 1, row );
+				++row;
+			}
+			contents.getChildren().add( keyRotations );
+		}
+		return rotations;
 	}
 
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/Navigation.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/Navigation.java
@@ -367,6 +367,13 @@ public class Navigation implements ToOnEnterOnExit
 		return this.allowRotations;
 	}
 
+	public void bindTo( final ButtonRotationSpeedConfig config )
+	{
+		this.buttonRotationSpeedConfig.regular.bind( config.regular );
+		this.buttonRotationSpeedConfig.slow.bind( config.slow );
+		this.buttonRotationSpeedConfig.fast.bind( config.fast );
+	}
+
 	private static final EventFX< KeyEvent > keyRotationHandler(
 			final String name,
 			final DoubleSupplier rotationCenterX,

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/Navigation.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/Navigation.java
@@ -17,6 +17,7 @@ import org.janelia.saalfeldlab.fx.event.InstallAndRemove;
 import org.janelia.saalfeldlab.fx.event.KeyTracker;
 import org.janelia.saalfeldlab.fx.event.MouseDragFX;
 import org.janelia.saalfeldlab.paintera.control.navigation.AffineTransformWithListeners;
+import org.janelia.saalfeldlab.paintera.control.navigation.ButtonRotationSpeedConfig;
 import org.janelia.saalfeldlab.paintera.control.navigation.KeyRotate;
 import org.janelia.saalfeldlab.paintera.control.navigation.RemoveRotation;
 import org.janelia.saalfeldlab.paintera.control.navigation.Rotate;
@@ -55,6 +56,8 @@ public class Navigation implements ToOnEnterOnExit
 	private final DoubleProperty rotationSpeed = new SimpleDoubleProperty( 1.0 );
 
 	private final BooleanProperty allowRotations = new SimpleBooleanProperty( true );
+
+	private final ButtonRotationSpeedConfig buttonRotationSpeedConfig = new ButtonRotationSpeedConfig();
 
 	private final GlobalTransformManager manager;
 
@@ -209,12 +212,12 @@ public class Navigation implements ToOnEnterOnExit
 				iars.add( EventFX.KEY_PRESSED( "set key rotation axis z", e -> keyRotationAxis.set( KeyRotate.Axis.Z ), e -> keyTracker.areOnlyTheseKeysDown( KeyCode.Z ) ) );
 
 				iars.add( keyRotationHandler(
-						"key rotate left 5",
+						"key rotate left regular",
 						mouseXIfInsideElseCenterX::get,
 						mouseYIfInsideElseCenterY::get,
 						allowRotations::get,
 						keyRotationAxis::get,
-						-5.0 / 180.0 * Math.PI,
+						this.buttonRotationSpeedConfig.regular.multiply( -Math.PI / 180.0 )::get,
 						displayTransform,
 						globalToViewerTransform,
 						globalTransform,
@@ -223,12 +226,26 @@ public class Navigation implements ToOnEnterOnExit
 						event -> keyTracker.areOnlyTheseKeysDown( KeyCode.LEFT ) ) );
 
 				iars.add( keyRotationHandler(
-						"key rotate left 45",
+						"key rotate left slow",
 						mouseXIfInsideElseCenterX::get,
 						mouseYIfInsideElseCenterY::get,
 						allowRotations::get,
 						keyRotationAxis::get,
-						-45.0 / 180.0 * Math.PI,
+						this.buttonRotationSpeedConfig.slow.multiply( -Math.PI / 180.0 )::get,
+						displayTransform,
+						globalToViewerTransform,
+						globalTransform,
+						manager::setTransform,
+						manager,
+						event -> keyTracker.areOnlyTheseKeysDown( KeyCode.CONTROL, KeyCode.LEFT ) ) );
+
+				iars.add( keyRotationHandler(
+						"key rotate left fast",
+						mouseXIfInsideElseCenterX::get,
+						mouseYIfInsideElseCenterY::get,
+						allowRotations::get,
+						keyRotationAxis::get,
+						this.buttonRotationSpeedConfig.fast.multiply( -Math.PI / 180.0 )::get,
 						displayTransform,
 						globalToViewerTransform,
 						globalTransform,
@@ -237,12 +254,12 @@ public class Navigation implements ToOnEnterOnExit
 						event -> keyTracker.areOnlyTheseKeysDown( KeyCode.SHIFT, KeyCode.LEFT ) ) );
 
 				iars.add( keyRotationHandler(
-						"key rotate right 5",
+						"key rotate right regular",
 						mouseXIfInsideElseCenterX::get,
 						mouseYIfInsideElseCenterY::get,
 						allowRotations::get,
 						keyRotationAxis::get,
-						5.0 / 180.0 * Math.PI,
+						this.buttonRotationSpeedConfig.regular.multiply( +Math.PI / 180.0 )::get,
 						displayTransform,
 						globalToViewerTransform,
 						globalTransform,
@@ -251,12 +268,26 @@ public class Navigation implements ToOnEnterOnExit
 						event -> keyTracker.areOnlyTheseKeysDown( KeyCode.RIGHT ) ) );
 
 				iars.add( keyRotationHandler(
-						"key rotate right 45",
+						"key rotate right slow",
 						mouseXIfInsideElseCenterX::get,
 						mouseYIfInsideElseCenterY::get,
 						allowRotations::get,
 						keyRotationAxis::get,
-						45.0 / 180.0 * Math.PI,
+						this.buttonRotationSpeedConfig.slow.multiply( +Math.PI / 180.0 )::get,
+						displayTransform,
+						globalToViewerTransform,
+						globalTransform,
+						manager::setTransform,
+						manager,
+						event -> keyTracker.areOnlyTheseKeysDown( KeyCode.CONTROL, KeyCode.RIGHT ) ) );
+
+				iars.add( keyRotationHandler(
+						"key rotate right fast",
+						mouseXIfInsideElseCenterX::get,
+						mouseYIfInsideElseCenterY::get,
+						allowRotations::get,
+						keyRotationAxis::get,
+						this.buttonRotationSpeedConfig.fast.multiply( +Math.PI / 180.0 )::get,
 						displayTransform,
 						globalToViewerTransform,
 						globalTransform,
@@ -342,7 +373,7 @@ public class Navigation implements ToOnEnterOnExit
 			final DoubleSupplier rotationCenterY,
 			final BooleanSupplier allowRotations,
 			final Supplier< KeyRotate.Axis > axis,
-			final double step,
+			final DoubleSupplier step,
 			final AffineTransform3D displayTransform,
 			final AffineTransform3D globalToViewerTransform,
 			final AffineTransform3D globalTransform,

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/Paint.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/Paint.java
@@ -125,9 +125,9 @@ public class Paint implements ToOnEnterOnExit
 					iars.add( EventFX.SCROLL( "change brush size", event -> paint2D.changeBrushRadius( event.getDeltaY() ), event -> keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE ) ) );
 
 					// click paint
-//					iars.add( EventFX.MOUSE_PRESSED( "paint click 2D", e -> paint2D.prepareAndPaintUnchecked( e, paintSelection.get() ), e -> e.isPrimaryButtonDown() && keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE ) && this.paint2D.get() ) );
-//					iars.add( EventFX.MOUSE_PRESSED( "erase canvas click 2D", e -> paint2D.prepareAndPaintUnchecked( e, Label.TRANSPARENT ), e -> e.isSecondaryButtonDown() && keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE ) && this.paint2D.get() ) );
-//					iars.add( EventFX.MOUSE_PRESSED( "to background click 2D", e -> paint2D.prepareAndPaintUnchecked( e, Label.BACKGROUND ), e -> e.isSecondaryButtonDown() && keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE, KeyCode.SHIFT ) && this.paint2D.get() ) );
+					iars.add( EventFX.MOUSE_PRESSED( "paint click 2D", e -> paint2D.prepareAndPaintUnchecked( e, paintSelection.get() ), e -> e.isPrimaryButtonDown() && keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE ) && this.paint2D.get() ) );
+					iars.add( EventFX.MOUSE_PRESSED( "erase canvas click 2D", e -> paint2D.prepareAndPaintUnchecked( e, Label.TRANSPARENT ), e -> e.isSecondaryButtonDown() && keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE ) && this.paint2D.get() ) );
+					iars.add( EventFX.MOUSE_PRESSED( "to background click 2D", e -> paint2D.prepareAndPaintUnchecked( e, Label.BACKGROUND ), e -> e.isSecondaryButtonDown() && keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE, KeyCode.SHIFT ) && this.paint2D.get() ) );
 
 					// drag paint
 					iars.add( paint2D.dragPaintLabel( "paint 2D", paintSelection::get, event -> event.isPrimaryButtonDown() && keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE ) && this.paint2D.get() ) );

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/navigation/ButtonRotationSpeedConfig.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/navigation/ButtonRotationSpeedConfig.java
@@ -1,0 +1,20 @@
+package org.janelia.saalfeldlab.paintera.control.navigation;
+
+import javafx.beans.property.SimpleDoubleProperty;
+
+public class ButtonRotationSpeedConfig
+{
+
+	private static final double DEFAULT_SLOW = 0.5;
+
+	private static final double DEFAULT_REGULAR = 5.0;
+
+	private static final double DEFAULT_FAST = 45.0;
+
+	public SimpleDoubleProperty slow = new SimpleDoubleProperty( DEFAULT_SLOW );
+
+	public SimpleDoubleProperty regular = new SimpleDoubleProperty( DEFAULT_REGULAR );
+
+	public SimpleDoubleProperty fast = new SimpleDoubleProperty( DEFAULT_FAST );
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/navigation/KeyRotate.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/navigation/KeyRotate.java
@@ -2,6 +2,7 @@ package org.janelia.saalfeldlab.paintera.control.navigation;
 
 import java.lang.invoke.MethodHandles;
 import java.util.function.Consumer;
+import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
 
 import org.slf4j.Logger;
@@ -30,7 +31,7 @@ public class KeyRotate
 
 	private final Supplier< Axis > axis;
 
-	private final double step;
+	private final DoubleSupplier step;
 
 	private final AffineTransform3D displayTransform;
 
@@ -44,7 +45,7 @@ public class KeyRotate
 
 	public KeyRotate(
 			final Supplier< Axis > axis,
-			final double step,
+			final DoubleSupplier step,
 			final AffineTransform3D displayTransform,
 			final AffineTransform3D globalToViewerTransform,
 			final AffineTransform3D globalTransform,
@@ -82,7 +83,7 @@ public class KeyRotate
 		concatenated.set( concatenated.get( 0, 3 ) - x, 0, 3 );
 		concatenated.set( concatenated.get( 1, 3 ) - y, 1, 3 );
 		LOG.debug( "Rotating {} around axis={} by angle={}", concatenated, axis, step );
-		concatenated.rotate( axis.get().axis, step );
+		concatenated.rotate( axis.get().axis, step.getAsDouble() );
 		concatenated.set( concatenated.get( 0, 3 ) + x, 0, 3 );
 		concatenated.set( concatenated.get( 1, 3 ) + y, 1, 3 );
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/serialization/Properties.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/serialization/Properties.java
@@ -178,7 +178,7 @@ public class Properties implements TransformListener< AffineTransform3D >
 		Optional
 				.ofNullable( serializedProperties.get( NAVIGATION_CONFIG_KEY ) )
 				.map( json -> gson.fromJson( json, NavigationConfig.class ) )
-				.ifPresent( conf -> properties.navigationConfig.allowRotationsProperty().set( conf.allowRotationsProperty().get() ) );
+				.ifPresent( properties.navigationConfig::set );
 
 		gridConstraints.set( deserializedGridConstraints );
 


### PR DESCRIPTION
 - add third speed level for key rotation (slow, regular, fast, defaulting to `0.5`, `5`, `45`, respectively)
 - add ui controls for speed level config (in pane on right side: `settings>Navigation>Rotations>Key Rotation Speeds`)
 - (de-)serialize key rotation speeds
 - always consume events in `EventFX.EventFXWithConsumer.actOn`
   - also allows to uncomment click painting in `Paint` handler class

Fixes #76 