### PR TITLE
Remove segmentFrom from segmentToFragmentsMap before manipulating the…

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/assignment/FragmentSegmentAssignmentOnlyLocal.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/assignment/FragmentSegmentAssignmentOnlyLocal.java
@@ -155,25 +155,30 @@ public class FragmentSegmentAssignmentOnlyLocal extends FragmentSegmentAssignmen
 			return;
 		}
 
+		final long segmentFrom = fragmentToSegmentMap.contains( from ) ? fragmentToSegmentMap.get( from ) : from;
+		final TLongHashSet fragmentsFrom = segmentToFragmentsMap.remove( segmentFrom );
+		LOG.debug( "From segment: {} To segment: {}", segmentFrom, segmentInto );
+
 		if ( !fragmentToSegmentMap.contains( into ) )
 		{
+			LOG.debug( "Adding segment {} to framgent {}", segmentInto, into );
 			fragmentToSegmentMap.put( into, segmentInto );
 		}
-
-		final long segmentFrom = fragmentToSegmentMap.get( from );
 
 		if ( !segmentToFragmentsMap.contains( segmentInto ) )
 		{
 			final TLongHashSet fragmentOnly = new TLongHashSet();
 			fragmentOnly.add( into );
+			LOG.debug( "Adding fragments {} for segmentInto {}", fragmentOnly, segmentInto );
 			segmentToFragmentsMap.put( segmentInto, fragmentOnly );
 		}
-
-		final TLongHashSet fragmentsFrom = segmentToFragmentsMap.remove( segmentFrom );
+		LOG.debug( "Framgents for from segment: {}", fragmentsFrom );
 
 		if ( fragmentsFrom != null )
 		{
-			segmentToFragmentsMap.get( segmentInto ).addAll( fragmentsFrom );
+			final TLongHashSet fragmentsInto = segmentToFragmentsMap.get( segmentInto );
+			LOG.debug( "Fragments into {}", fragmentsInto );
+			fragmentsInto.addAll( fragmentsFrom );
 			Arrays.stream( fragmentsFrom.toArray() ).forEach( id -> fragmentToSegmentMap.put( id, segmentInto ) );
 		}
 		else
@@ -206,6 +211,7 @@ public class FragmentSegmentAssignmentOnlyLocal extends FragmentSegmentAssignmen
 			break;
 		}
 		case DETACH:
+			LOG.debug( "Applying detach {}", action );
 			detachFragmentImpl( ( Detach ) action );
 			break;
 		}
@@ -260,6 +266,8 @@ public class FragmentSegmentAssignmentOnlyLocal extends FragmentSegmentAssignmen
 			return Optional.empty();
 		}
 
+		// TODO do not add to fragmentToSegmentMap here. Have the mergeImpl take
+		// care of it instead.
 		if ( getSegment( into ) == into )
 		{
 			fragmentToSegmentMap.put( into, newSegmentId.getAsLong() );


### PR DESCRIPTION
… fragments for segmentTo

 - handles the case that segmentFrom == merge.segmentId
 - not 100% sure why such a merge was generated. Could be related to (resolved) bug that actions would be saved repeatedly
 - should also deal with segmentInto == segmentFrom == merge.segmentId
   - get fragments for segmentFrom (remove from map)
   - add new fragment list {into} for segment segmentInto
   - add fragments for segmentFrom to {into}