### PR TITLE
Bind synapse settings to global neuron settings

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/meshes/MeshManagerSimple.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/meshes/MeshManagerSimple.java
@@ -138,6 +138,9 @@ public class MeshManagerSimple< N, T > implements MeshManager< N, T >
 				workers );
 		nfx.opacityProperty().set( this.opacity.get() );
 		nfx.scaleIndexProperty().bind( this.scaleLevel );
+		nfx.meshSimplificationIterationsProperty().bind( this.meshSimplificationIterations );
+		nfx.smoothingIterationsProperty().bind( this.smoothingIterations );
+		nfx.smoothingLambdaProperty().bind( this.smoothingLambda );
 
 		neurons.put( id, nfx );
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/IntersectingSourceState.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/IntersectingSourceState.java
@@ -135,6 +135,9 @@ public class IntersectingSourceState
 		this.meshManager.colorProperty().bind( colorProperty );
 		this.meshManager.scaleLevelProperty().bind( meshManager.scaleLevelProperty() );
 		this.meshManager.areMeshesEnabledProperty().bind( meshManager.areMeshesEnabledProperty() );
+		this.meshManager.meshSimplificationIterationsProperty().bind( meshManager.meshSimplificationIterationsProperty() );
+		this.meshManager.smoothingIterationsProperty().bind( meshManager.smoothingIterationsProperty() );
+		this.meshManager.smoothingLambdaProperty().bind( meshManager.smoothingLambdaProperty() );
 
 		thresholded.getThreshold().minValue().addListener( ( obs, oldv, newv ) -> {
 			Arrays.stream( meshCaches ).forEach( UncheckedCache::invalidateAll );


### PR DESCRIPTION
Added bindings for (omitted other bindings like opacity or visibility)
 - meshSimplificationIterations
 - smoothingIterations
 - smoothingLambda

cc @axtimwalde 