### PR TITLE
Fix brush

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Usage: Paintera [-h] [--height=HEIGHT] [--width=WIDTH]
 | `Space` right click/drag | Erase within canvas only |
 | `Shift` + `Space` right click/drag | Paint background label |
 | `Space` wheel | change brush size |
+| `F` + left click | 2D Flood-fill in current viewer plane with id that was last toggled active (if any) |
 | `Shift` + `F` + left click | Flood-fill with id that was last toggled active (if any) |
 | `N` | Select new, previously unused id |
 | `Ctrl` + `C` | Show dialog to commit canvas and/or assignments |

--- a/src/main/java/org/janelia/saalfeldlab/fx/event/EventFX.java
+++ b/src/main/java/org/janelia/saalfeldlab/fx/event/EventFX.java
@@ -62,9 +62,14 @@ public abstract class EventFX< E extends Event > implements EventHandler< E >, I
 		return new EventFXWithConsumer<>( name, KeyEvent.KEY_PRESSED, eventHandler, eventFilter );
 	}
 
+	public static EventFX< KeyEvent > KEY_RELEASED( final String name, final Consumer< KeyEvent > eventHandler, final Predicate< KeyEvent > eventFilter, final boolean consume )
+	{
+		return new EventFXWithConsumer<>( name, KeyEvent.KEY_RELEASED, eventHandler, eventFilter, consume );
+	}
+
 	public static EventFX< KeyEvent > KEY_RELEASED( final String name, final Consumer< KeyEvent > eventHandler, final Predicate< KeyEvent > eventFilter )
 	{
-		return new EventFXWithConsumer<>( name, KeyEvent.KEY_RELEASED, eventHandler, eventFilter );
+		return KEY_RELEASED( name, eventHandler, eventFilter, true );
 	}
 
 	public static EventFX< KeyEvent > KEY_TYPED( final String name, final Consumer< KeyEvent > eventHandler, final Predicate< KeyEvent > eventFilter )
@@ -107,20 +112,36 @@ public abstract class EventFX< E extends Event > implements EventHandler< E >, I
 
 		private final Consumer< E > eventHandler;
 
+		private final boolean consume;
+
 		public EventFXWithConsumer(
 				final String name,
 				final EventType< E > eventType,
 				final Consumer< E > eventHandler,
 				final Predicate< E > eventFilter )
 		{
+			this( name, eventType, eventHandler, eventFilter, false );
+		}
+
+		public EventFXWithConsumer(
+				final String name,
+				final EventType< E > eventType,
+				final Consumer< E > eventHandler,
+				final Predicate< E > eventFilter,
+				final boolean consume )
+		{
 			super( name, eventType, eventFilter );
 			this.eventHandler = eventHandler;
+			this.consume = consume;
 		}
 
 		@Override
 		public void actOn( final E event )
 		{
-			event.consume();
+			if ( consume )
+			{
+				event.consume();
+			}
 			eventHandler.accept( event );
 		}
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/LockFile.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/LockFile.java
@@ -51,6 +51,7 @@ public class LockFile
 	{
 		directory.mkdirs();
 		this.file = new File( directory, filename );
+		this.file.deleteOnExit();
 	}
 
 	public boolean lock() throws UnableToCreateLock

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/Paint.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/Paint.java
@@ -14,7 +14,7 @@ import org.janelia.saalfeldlab.fx.event.InstallAndRemove;
 import org.janelia.saalfeldlab.fx.event.KeyTracker;
 import org.janelia.saalfeldlab.paintera.control.paint.FloodFill;
 import org.janelia.saalfeldlab.paintera.control.paint.FloodFill2D;
-import org.janelia.saalfeldlab.paintera.control.paint.Paint2D;
+import org.janelia.saalfeldlab.paintera.control.paint.PaintActions2D;
 import org.janelia.saalfeldlab.paintera.control.paint.RestrictPainting;
 import org.janelia.saalfeldlab.paintera.control.paint.SelectNextId;
 import org.janelia.saalfeldlab.paintera.control.selection.SelectedIds;
@@ -45,7 +45,7 @@ public class Paint implements ToOnEnterOnExit
 
 	private final HashMap< ViewerPanelFX, Collection< InstallAndRemove< Node > > > mouseAndKeyHandlers = new HashMap<>();
 
-	private final HashMap< ViewerPanelFX, Paint2D > painters = new HashMap<>();
+	private final HashMap< ViewerPanelFX, PaintActions2D > painters = new HashMap<>();
 
 	private final SourceInfo sourceInfo;
 
@@ -88,7 +88,7 @@ public class Paint implements ToOnEnterOnExit
 			{
 				if ( !this.mouseAndKeyHandlers.containsKey( t ) )
 				{
-					final Paint2D paint2D = new Paint2D( t, sourceInfo, manager, requestRepaint, paintQueue );
+					final PaintActions2D paint2D = new PaintActions2D( t, sourceInfo, manager, requestRepaint, paintQueue );
 					paint2D.brushRadiusProperty().set( this.brushRadius.get() );
 					paint2D.brushRadiusProperty().bindBidirectional( this.brushRadius );
 					paint2D.brushRadiusIncrementProperty().set( this.brushRadiusIncrement.get() );
@@ -127,6 +127,9 @@ public class Paint implements ToOnEnterOnExit
 					iars.add( EventFX.SCROLL( "change brush size", event -> paint2D.changeBrushRadius( event.getDeltaY() ), event -> keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE ) ) );
 
 					// click paint
+					iars.add( paint2D.clickPaintLabel( "paint 2D", paintSelection::get, event -> event.isPrimaryButtonDown() && keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE ) && this.paint2D.get() ) );
+					iars.add( paint2D.clickPaintLabel( "erase canvas click 2D", () -> Label.TRANSPARENT, event -> event.isSecondaryButtonDown() && keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE ) && this.paint2D.get() ) );
+					iars.add( paint2D.clickPaintLabel( "to background 2D", () -> Label.BACKGROUND, event -> event.isSecondaryButtonDown() && keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE, KeyCode.SHIFT ) && this.paint2D.get() ) );
 //					iars.add( EventFX.MOUSE_PRESSED( "paint click 2D", e -> paint2D.prepareAndPaintUnchecked( e, paintSelection.get() ), e -> e.isPrimaryButtonDown() && keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE ) && this.paint2D.get() ) );
 //					iars.add( EventFX.MOUSE_PRESSED( "erase canvas click 2D", e -> paint2D.prepareAndPaintUnchecked( e, Label.TRANSPARENT ), e -> e.isSecondaryButtonDown() && keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE ) && this.paint2D.get() ) );
 //					iars.add( EventFX.MOUSE_PRESSED( "to background click 2D", e -> paint2D.prepareAndPaintUnchecked( e, Label.BACKGROUND ), e -> e.isSecondaryButtonDown() && keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE, KeyCode.SHIFT ) && this.paint2D.get() ) );

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/Paint.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/Paint.java
@@ -130,9 +130,6 @@ public class Paint implements ToOnEnterOnExit
 					iars.add( paint2D.clickPaintLabel( "paint 2D", paintSelection::get, event -> event.isPrimaryButtonDown() && keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE ) && this.paint2D.get() ) );
 					iars.add( paint2D.clickPaintLabel( "erase canvas click 2D", () -> Label.TRANSPARENT, event -> event.isSecondaryButtonDown() && keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE ) && this.paint2D.get() ) );
 					iars.add( paint2D.clickPaintLabel( "to background 2D", () -> Label.BACKGROUND, event -> event.isSecondaryButtonDown() && keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE, KeyCode.SHIFT ) && this.paint2D.get() ) );
-//					iars.add( EventFX.MOUSE_PRESSED( "paint click 2D", e -> paint2D.prepareAndPaintUnchecked( e, paintSelection.get() ), e -> e.isPrimaryButtonDown() && keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE ) && this.paint2D.get() ) );
-//					iars.add( EventFX.MOUSE_PRESSED( "erase canvas click 2D", e -> paint2D.prepareAndPaintUnchecked( e, Label.TRANSPARENT ), e -> e.isSecondaryButtonDown() && keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE ) && this.paint2D.get() ) );
-//					iars.add( EventFX.MOUSE_PRESSED( "to background click 2D", e -> paint2D.prepareAndPaintUnchecked( e, Label.BACKGROUND ), e -> e.isSecondaryButtonDown() && keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE, KeyCode.SHIFT ) && this.paint2D.get() ) );
 
 					// drag paint
 					iars.add( paint2D.dragPaintLabel( "paint 2D", paintSelection::get, event -> event.isPrimaryButtonDown() && keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE ) && this.paint2D.get() ) );

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/Paint.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/Paint.java
@@ -57,6 +57,8 @@ public class Paint implements ToOnEnterOnExit
 
 	private final SimpleDoubleProperty brushRadiusIncrement = new SimpleDoubleProperty( 1.0 );
 
+	private final SimpleDoubleProperty brushDepth = new SimpleDoubleProperty( 1.0 );
+
 	private final Runnable requestRepaint;
 
 	private final BooleanProperty paint3D = new SimpleBooleanProperty( false );
@@ -89,10 +91,9 @@ public class Paint implements ToOnEnterOnExit
 				if ( !this.mouseAndKeyHandlers.containsKey( t ) )
 				{
 					final PaintActions2D paint2D = new PaintActions2D( t, sourceInfo, manager, requestRepaint, paintQueue );
-					paint2D.brushRadiusProperty().set( this.brushRadius.get() );
 					paint2D.brushRadiusProperty().bindBidirectional( this.brushRadius );
-					paint2D.brushRadiusIncrementProperty().set( this.brushRadiusIncrement.get() );
 					paint2D.brushRadiusIncrementProperty().bindBidirectional( this.brushRadiusIncrement );
+					paint2D.brushDepthProperty().bindBidirectional( this.brushDepth );
 					final ObjectProperty< Source< ? > > currentSource = sourceInfo.currentSourceProperty();
 					final ObjectBinding< SelectedIds > currentSelectedIds = Bindings.createObjectBinding(
 							() -> selectedIdsFromState( sourceInfo.getState( currentSource.get() ) ),
@@ -125,6 +126,7 @@ public class Paint implements ToOnEnterOnExit
 					iars.add( EventFX.KEY_PRESSED( "show brush overlay", event -> paint2D.showBrushOverlay(), event -> keyTracker.areKeysDown( KeyCode.SPACE ) ) );
 					iars.add( EventFX.KEY_RELEASED( "show brush overlay", event -> paint2D.hideBrushOverlay(), event -> event.getCode().equals( KeyCode.SPACE ) && !keyTracker.areKeysDown( KeyCode.SPACE ) ) );
 					iars.add( EventFX.SCROLL( "change brush size", event -> paint2D.changeBrushRadius( event.getDeltaY() ), event -> keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE ) ) );
+					iars.add( EventFX.SCROLL( "change brush depth", event -> paint2D.changeBrushDepth( event.getDeltaY() ), event -> keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE, KeyCode.SHIFT ) ) );
 
 					// click paint
 					iars.add( paint2D.clickPaintLabel( "paint 2D", paintSelection::get, event -> event.isPrimaryButtonDown() && keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE ) && this.paint2D.get() ) );

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/Paint.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/Paint.java
@@ -13,6 +13,7 @@ import org.janelia.saalfeldlab.fx.event.EventFX;
 import org.janelia.saalfeldlab.fx.event.InstallAndRemove;
 import org.janelia.saalfeldlab.fx.event.KeyTracker;
 import org.janelia.saalfeldlab.paintera.control.paint.FloodFill;
+import org.janelia.saalfeldlab.paintera.control.paint.FloodFill2D;
 import org.janelia.saalfeldlab.paintera.control.paint.Paint2D;
 import org.janelia.saalfeldlab.paintera.control.paint.RestrictPainting;
 import org.janelia.saalfeldlab.paintera.control.paint.SelectNextId;
@@ -114,6 +115,7 @@ public class Paint implements ToOnEnterOnExit
 					painters.put( t, paint2D );
 
 					final FloodFill fill = new FloodFill( t, sourceInfo, requestRepaint );
+					final FloodFill2D fill2D = new FloodFill2D( t, sourceInfo, requestRepaint );
 
 					final RestrictPainting restrictor = new RestrictPainting( t, sourceInfo, requestRepaint );
 
@@ -136,6 +138,7 @@ public class Paint implements ToOnEnterOnExit
 
 					// advanced paint stuff
 					iars.add( EventFX.MOUSE_PRESSED( "fill", event -> fill.fillAt( event.getX(), event.getY(), paintSelection::get ), event -> event.isPrimaryButtonDown() && keyTracker.areOnlyTheseKeysDown( KeyCode.SHIFT, KeyCode.F ) ) );
+					iars.add( EventFX.MOUSE_PRESSED( "fill 2D", event -> fill2D.fillAt( event.getX(), event.getY(), paintSelection::get ), event -> event.isPrimaryButtonDown() && keyTracker.areOnlyTheseKeysDown( KeyCode.F ) ) );
 					iars.add( EventFX.MOUSE_PRESSED( "restrict", event -> restrictor.restrictTo( event.getX(), event.getY() ), event -> event.isPrimaryButtonDown() && keyTracker.areOnlyTheseKeysDown( KeyCode.SHIFT, KeyCode.R ) ) );
 
 					final SelectNextId nextId = new SelectNextId( sourceInfo );

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/Paint.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/Paint.java
@@ -12,6 +12,8 @@ import java.util.function.Supplier;
 import org.janelia.saalfeldlab.fx.event.EventFX;
 import org.janelia.saalfeldlab.fx.event.InstallAndRemove;
 import org.janelia.saalfeldlab.fx.event.KeyTracker;
+import org.janelia.saalfeldlab.paintera.control.paint.Fill2DOverlay;
+import org.janelia.saalfeldlab.paintera.control.paint.FillOverlay;
 import org.janelia.saalfeldlab.paintera.control.paint.FloodFill;
 import org.janelia.saalfeldlab.paintera.control.paint.FloodFill2D;
 import org.janelia.saalfeldlab.paintera.control.paint.PaintActions2D;
@@ -117,6 +119,10 @@ public class Paint implements ToOnEnterOnExit
 
 					final FloodFill fill = new FloodFill( t, sourceInfo, requestRepaint );
 					final FloodFill2D fill2D = new FloodFill2D( t, sourceInfo, requestRepaint );
+					fill2D.fillDepthProperty().bindBidirectional( this.brushDepth );
+					final Fill2DOverlay fill2DOverlay = new Fill2DOverlay( t );
+					fill2DOverlay.brushDepthProperty().bindBidirectional( this.brushDepth );
+					final FillOverlay fillOverlay = new FillOverlay( t );
 
 					final RestrictPainting restrictor = new RestrictPainting( t, sourceInfo, requestRepaint );
 
@@ -126,7 +132,20 @@ public class Paint implements ToOnEnterOnExit
 					iars.add( EventFX.KEY_PRESSED( "show brush overlay", event -> paint2D.showBrushOverlay(), event -> keyTracker.areKeysDown( KeyCode.SPACE ) ) );
 					iars.add( EventFX.KEY_RELEASED( "show brush overlay", event -> paint2D.hideBrushOverlay(), event -> event.getCode().equals( KeyCode.SPACE ) && !keyTracker.areKeysDown( KeyCode.SPACE ) ) );
 					iars.add( EventFX.SCROLL( "change brush size", event -> paint2D.changeBrushRadius( event.getDeltaY() ), event -> keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE ) ) );
-					iars.add( EventFX.SCROLL( "change brush depth", event -> paint2D.changeBrushDepth( event.getDeltaY() ), event -> keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE, KeyCode.SHIFT ) ) );
+					iars.add( EventFX.SCROLL(
+							"change brush depth",
+							event -> paint2D.changeBrushDepth( event.getDeltaY() ),
+							event -> keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE, KeyCode.SHIFT ) || keyTracker.areOnlyTheseKeysDown( KeyCode.F ) || keyTracker.areOnlyTheseKeysDown( KeyCode.SHIFT, KeyCode.F ) ) );
+					iars.add( EventFX.KEY_PRESSED( "show fill 2D overlay", event -> {
+						fill2DOverlay.setVisible( true );
+						fillOverlay.setVisible( false );
+					}, event -> keyTracker.areOnlyTheseKeysDown( KeyCode.F ) ) );
+					iars.add( EventFX.KEY_RELEASED( "show fill 2D overlay", event -> fill2DOverlay.setVisible( false ), event -> event.getCode().equals( KeyCode.F ) && keyTracker.noKeysActive() ) );
+					iars.add( EventFX.KEY_PRESSED( "show fill overlay", event -> {
+						fillOverlay.setVisible( true );
+						fill2DOverlay.setVisible( false );
+					}, event -> keyTracker.areOnlyTheseKeysDown( KeyCode.F, KeyCode.SHIFT ) ) );
+					iars.add( EventFX.KEY_RELEASED( "show fill overlay", event -> fillOverlay.setVisible( false ), event -> event.getCode().equals( KeyCode.F ) && keyTracker.areOnlyTheseKeysDown( KeyCode.SHIFT ) || event.isShiftDown() && keyTracker.areOnlyTheseKeysDown( KeyCode.F ) ) );
 
 					// click paint
 					iars.add( paint2D.clickPaintLabel( "paint 2D", paintSelection::get, event -> event.isPrimaryButtonDown() && keyTracker.areOnlyTheseKeysDown( KeyCode.SPACE ) && this.paint2D.get() ) );

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/BrushOverlay.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/BrushOverlay.java
@@ -16,6 +16,7 @@ import javafx.scene.Cursor;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.paint.Color;
+import javafx.scene.text.Font;
 import net.imglib2.realtransform.AffineTransform3D;
 
 public class BrushOverlay implements OverlayRendererGeneric< GraphicsContext >
@@ -32,6 +33,8 @@ public class BrushOverlay implements OverlayRendererGeneric< GraphicsContext >
 	private final SimpleDoubleProperty physicalRadius = new SimpleDoubleProperty();
 
 	private final SimpleDoubleProperty viewerRadius = new SimpleDoubleProperty();
+
+	private final SimpleDoubleProperty brushDepth = new SimpleDoubleProperty();
 
 	protected boolean visible = false;
 
@@ -62,7 +65,9 @@ public class BrushOverlay implements OverlayRendererGeneric< GraphicsContext >
 		if ( visible != this.visible )
 		{
 			if ( this.visible )
+			{
 				this.wasVisible = true;
+			}
 			this.visible = visible;
 			this.viewer.getDisplay().drawOverlays();
 		}
@@ -94,9 +99,26 @@ public class BrushOverlay implements OverlayRendererGeneric< GraphicsContext >
 					y + scaledRadius > 0 &&
 					y - scaledRadius < height )
 			{
+				final double depth = brushDepth.get();
+				final double depthScaleFactor = 5;
+				if ( depth > 1 )
+				{
+//					g.setStroke( Color.BLACK.deriveColor( 0.0, 1.0, 1.0, 0.5 ) );
+					g.setStroke( Color.WHEAT.deriveColor( 0.0, 1.0, 1.0, 0.5 ) );
+					g.setFill( Color.WHITE.deriveColor( 0.0, 1.0, 1.0, 0.5 ) );
+					g.setFont( Font.font( g.getFont().getFamily(), 15.0 ) );
+					g.setLineWidth( this.strokeWidth );
+					g.strokeOval( x - scaledRadius, y - scaledRadius + depth * depthScaleFactor, 2 * scaledRadius + 1, 2 * scaledRadius + 1 );
+//					g.fillRect( x - scaledRadius, y, 2 * scaledRadius + 1, depth * depthScaleFactor );
+					g.strokeLine( x - scaledRadius, y + depth * depthScaleFactor, x - scaledRadius, y );
+					g.strokeLine( x + scaledRadius + 1, y + depth * depthScaleFactor, x + scaledRadius + 1, y );
+					g.fillText( "depth=" + depth, x + scaledRadius + 1, y + depth * depthScaleFactor + scaledRadius + 1 );
+				}
+
 				g.setStroke( Color.WHITE );
 				g.setLineWidth( this.strokeWidth );
 				g.strokeOval( x - scaledRadius, y - scaledRadius, 2 * scaledRadius + 1, 2 * scaledRadius + 1 );
+
 //				this.viewer.getScene().setCursor( Cursor.NONE );
 				return;
 			}
@@ -123,6 +145,11 @@ public class BrushOverlay implements OverlayRendererGeneric< GraphicsContext >
 	public ObservableDoubleValue viewerRadiusProperty()
 	{
 		return this.viewerRadius;
+	}
+
+	public DoubleProperty brushDepthProperty()
+	{
+		return this.brushDepth;
 	}
 
 	private void updateViewerRadius( final AffineTransform3D transform )

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/Fill2DOverlay.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/Fill2DOverlay.java
@@ -36,6 +36,12 @@ public class Fill2DOverlay implements OverlayRendererGeneric< GraphicsContext >
 		this.viewer.getDisplay().addOverlayRenderer( this );
 		this.viewer.addEventFilter( MouseEvent.MOUSE_MOVED, this::setPosition );
 		this.viewer.addEventFilter( MouseEvent.MOUSE_DRAGGED, this::setPosition );
+		this.brushDepth.addListener( ( obs, oldv, newv ) -> {
+			if ( visible )
+			{
+				this.viewer.getDisplay().drawOverlays();
+			}
+		} );
 
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/Fill2DOverlay.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/Fill2DOverlay.java
@@ -1,0 +1,110 @@
+package org.janelia.saalfeldlab.paintera.control.paint;
+
+import java.lang.invoke.MethodHandles;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import bdv.fx.viewer.OverlayRendererGeneric;
+import bdv.fx.viewer.ViewerPanelFX;
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.SimpleDoubleProperty;
+import javafx.scene.Cursor;
+import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.paint.Color;
+import javafx.scene.text.Font;
+
+public class Fill2DOverlay implements OverlayRendererGeneric< GraphicsContext >
+{
+
+	private static final Logger LOG = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
+
+	private final ViewerPanelFX viewer;
+
+	private double x, y;
+
+	private final SimpleDoubleProperty brushDepth = new SimpleDoubleProperty();
+
+	protected boolean visible = false;
+
+	protected boolean wasVisible = false;
+
+	public Fill2DOverlay( final ViewerPanelFX viewer )
+	{
+		this.viewer = viewer;
+		this.viewer.getDisplay().addOverlayRenderer( this );
+		this.viewer.addEventFilter( MouseEvent.MOUSE_MOVED, this::setPosition );
+		this.viewer.addEventFilter( MouseEvent.MOUSE_DRAGGED, this::setPosition );
+
+	}
+
+	public void setVisible( final boolean visible )
+	{
+		if ( visible != this.visible )
+		{
+			if ( this.visible )
+			{
+				this.wasVisible = true;
+			}
+			this.visible = visible;
+			this.viewer.getDisplay().drawOverlays();
+		}
+	}
+
+	public void setPosition( final MouseEvent event )
+	{
+		setPosition( event.getX(), event.getY() );
+	}
+
+	public void setPosition( final double x, final double y )
+	{
+		this.x = x;
+		this.y = y;
+		this.viewer.getDisplay().drawOverlays();
+	}
+
+	@Override
+	public void drawOverlays( final GraphicsContext g )
+	{
+
+		if ( visible && this.viewer.isMouseInside() )
+		{
+
+			{
+				this.viewer.getScene().setCursor( Cursor.CROSSHAIR );
+				final double depth = brushDepth.get();
+				if ( depth > 1 )
+				{
+					g.setFill( Color.WHITE );
+					g.setFont( Font.font( g.getFont().getFamily(), 15.0 ) );
+					g.fillText( "Fill 2D depth=" + depth, x + 5, y - 5 );
+				}
+				else
+				{
+					g.setFill( Color.WHITE );
+					g.setFont( Font.font( g.getFont().getFamily(), 15.0 ) );
+					g.fillText( "Fill 2D", x + 5, y - 5 );
+				}
+
+//				this.viewer.getScene().setCursor( Cursor.NONE );
+				return;
+			}
+		}
+		if ( wasVisible )
+		{
+			this.viewer.getScene().setCursor( Cursor.DEFAULT );
+			wasVisible = false;
+		}
+	}
+
+	@Override
+	public void setCanvasSize( final int width, final int height )
+	{}
+
+	public DoubleProperty brushDepthProperty()
+	{
+		return this.brushDepth;
+	}
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FillOverlay.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FillOverlay.java
@@ -1,0 +1,90 @@
+package org.janelia.saalfeldlab.paintera.control.paint;
+
+import java.lang.invoke.MethodHandles;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import bdv.fx.viewer.OverlayRendererGeneric;
+import bdv.fx.viewer.ViewerPanelFX;
+import javafx.scene.Cursor;
+import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.paint.Color;
+import javafx.scene.text.Font;
+
+public class FillOverlay implements OverlayRendererGeneric< GraphicsContext >
+{
+
+	private static final Logger LOG = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
+
+	private final ViewerPanelFX viewer;
+
+	private double x, y;
+
+	protected boolean visible = false;
+
+	protected boolean wasVisible = false;
+
+	public FillOverlay( final ViewerPanelFX viewer )
+	{
+		this.viewer = viewer;
+		this.viewer.getDisplay().addOverlayRenderer( this );
+		this.viewer.addEventFilter( MouseEvent.MOUSE_MOVED, this::setPosition );
+		this.viewer.addEventFilter( MouseEvent.MOUSE_DRAGGED, this::setPosition );
+
+	}
+
+	public void setVisible( final boolean visible )
+	{
+		if ( visible != this.visible )
+		{
+			if ( this.visible )
+			{
+				this.wasVisible = true;
+			}
+			this.visible = visible;
+			this.viewer.getDisplay().drawOverlays();
+		}
+	}
+
+	public void setPosition( final MouseEvent event )
+	{
+		setPosition( event.getX(), event.getY() );
+	}
+
+	public void setPosition( final double x, final double y )
+	{
+		this.x = x;
+		this.y = y;
+		this.viewer.getDisplay().drawOverlays();
+	}
+
+	@Override
+	public void drawOverlays( final GraphicsContext g )
+	{
+
+		if ( visible && this.viewer.isMouseInside() )
+		{
+
+			{
+				this.viewer.getScene().setCursor( Cursor.CROSSHAIR );
+				g.setFill( Color.WHITE );
+				g.setFont( Font.font( g.getFont().getFamily(), 15.0 ) );
+				g.fillText( "Fill 3D", x + 5, y - 5 );
+//				this.viewer.getScene().setCursor( Cursor.NONE );
+				return;
+			}
+		}
+		if ( wasVisible )
+		{
+			this.viewer.getScene().setCursor( Cursor.DEFAULT );
+			wasVisible = false;
+		}
+	}
+
+	@Override
+	public void setCanvasSize( final int width, final int height )
+	{}
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFill.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFill.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.BiPredicate;
 import java.util.function.LongFunction;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import org.janelia.saalfeldlab.paintera.data.mask.MaskInUse;
@@ -38,7 +39,6 @@ import net.imglib2.type.label.Label;
 import net.imglib2.type.label.LabelMultisetType;
 import net.imglib2.type.label.Multiset.Entry;
 import net.imglib2.type.numeric.RealType;
-import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.type.numeric.integer.UnsignedLongType;
 import net.imglib2.util.AccessBoxRandomAccessible;
 import net.imglib2.util.Intervals;
@@ -56,6 +56,19 @@ public class FloodFill
 	private final Runnable requestRepaint;
 
 	private final AffineTransform3D viewerTransform = new AffineTransform3D();
+
+	private static final class ForegroundCheck implements Predicate< UnsignedLongType >
+	{
+
+		@Override
+		public boolean test( final UnsignedLongType t )
+		{
+			return t.getIntegerLong() == 1;
+		}
+
+	}
+
+	private static final ForegroundCheck FOREGROUND_CHECK = new ForegroundCheck();
 
 	public FloodFill( final ViewerPanelFX viewer, final SourceInfo sourceInfo, final Runnable requestRepaint )
 	{
@@ -218,14 +231,14 @@ public class FloodFill
 			final Runnable doWhenDone ) throws MaskInUse
 	{
 		final MaskInfo< UnsignedLongType > maskInfo = new MaskInfo<>( time, level, new UnsignedLongType( fill ) );
-		final RandomAccessibleInterval< UnsignedByteType > mask = source.generateMask( maskInfo );
-		final AccessBoxRandomAccessible< UnsignedByteType > accessTracker = new AccessBoxRandomAccessible<>( Views.extendValue( mask, new UnsignedByteType( 1 ) ) );
+		final RandomAccessibleInterval< UnsignedLongType > mask = source.generateMask( maskInfo, FOREGROUND_CHECK );
+		final AccessBoxRandomAccessible< UnsignedLongType > accessTracker = new AccessBoxRandomAccessible<>( Views.extendValue( mask, new UnsignedLongType( 1 ) ) );
 		final Thread t = new Thread( () -> {
 			net.imglib2.algorithm.fill.FloodFill.fill(
 					source.getDataSource( time, level ),
 					accessTracker,
 					seed,
-					new UnsignedByteType( 1 ),
+					new UnsignedLongType( 1 ),
 					new DiamondShape( 1 ) );
 			final Interval interval = accessTracker.createAccessInterval();
 			LOG.debug( "Applying mask for interval {} {}", Arrays.toString( Intervals.minAsLongArray( interval ) ), Arrays.toString( Intervals.maxAsLongArray( interval ) ) );
@@ -249,7 +262,7 @@ public class FloodFill
 			doWhenDone.run();
 			if ( !Thread.interrupted() )
 			{
-				source.applyMask( mask, accessTracker.createAccessInterval() );
+				source.applyMask( mask, accessTracker.createAccessInterval(), FOREGROUND_CHECK );
 			}
 		} ).start();
 	}
@@ -275,14 +288,14 @@ public class FloodFill
 		}
 
 		final MaskInfo< UnsignedLongType > maskInfo = new MaskInfo<>( time, level, new UnsignedLongType( fill ) );
-		final RandomAccessibleInterval< UnsignedByteType > mask = source.generateMask( maskInfo );
-		final AccessBoxRandomAccessible< UnsignedByteType > accessTracker = new AccessBoxRandomAccessible<>( Views.extendValue( mask, new UnsignedByteType( 1 ) ) );
+		final RandomAccessibleInterval< UnsignedLongType > mask = source.generateMask( maskInfo, FOREGROUND_CHECK );
+		final AccessBoxRandomAccessible< UnsignedLongType > accessTracker = new AccessBoxRandomAccessible<>( Views.extendValue( mask, new UnsignedLongType( 1 ) ) );
 		final Thread t = new Thread( () -> {
 			net.imglib2.algorithm.fill.FloodFill.fill(
 					Views.extendValue( data, new LabelMultisetType() ),
 					accessTracker,
 					seed,
-					new UnsignedByteType( 1 ),
+					new UnsignedLongType( 1 ),
 					new DiamondShape( 1 ),
 					makePredicateMultiset( seedLabel ) );
 			final Interval interval = accessTracker.createAccessInterval();
@@ -307,14 +320,14 @@ public class FloodFill
 			doWhenDone.run();
 			if ( !Thread.interrupted() )
 			{
-				source.applyMask( mask, accessTracker.createAccessInterval() );
+				source.applyMask( mask, accessTracker.createAccessInterval(), FOREGROUND_CHECK );
 			}
 		} ).start();
 	}
 
-	private static BiPredicate< LabelMultisetType, UnsignedByteType > makePredicateMultiset( final long id )
+	private static BiPredicate< LabelMultisetType, UnsignedLongType > makePredicateMultiset( final long id )
 	{
-		final UnsignedByteType zero = new UnsignedByteType( 0 );
+		final UnsignedLongType zero = new UnsignedLongType( 0 );
 		return ( l, u ) -> zero.valueEquals( u ) && l.contains( id );
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFill.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFill.java
@@ -145,8 +145,6 @@ public class FloodFill
 			return;
 		}
 
-		// TODO always fill at highest resolution?
-//		final int level = viewerState.getBestMipMapLevel( new AffineTransform3D(), sourceInfo.currentSourceIndexInVisibleSources().get() );
 		final int level = 0;
 		final AffineTransform3D labelTransform = new AffineTransform3D();
 		final int time = viewerState.timepointProperty().get();

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFill2D.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFill2D.java
@@ -142,7 +142,7 @@ public class FloodFill2D
 		final int time = viewerState.timepointProperty().get();
 		source.getSourceTransform( time, level, labelTransform );
 		final AffineTransform3D viewerTransform = this.viewerTransform.copy();
-		final AffineTransform3D labelToViewerTransform = this.viewerTransform.copy().preConcatenate( labelTransform );
+		final AffineTransform3D labelToViewerTransform = this.viewerTransform.copy().concatenate( labelTransform );
 
 		final RealPoint rp = setCoordinates( x, y, viewer, labelTransform );
 		final RandomAccessibleInterval background = source.underlyingSource().getDataSource( time, level );
@@ -161,6 +161,7 @@ public class FloodFill2D
 		{
 			final RandomAccessibleInterval mask = source.generateMask( maskInfo, px -> px.getIntegerLong() > 0 );
 			final long seedLabel = state.toIdConverter().biggestFragment( access.get() );
+			LOG.warn( "Got seed label {}", seedLabel );
 			final RandomAccessibleInterval relevantBackground = Converters.convert( background, state.maskForLabel().apply( seedLabel ), new BoolType() );
 			final ExtendedRandomAccessibleInterval< BoolType, ? > extended = Views.extendValue( relevantBackground, new BoolType( false ) );
 
@@ -169,7 +170,7 @@ public class FloodFill2D
 
 			FloodFillTransformedPlane.fill(
 					labelToViewerTransform,
-					PaintUtils.maximumVoxelDiagonalLengthPerDimension( labelTransform, viewerTransform )[ 2 ],
+					0.5 * PaintUtils.maximumVoxelDiagonalLengthPerDimension( labelTransform, viewerTransform )[ 2 ],
 					extended.randomAccess(),
 					accessTracker.randomAccess(),
 					new RealPoint( x, y, 0 ),

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFill2D.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFill2D.java
@@ -159,7 +159,7 @@ public class FloodFill2D
 		scene.setCursor( Cursor.WAIT );
 		try
 		{
-			final RandomAccessibleInterval mask = source.generateMask( maskInfo, px -> px.getIntegerLong() > 0 );
+			final RandomAccessibleInterval mask = source.generateMask( maskInfo, FOREGROUND_CHECK );
 			final long seedLabel = state.toIdConverter().biggestFragment( access.get() );
 			LOG.warn( "Got seed label {}", seedLabel );
 			final RandomAccessibleInterval relevantBackground = Converters.convert( background, state.maskForLabel().apply( seedLabel ), new BoolType() );
@@ -177,7 +177,7 @@ public class FloodFill2D
 					1l );
 
 			requestRepaint.run();
-			source.applyMask( mask, new FinalInterval( accessTracker.getMin(), accessTracker.getMax() ), px -> px.getIntegerLong() > 0 );
+			source.applyMask( mask, new FinalInterval( accessTracker.getMin(), accessTracker.getMax() ), FOREGROUND_CHECK );
 
 		}
 		catch ( final MaskInUse e )

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFill2D.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFill2D.java
@@ -1,0 +1,220 @@
+package org.janelia.saalfeldlab.paintera.control.paint;
+
+import java.lang.invoke.MethodHandles;
+import java.util.function.LongFunction;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import org.janelia.saalfeldlab.paintera.data.mask.MaskInUse;
+import org.janelia.saalfeldlab.paintera.data.mask.MaskInfo;
+import org.janelia.saalfeldlab.paintera.data.mask.MaskedSource;
+import org.janelia.saalfeldlab.paintera.state.LabelSourceState;
+import org.janelia.saalfeldlab.paintera.state.SourceInfo;
+import org.janelia.saalfeldlab.paintera.state.SourceState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import bdv.fx.viewer.ViewerPanelFX;
+import bdv.fx.viewer.ViewerState;
+import bdv.viewer.Source;
+import javafx.scene.Cursor;
+import javafx.scene.Scene;
+import net.imglib2.FinalInterval;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RealLocalizable;
+import net.imglib2.RealPoint;
+import net.imglib2.RealPositionable;
+import net.imglib2.converter.Converters;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.Type;
+import net.imglib2.type.label.LabelMultisetType;
+import net.imglib2.type.logic.BoolType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.integer.UnsignedLongType;
+import net.imglib2.util.AccessBoxRandomAccessibleOnGet;
+import net.imglib2.view.ExtendedRandomAccessibleInterval;
+import net.imglib2.view.Views;
+
+public class FloodFill2D
+{
+
+	private static final Logger LOG = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
+
+	private final ViewerPanelFX viewer;
+
+	private final SourceInfo sourceInfo;
+
+	private final Runnable requestRepaint;
+
+	private final AffineTransform3D viewerTransform = new AffineTransform3D();
+
+	private static final class ForegroundCheck implements Predicate< UnsignedLongType >
+	{
+
+		@Override
+		public boolean test( final UnsignedLongType t )
+		{
+			return t.getIntegerLong() == 1;
+		}
+
+	}
+
+	private static final ForegroundCheck FOREGROUND_CHECK = new ForegroundCheck();
+
+	public FloodFill2D( final ViewerPanelFX viewer, final SourceInfo sourceInfo, final Runnable requestRepaint )
+	{
+		super();
+		this.viewer = viewer;
+		this.sourceInfo = sourceInfo;
+		this.requestRepaint = requestRepaint;
+		viewer.addTransformListener( t -> viewerTransform.set( t ) );
+	}
+
+	public void fillAt( final double x, final double y, final Supplier< Long > fillSupplier )
+	{
+		if ( sourceInfo.currentSourceProperty().get() == null )
+		{
+			LOG.warn( "No current source selected -- will not fill" );
+			return;
+		}
+		final Long fill = fillSupplier.get();
+		if ( fill == null )
+		{
+			LOG.warn( "Received invalid label {} -- will not fill.", fill );
+			return;
+		}
+		fillAt( x, y, fill );
+	}
+
+	@SuppressWarnings( { "rawtypes", "unchecked" } )
+	public void fillAt( final double x, final double y, final long fill )
+	{
+		final Source< ? > currentSource = sourceInfo.currentSourceProperty().get();
+		final ViewerState viewerState = viewer.getState();
+		if ( currentSource == null )
+		{
+			LOG.warn( "No current source selected -- will not fill" );
+			return;
+		}
+
+		final SourceState< ?, ? > currentSourceState = sourceInfo.getState( currentSource );
+
+		if ( !( currentSourceState instanceof LabelSourceState< ?, ? > ) )
+		{
+			LOG.warn( "Selected source is not a label source -- will not fill" );
+			return;
+		}
+
+		final LabelSourceState< ?, ? > state = ( LabelSourceState< ?, ? > ) currentSourceState;
+
+		if ( !state.isVisibleProperty().get() )
+		{
+			LOG.warn( "Selected source is not visible -- will not fill" );
+			return;
+		}
+
+		if ( !( currentSource instanceof MaskedSource< ?, ? > ) )
+		{
+			LOG.warn( "Selected source is not painting-enabled -- will not fill" );
+			return;
+		}
+
+		final LongFunction< ? > maskForLabel = state.maskForLabel();
+		if ( maskForLabel == null )
+		{
+			LOG.warn( "Cannot generate boolean mask for this source -- will not fill" );
+			return;
+		}
+
+		final MaskedSource< ?, ? > source = ( MaskedSource< ?, ? > ) currentSource;
+
+		final Type< ? > t = source.getDataType();
+
+		if ( !( t instanceof RealType< ? > ) && !( t instanceof LabelMultisetType ) )
+		{
+			LOG.warn( "Data type is not real or LabelMultisetType type -- will not fill" );
+			return;
+		}
+
+		final int level = 0;
+		final AffineTransform3D labelTransform = new AffineTransform3D();
+		final int time = viewerState.timepointProperty().get();
+		source.getSourceTransform( time, level, labelTransform );
+		final AffineTransform3D viewerTransform = this.viewerTransform.copy();
+		final AffineTransform3D labelToViewerTransform = this.viewerTransform.copy().preConcatenate( labelTransform );
+
+		final RealPoint rp = setCoordinates( x, y, viewer, labelTransform );
+		final RandomAccessibleInterval background = source.underlyingSource().getDataSource( time, level );
+		final RandomAccess< ? > access = background.randomAccess();
+		for ( int d = 0; d < access.numDimensions(); ++d )
+		{
+			access.setPosition( Math.round( rp.getDoublePosition( d ) ), d );
+		}
+
+		final MaskInfo maskInfo = new MaskInfo<>( time, level, new UnsignedLongType( fill ) );
+
+		final Scene scene = viewer.getScene();
+		final Cursor previousCursor = scene.getCursor();
+		scene.setCursor( Cursor.WAIT );
+		try
+		{
+			final RandomAccessibleInterval mask = source.generateMask( maskInfo, px -> px.getIntegerLong() > 0 );
+			final long seedLabel = state.toIdConverter().biggestFragment( access.get() );
+			final RandomAccessibleInterval relevantBackground = Converters.convert( background, state.maskForLabel().apply( seedLabel ), new BoolType() );
+			final ExtendedRandomAccessibleInterval< BoolType, ? > extended = Views.extendValue( relevantBackground, new BoolType( false ) );
+
+			final AccessBoxRandomAccessibleOnGet accessTracker = new AccessBoxRandomAccessibleOnGet<>( Views.extendValue( mask, new UnsignedLongType( 1l ) ) );
+			accessTracker.initAccessBox();
+
+			FloodFillTransformedPlane.fill(
+					labelToViewerTransform,
+					PaintUtils.maximumVoxelDiagonalLengthPerDimension( labelTransform, viewerTransform )[ 2 ],
+					extended.randomAccess(),
+					accessTracker.randomAccess(),
+					new RealPoint( x, y, 0 ),
+					1l );
+
+			requestRepaint.run();
+			source.applyMask( mask, new FinalInterval( accessTracker.getMin(), accessTracker.getMax() ), px -> px.getIntegerLong() > 0 );
+
+		}
+		catch ( final MaskInUse e )
+		{
+			LOG.warn( e.getMessage() );
+			return;
+		}
+		finally
+		{
+			scene.setCursor( previousCursor );
+		}
+
+	}
+
+	private static RealPoint setCoordinates(
+			final double x,
+			final double y,
+			final ViewerPanelFX viewer,
+			final AffineTransform3D labelTransform )
+	{
+		return setCoordinates( x, y, new RealPoint( labelTransform.numDimensions() ), viewer, labelTransform );
+	}
+
+	private static < P extends RealLocalizable & RealPositionable > P setCoordinates(
+			final double x,
+			final double y,
+			final P location,
+			final ViewerPanelFX viewer,
+			final AffineTransform3D labelTransform )
+	{
+		location.setPosition( x, 0 );
+		location.setPosition( y, 1 );
+		location.setPosition( 0, 2 );
+
+		viewer.displayToGlobalCoordinates( location );
+		labelTransform.applyInverse( location, location );
+
+		return location;
+	}
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFill2D.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFill2D.java
@@ -17,6 +17,8 @@ import org.slf4j.LoggerFactory;
 import bdv.fx.viewer.ViewerPanelFX;
 import bdv.fx.viewer.ViewerState;
 import bdv.viewer.Source;
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.SimpleDoubleProperty;
 import javafx.scene.Cursor;
 import javafx.scene.Scene;
 import net.imglib2.FinalInterval;
@@ -49,6 +51,8 @@ public class FloodFill2D
 	private final Runnable requestRepaint;
 
 	private final AffineTransform3D viewerTransform = new AffineTransform3D();
+
+	private final SimpleDoubleProperty fillDepth = new SimpleDoubleProperty( 1.0 );
 
 	private static final class ForegroundCheck implements Predicate< UnsignedLongType >
 	{
@@ -172,7 +176,7 @@ public class FloodFill2D
 
 			FloodFillTransformedPlane.fill(
 					labelToViewerTransform,
-					0.5 * PaintUtils.maximumVoxelDiagonalLengthPerDimension( labelTransform, viewerTransform )[ 2 ],
+					( 0.5 + this.fillDepth.get() - 1.0 ) * PaintUtils.maximumVoxelDiagonalLengthPerDimension( labelTransform, viewerTransform )[ 2 ],
 					extended.randomAccess(),
 					accessTracker.randomAccess(),
 					new RealPoint( x, y, 0 ),
@@ -218,6 +222,11 @@ public class FloodFill2D
 		labelTransform.applyInverse( location, location );
 
 		return location;
+	}
+
+	public DoubleProperty fillDepthProperty()
+	{
+		return this.fillDepth;
 	}
 
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFillTransformedCylinder3D.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFillTransformedCylinder3D.java
@@ -128,8 +128,8 @@ public class FloodFillTransformedCylinder3D
 
 		final double cx = seedWorld.getDoublePosition( 0 );
 		final double cy = seedWorld.getDoublePosition( 1 );
-		final double zMinExclusive = seedWorld.getDoublePosition( 2 ) + zRangeNeg;
-		final double zMaxExclusive = seedWorld.getDoublePosition( 2 ) + zRangePos;
+		final double zMinInclusive = seedWorld.getDoublePosition( 2 ) + zRangeNeg;
+		final double zMaxInclusive = seedWorld.getDoublePosition( 2 ) + zRangePos;
 
 		for ( int d = 0; d < 3; ++d )
 		{
@@ -168,7 +168,7 @@ public class FloodFillTransformedCylinder3D
 					x + dxx, y + dxy, z + dxz,
 					radiusSquared,
 					cx, cy,
-					zMinExclusive, zMaxExclusive );
+					zMinInclusive, zMaxInclusive );
 
 			addIfInside(
 					sourceCoordinates,
@@ -177,7 +177,7 @@ public class FloodFillTransformedCylinder3D
 					x - dxx, y - dxy, z - dxz,
 					radiusSquared,
 					cx, cy,
-					zMinExclusive, zMaxExclusive );
+					zMinInclusive, zMaxInclusive );
 
 			addIfInside(
 					sourceCoordinates,
@@ -186,7 +186,7 @@ public class FloodFillTransformedCylinder3D
 					x + dyx, y + dyy, z + dyz,
 					radiusSquared,
 					cx, cy,
-					zMinExclusive, zMaxExclusive );
+					zMinInclusive, zMaxInclusive );
 
 			addIfInside(
 					sourceCoordinates,
@@ -195,7 +195,7 @@ public class FloodFillTransformedCylinder3D
 					x - dyx, y - dyy, z - dyz,
 					radiusSquared,
 					cx, cy,
-					zMinExclusive, zMaxExclusive );
+					zMinInclusive, zMaxInclusive );
 
 			addIfInside(
 					sourceCoordinates,
@@ -204,7 +204,7 @@ public class FloodFillTransformedCylinder3D
 					x + dzx, y + dzy, z + dzz,
 					radiusSquared,
 					cx, cy,
-					zMinExclusive, zMaxExclusive );
+					zMinInclusive, zMaxInclusive );
 
 			addIfInside(
 					sourceCoordinates,
@@ -213,7 +213,7 @@ public class FloodFillTransformedCylinder3D
 					x - dzx, y - dzy, z - dzz,
 					radiusSquared,
 					cx, cy,
-					zMinExclusive, zMaxExclusive );
+					zMinInclusive, zMaxInclusive );
 
 		}
 	}
@@ -230,14 +230,14 @@ public class FloodFillTransformedCylinder3D
 			final double rSquared,
 			final double cx,
 			final double cy,
-			final double zMinExclusive,
-			final double zMaxExclusive )
+			final double zMinInclusive,
+			final double zMaxInclusive )
 	{
-		if ( wz > zMinExclusive && wz < zMaxExclusive )
+		if ( wz >= zMinInclusive && wz <= zMaxInclusive )
 		{
 			final double dx = wx - cx;
 			final double dy = wy - cy;
-			if ( dx * dx + dy * dy < rSquared )
+			if ( dx * dx + dy * dy <= rSquared )
 			{
 				labelCoordinates.add( lx );
 				labelCoordinates.add( ly );

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFillTransformedCylinder3D.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFillTransformedCylinder3D.java
@@ -1,0 +1,253 @@
+package org.janelia.saalfeldlab.paintera.control.paint;
+
+import java.util.stream.IntStream;
+
+import gnu.trove.list.array.TDoubleArrayList;
+import gnu.trove.list.array.TLongArrayList;
+import net.imglib2.RandomAccess;
+import net.imglib2.RealLocalizable;
+import net.imglib2.RealPoint;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.numeric.IntegerType;
+
+public class FloodFillTransformedCylinder3D
+{
+
+	private static final double[] D_X_LOCAL = { 1.0, 0.0, 0.0 };
+
+	private static final double[] D_Y_LOCAL = { 0.0, 1.0, 0.0 };
+
+	private static final double[] D_Z_LOCAL = { 0.0, 0.0, 1.0 };
+
+	private final AffineTransform3D localToWorld;
+
+	private final double radiusSquared;
+
+	private final double zRangePos;
+
+	private final double zRangeNeg;
+
+	private final double dxx;
+
+	private final double dxy;
+
+	private final double dxz;
+
+	private final double dyx;
+
+	private final double dyy;
+
+	private final double dyz;
+
+	private final double dzx;
+
+	private final double dzy;
+
+	private final double dzz;
+
+	public static void fill(
+			final AffineTransform3D localToWorld,
+			final double radius,
+			final double zRange,
+			final RandomAccess< ? extends IntegerType< ? > > localAccess,
+			final RealLocalizable seedWorld,
+			final long fillLabel )
+	{
+		new FloodFillTransformedCylinder3D( localToWorld, radius, zRange ).fill( localAccess, seedWorld, fillLabel );
+	}
+
+	public static void fill(
+			final AffineTransform3D localToWorld,
+			final double radius,
+			final double zRangePos,
+			final double zRangeNeg,
+			final RandomAccess< ? extends IntegerType< ? > > localAccess,
+			final RealLocalizable seedWorld,
+			final long fillLabel )
+	{
+		new FloodFillTransformedCylinder3D( localToWorld, radius, zRangePos, zRangeNeg ).fill( localAccess, seedWorld, fillLabel );
+	}
+
+	// radius and range in world coordinates
+	public FloodFillTransformedCylinder3D(
+			final AffineTransform3D localToWorld,
+			final double radius,
+			final double zRange )
+	{
+		this( localToWorld, radius, +zRange, -zRange );
+	}
+
+	// radius and range in world coordinates
+	public FloodFillTransformedCylinder3D(
+			final AffineTransform3D localToWorld,
+			final double radius,
+			final double zRangePos,
+			final double zRangeNeg )
+	{
+		super();
+		this.localToWorld = localToWorld;
+		this.radiusSquared = radius * radius;
+		this.zRangePos = zRangePos;
+		this.zRangeNeg = zRangeNeg;
+
+		final double[] dx = D_X_LOCAL.clone();
+		final double[] dy = D_Y_LOCAL.clone();
+		final double[] dz = D_Z_LOCAL.clone();
+
+		final AffineTransform3D transformNoTranslation = this.localToWorld.copy();
+		transformNoTranslation.setTranslation( 0.0, 0.0, 0.0 );
+		transformNoTranslation.apply( dx, dx );
+		transformNoTranslation.apply( dy, dy );
+		transformNoTranslation.apply( dz, dz );
+
+		this.dxx = dx[ 0 ];
+		this.dxy = dx[ 1 ];
+		this.dxz = dx[ 2 ];
+
+		this.dyx = dy[ 0 ];
+		this.dyy = dy[ 1 ];
+		this.dyz = dy[ 2 ];
+
+		this.dzx = dz[ 0 ];
+		this.dzy = dz[ 1 ];
+		this.dzz = dz[ 2 ];
+	}
+
+	public void fill(
+			final RandomAccess< ? extends IntegerType< ? > > localAccess,
+			final RealLocalizable seedWorld,
+			final long fillLabel )
+	{
+		final double[] pos = IntStream.range( 0, 3 ).mapToDouble( seedWorld::getDoublePosition ).toArray();
+
+		final RealPoint seedLocal = new RealPoint( seedWorld );
+		localToWorld.applyInverse( seedLocal, seedLocal );
+
+		final TLongArrayList sourceCoordinates = new TLongArrayList();
+		final TDoubleArrayList worldCoordinates = new TDoubleArrayList();
+
+		final double cx = seedWorld.getDoublePosition( 0 );
+		final double cy = seedWorld.getDoublePosition( 1 );
+		final double zMinExclusive = seedWorld.getDoublePosition( 2 ) + zRangeNeg;
+		final double zMaxExclusive = seedWorld.getDoublePosition( 2 ) + zRangePos;
+
+		for ( int d = 0; d < 3; ++d )
+		{
+			sourceCoordinates.add( Math.round( seedLocal.getDoublePosition( d ) ) );
+			worldCoordinates.add( pos[ d ] );
+		}
+
+		for ( int offset = 0; offset < sourceCoordinates.size(); offset += 3 )
+		{
+			final int o0 = offset + 0;
+			final int o1 = offset + 1;
+			final int o2 = offset + 2;
+			final long lx = sourceCoordinates.get( o0 );
+			final long ly = sourceCoordinates.get( o1 );
+			final long lz = sourceCoordinates.get( o2 );
+			localAccess.setPosition( lx, 0 );
+			localAccess.setPosition( ly, 1 );
+			localAccess.setPosition( lz, 2 );
+
+			final IntegerType< ? > val = localAccess.get();
+
+			if ( val.getIntegerLong() == fillLabel )
+			{
+				continue;
+			}
+			val.setInteger( fillLabel );
+
+			final double x = worldCoordinates.get( o0 );
+			final double y = worldCoordinates.get( o1 );
+			final double z = worldCoordinates.get( o2 );
+
+			addIfInside(
+					sourceCoordinates,
+					worldCoordinates,
+					lx + 1, ly, lz,
+					x + dxx, y + dxy, z + dxz,
+					radiusSquared,
+					cx, cy,
+					zMinExclusive, zMaxExclusive );
+
+			addIfInside(
+					sourceCoordinates,
+					worldCoordinates,
+					lx - 1, ly, lz,
+					x - dxx, y - dxy, z - dxz,
+					radiusSquared,
+					cx, cy,
+					zMinExclusive, zMaxExclusive );
+
+			addIfInside(
+					sourceCoordinates,
+					worldCoordinates,
+					lx, ly + 1, lz,
+					x + dyx, y + dyy, z + dyz,
+					radiusSquared,
+					cx, cy,
+					zMinExclusive, zMaxExclusive );
+
+			addIfInside(
+					sourceCoordinates,
+					worldCoordinates,
+					lx, ly - 1, lz,
+					x - dyx, y - dyy, z - dyz,
+					radiusSquared,
+					cx, cy,
+					zMinExclusive, zMaxExclusive );
+
+			addIfInside(
+					sourceCoordinates,
+					worldCoordinates,
+					lx, ly, lz + 1,
+					x + dzx, y + dzy, z + dzz,
+					radiusSquared,
+					cx, cy,
+					zMinExclusive, zMaxExclusive );
+
+			addIfInside(
+					sourceCoordinates,
+					worldCoordinates,
+					lx, ly, lz - 1,
+					x - dzx, y - dzy, z - dzz,
+					radiusSquared,
+					cx, cy,
+					zMinExclusive, zMaxExclusive );
+
+		}
+	}
+
+	private static final void addIfInside(
+			final TLongArrayList labelCoordinates,
+			final TDoubleArrayList worldCoordinates,
+			final long lx,
+			final long ly,
+			final long lz,
+			final double wx,
+			final double wy,
+			final double wz,
+			final double rSquared,
+			final double cx,
+			final double cy,
+			final double zMinExclusive,
+			final double zMaxExclusive )
+	{
+		if ( wz > zMinExclusive && wz < zMaxExclusive )
+		{
+			final double dx = wx - cx;
+			final double dy = wy - cy;
+			if ( dx * dx + dy * dy < rSquared )
+			{
+				labelCoordinates.add( lx );
+				labelCoordinates.add( ly );
+				labelCoordinates.add( lz );
+
+				worldCoordinates.add( wx );
+				worldCoordinates.add( wy );
+				worldCoordinates.add( wz );
+			}
+		}
+	}
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFillTransformedPlane.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFillTransformedPlane.java
@@ -1,0 +1,321 @@
+package org.janelia.saalfeldlab.paintera.control.paint;
+
+import java.lang.invoke.MethodHandles;
+import java.util.stream.IntStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import gnu.trove.list.array.TDoubleArrayList;
+import gnu.trove.list.array.TLongArrayList;
+import net.imglib2.Point;
+import net.imglib2.RandomAccess;
+import net.imglib2.RealLocalizable;
+import net.imglib2.RealPoint;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.BooleanType;
+import net.imglib2.type.numeric.IntegerType;
+
+public class FloodFillTransformedPlane
+{
+
+	private static final Logger LOG = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
+
+	private static final double[] D_X_LOCAL = { 1.0, 0.0, 0.0 };
+
+	private static final double[] D_Y_LOCAL = { 0.0, 1.0, 0.0 };
+
+	private static final double[] D_Z_LOCAL = { 0.0, 0.0, 1.0 };
+
+	private final AffineTransform3D localToWorld;
+
+	private final double minX;
+
+	private final double minY;
+
+	private final double maxX;
+
+	private final double maxY;
+
+	private final double zRangePos;
+
+	private final double zRangeNeg;
+
+	private final double dxx;
+
+	private final double dxy;
+
+	private final double dxz;
+
+	private final double dyx;
+
+	private final double dyy;
+
+	private final double dyz;
+
+	private final double dzx;
+
+	private final double dzy;
+
+	private final double dzz;
+
+	public static void fill(
+			final AffineTransform3D localToWorld,
+			final double zRange,
+			final RandomAccess< ? extends BooleanType< ? > > relevantBackgroundAccess,
+			final RandomAccess< ? extends IntegerType< ? > > localAccess,
+			final RealLocalizable seedWorld,
+			final long fillLabel )
+	{
+		new FloodFillTransformedPlane( localToWorld, zRange ).fill( relevantBackgroundAccess, localAccess, seedWorld, fillLabel );
+	}
+
+	public static void fill(
+			final AffineTransform3D localToWorld,
+			final double[] min,
+			final double[] max,
+			final double zRangePos,
+			final double zRangeNeg,
+			final RandomAccess< ? extends BooleanType< ? > > relevantBackgroundAccess,
+			final RandomAccess< ? extends IntegerType< ? > > localAccess,
+			final RealLocalizable seedWorld,
+			final long fillLabel )
+	{
+		new FloodFillTransformedPlane( localToWorld, min[ 0 ], min[ 1 ], max[ 0 ], max[ 1 ], zRangePos, zRangeNeg ).fill( relevantBackgroundAccess, localAccess, seedWorld, fillLabel );
+	}
+
+	// maxX, maxY, zRange in world coordinates
+	public FloodFillTransformedPlane(
+			final AffineTransform3D localToWorld,
+			final double zRange )
+	{
+		this( localToWorld, Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, +zRange, -zRange );
+	}
+
+	// maxX, maxY, zRange in world coordinates
+	public FloodFillTransformedPlane(
+			final AffineTransform3D localToWorld,
+			final double minX,
+			final double minY,
+			final double maxX,
+			final double maxY,
+			final double zRange )
+	{
+		this( localToWorld, minX, minY, maxX, maxY, +zRange, -zRange );
+	}
+
+	// maxX, maxY, zRange in world coordinates
+	public FloodFillTransformedPlane(
+			final AffineTransform3D localToWorld,
+			final double minX,
+			final double minY,
+			final double maxX,
+			final double maxY,
+			final double zRangePos,
+			final double zRangeNeg )
+	{
+		super();
+		this.minX = minX;
+		this.minY = minY;
+		this.maxX = maxX;
+		this.maxY = maxY;
+		this.localToWorld = localToWorld;
+		this.zRangePos = zRangePos;
+		this.zRangeNeg = zRangeNeg;
+
+		final double[] dx = D_X_LOCAL.clone();
+		final double[] dy = D_Y_LOCAL.clone();
+		final double[] dz = D_Z_LOCAL.clone();
+
+		final AffineTransform3D transformNoTranslation = this.localToWorld.copy();
+		transformNoTranslation.setTranslation( 0.0, 0.0, 0.0 );
+		transformNoTranslation.apply( dx, dx );
+		transformNoTranslation.apply( dy, dy );
+		transformNoTranslation.apply( dz, dz );
+
+		this.dxx = dx[ 0 ];
+		this.dxy = dx[ 1 ];
+		this.dxz = dx[ 2 ];
+
+		this.dyx = dy[ 0 ];
+		this.dyy = dy[ 1 ];
+		this.dyz = dy[ 2 ];
+
+		this.dzx = dz[ 0 ];
+		this.dzy = dz[ 1 ];
+		this.dzz = dz[ 2 ];
+
+	}
+
+	public void fill(
+			final RandomAccess< ? extends BooleanType< ? > > relevantBackgroundAccess,
+			final RandomAccess< ? extends IntegerType< ? > > maskAccess,
+			final RealLocalizable seedWorld,
+			final long fillLabel )
+	{
+		final double[] pos = IntStream.range( 0, 3 ).mapToDouble( seedWorld::getDoublePosition ).toArray();
+
+		final RealPoint seedLocal = new RealPoint( seedWorld );
+		localToWorld.applyInverse( seedLocal, seedLocal );
+
+		final TLongArrayList sourceCoordinates = new TLongArrayList();
+		final TDoubleArrayList worldCoordinates = new TDoubleArrayList();
+
+		final double zMinInclusive = seedWorld.getDoublePosition( 2 ) + zRangeNeg;
+		final double zMaxInclusive = seedWorld.getDoublePosition( 2 ) + zRangePos;
+
+		for ( int d = 0; d < 3; ++d )
+		{
+			sourceCoordinates.add( Math.round( seedLocal.getDoublePosition( d ) ) );
+			worldCoordinates.add( pos[ d ] );
+		}
+
+		relevantBackgroundAccess.setPosition( sourceCoordinates.get( 0 ), 0 );
+		relevantBackgroundAccess.setPosition( sourceCoordinates.get( 1 ), 1 );
+		relevantBackgroundAccess.setPosition( sourceCoordinates.get( 2 ), 2 );
+
+		if ( !relevantBackgroundAccess.get().get() )
+		{
+			LOG.warn( "Started at invalid position {}: {} -- not doing anything", new Point( relevantBackgroundAccess ), relevantBackgroundAccess.get() );
+			return;
+		}
+
+		for ( int offset = 0; offset < sourceCoordinates.size(); offset += 3 )
+		{
+			final int o0 = offset + 0;
+			final int o1 = offset + 1;
+			final int o2 = offset + 2;
+			final long lx = sourceCoordinates.get( o0 );
+			final long ly = sourceCoordinates.get( o1 );
+			final long lz = sourceCoordinates.get( o2 );
+			relevantBackgroundAccess.setPosition( lx, 0 );
+			relevantBackgroundAccess.setPosition( ly, 1 );
+			relevantBackgroundAccess.setPosition( lz, 2 );
+			maskAccess.setPosition( lx, 0 );
+			maskAccess.setPosition( ly, 1 );
+			maskAccess.setPosition( lz, 2 );
+
+			final IntegerType< ? > val = maskAccess.get();
+
+			if ( val.getIntegerLong() == fillLabel )
+			{
+				continue;
+			}
+			val.setInteger( fillLabel );
+
+			final double x = worldCoordinates.get( o0 );
+			final double y = worldCoordinates.get( o1 );
+			final double z = worldCoordinates.get( o2 );
+
+			maskAccess.fwd( 0 );
+			relevantBackgroundAccess.fwd( 0 );
+			addIfInside(
+					!relevantBackgroundAccess.get().get(),
+					fillLabel,
+					maskAccess.get().getIntegerLong(),
+					sourceCoordinates,
+					worldCoordinates,
+					lx + 1, ly, lz,
+					x + dxx, y + dxy, z + dxz,
+					zMinInclusive, zMaxInclusive );
+
+			maskAccess.move( -2l, 0 );
+			relevantBackgroundAccess.move( -2l, 0 );
+			addIfInside(
+					!relevantBackgroundAccess.get().get(),
+					fillLabel,
+					maskAccess.get().getIntegerLong(),
+					sourceCoordinates,
+					worldCoordinates,
+					lx - 1, ly, lz,
+					x - dxx, y - dxy, z - dxz,
+					zMinInclusive, zMaxInclusive );
+			maskAccess.fwd( 0 );
+			relevantBackgroundAccess.fwd( 0 );
+
+			maskAccess.fwd( 1 );
+			relevantBackgroundAccess.fwd( 1 );
+			addIfInside(
+					!relevantBackgroundAccess.get().get(),
+					fillLabel,
+					maskAccess.get().getIntegerLong(),
+					sourceCoordinates,
+					worldCoordinates,
+					lx, ly + 1, lz,
+					x + dyx, y + dyy, z + dyz,
+					zMinInclusive, zMaxInclusive );
+
+			maskAccess.move( -2l, 1 );
+			relevantBackgroundAccess.move( -2l, 1 );
+			addIfInside(
+					!relevantBackgroundAccess.get().get(),
+					fillLabel,
+					maskAccess.get().getIntegerLong(),
+					sourceCoordinates,
+					worldCoordinates,
+					lx, ly - 1, lz,
+					x - dyx, y - dyy, z - dyz,
+					zMinInclusive, zMaxInclusive );
+			maskAccess.fwd( 1 );
+			relevantBackgroundAccess.fwd( 1 );
+
+			maskAccess.fwd( 2 );
+			relevantBackgroundAccess.fwd( 2 );
+			addIfInside(
+					!relevantBackgroundAccess.get().get(),
+					fillLabel,
+					maskAccess.get().getIntegerLong(),
+					sourceCoordinates,
+					worldCoordinates,
+					lx, ly, lz + 1,
+					x + dzx, y + dzy, z + dzz,
+					zMinInclusive, zMaxInclusive );
+
+			maskAccess.move( -2l, 2 );
+			relevantBackgroundAccess.move( -2l, 2 );
+			addIfInside(
+					!relevantBackgroundAccess.get().get(),
+					fillLabel,
+					maskAccess.get().getIntegerLong(),
+					sourceCoordinates,
+					worldCoordinates,
+					lx, ly, lz - 1,
+					x - dzx, y - dzy, z - dzz,
+					zMinInclusive, zMaxInclusive );
+			maskAccess.fwd( 2 );
+			relevantBackgroundAccess.fwd( 2 );
+
+		}
+	}
+
+	private void addIfInside(
+			final boolean isRelevant,
+			final long fillLabel,
+			final long pixelLabel,
+			final TLongArrayList labelCoordinates,
+			final TDoubleArrayList worldCoordinates,
+			final long lx,
+			final long ly,
+			final long lz,
+			final double wx,
+			final double wy,
+			final double wz,
+			final double zMinInclusive,
+			final double zMaxInclusive )
+	{
+		if ( isRelevant && fillLabel != pixelLabel && wz >= zMinInclusive && wz <= zMaxInclusive )
+		{
+			if ( wx > minX && wx < maxX && wy > minY && wy < maxY )
+			{
+				labelCoordinates.add( lx );
+				labelCoordinates.add( ly );
+				labelCoordinates.add( lz );
+
+				worldCoordinates.add( wx );
+				worldCoordinates.add( wy );
+				worldCoordinates.add( wz );
+			}
+		}
+	}
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFillTransformedPlane.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFillTransformedPlane.java
@@ -210,7 +210,7 @@ public class FloodFillTransformedPlane
 			maskAccess.fwd( 0 );
 			relevantBackgroundAccess.fwd( 0 );
 			addIfInside(
-					!relevantBackgroundAccess.get().get(),
+					relevantBackgroundAccess.get().get(),
 					fillLabel,
 					maskAccess.get().getIntegerLong(),
 					sourceCoordinates,
@@ -222,7 +222,7 @@ public class FloodFillTransformedPlane
 			maskAccess.move( -2l, 0 );
 			relevantBackgroundAccess.move( -2l, 0 );
 			addIfInside(
-					!relevantBackgroundAccess.get().get(),
+					relevantBackgroundAccess.get().get(),
 					fillLabel,
 					maskAccess.get().getIntegerLong(),
 					sourceCoordinates,
@@ -236,7 +236,7 @@ public class FloodFillTransformedPlane
 			maskAccess.fwd( 1 );
 			relevantBackgroundAccess.fwd( 1 );
 			addIfInside(
-					!relevantBackgroundAccess.get().get(),
+					relevantBackgroundAccess.get().get(),
 					fillLabel,
 					maskAccess.get().getIntegerLong(),
 					sourceCoordinates,
@@ -248,7 +248,7 @@ public class FloodFillTransformedPlane
 			maskAccess.move( -2l, 1 );
 			relevantBackgroundAccess.move( -2l, 1 );
 			addIfInside(
-					!relevantBackgroundAccess.get().get(),
+					relevantBackgroundAccess.get().get(),
 					fillLabel,
 					maskAccess.get().getIntegerLong(),
 					sourceCoordinates,
@@ -262,7 +262,7 @@ public class FloodFillTransformedPlane
 			maskAccess.fwd( 2 );
 			relevantBackgroundAccess.fwd( 2 );
 			addIfInside(
-					!relevantBackgroundAccess.get().get(),
+					relevantBackgroundAccess.get().get(),
 					fillLabel,
 					maskAccess.get().getIntegerLong(),
 					sourceCoordinates,
@@ -274,7 +274,7 @@ public class FloodFillTransformedPlane
 			maskAccess.move( -2l, 2 );
 			relevantBackgroundAccess.move( -2l, 2 );
 			addIfInside(
-					!relevantBackgroundAccess.get().get(),
+					relevantBackgroundAccess.get().get(),
 					fillLabel,
 					maskAccess.get().getIntegerLong(),
 					sourceCoordinates,

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/Paint2D.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/Paint2D.java
@@ -43,7 +43,7 @@ public class Paint2D
 		// get maximum extent of pixels along z
 		final double[] projections = PaintUtils.maximumVoxelDiagonalLengthPerDimension( labelToGlobalTransformWithoutTranslation, globalToViewerTransform );
 
-		final double factor = 0.5 * brushDepth;
+		final double factor = 0.5 + brushDepth - 1;
 		final double xRange = factor * projections[ 0 ];
 		final double yRange = factor * projections[ 1 ];
 		final double zRange = factor * projections[ 2 ];

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/Paint2D.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/Paint2D.java
@@ -268,20 +268,12 @@ public class Paint2D
 		viewerTransformWithoutTranslation.setTranslation( 0.0, 0.0, 0.0 );
 
 		// get maximum extent of pixels along z
-		final double[] unitX = { 1.0, 0.0, 0.0 };
-		final double[] unitY = { 0.0, 1.0, 0.0 };
-		final double[] unitZ = { 0.0, 0.0, 1.0 };
-		labelToGlobalTransformWithoutTranslation.apply( unitX, unitX );
-		labelToGlobalTransformWithoutTranslation.apply( unitY, unitY );
-		labelToGlobalTransformWithoutTranslation.apply( unitZ, unitZ );
-		viewerTransformWithoutTranslation.apply( unitX, unitX );
-		viewerTransformWithoutTranslation.apply( unitY, unitY );
-		viewerTransformWithoutTranslation.apply( unitZ, unitZ );
-		LOG.debug( "Transformed unit vectors x={} y={} z={}", unitX, unitY, unitZ );
+		final double[] projections = PaintUtils.maximumVoxelDiagonalLengthPerDimension( labelToGlobalTransformWithoutTranslation, globalToViewerTransform );
+
 		final double factor = 0.5;
-		final double xRange = factor * ( Math.abs( unitX[ 0 ] ) + Math.abs( unitY[ 0 ] ) + Math.abs( unitZ[ 0 ] ) );
-		final double yRange = factor * ( Math.abs( unitX[ 1 ] ) + Math.abs( unitY[ 1 ] ) + Math.abs( unitZ[ 1 ] ) );
-		final double zRange = factor * ( Math.abs( unitX[ 2 ] ) + Math.abs( unitY[ 2 ] ) + Math.abs( unitZ[ 2 ] ) );
+		final double xRange = factor * projections[ 0 ];
+		final double yRange = factor * projections[ 1 ];
+		final double zRange = factor * projections[ 2 ];
 		LOG.debug( "range is {}", zRange );
 
 		final double radius = this.brushRadius.get();

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/Paint2D.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/Paint2D.java
@@ -29,6 +29,7 @@ public class Paint2D
 			final double x,
 			final double y,
 			final double radius,
+			final double brushDepth,
 			final AffineTransform3D labelToViewerTransform,
 			final AffineTransform3D globalToViewerTransform,
 			final AffineTransform3D labelToGlobalTransform )
@@ -42,7 +43,7 @@ public class Paint2D
 		// get maximum extent of pixels along z
 		final double[] projections = PaintUtils.maximumVoxelDiagonalLengthPerDimension( labelToGlobalTransformWithoutTranslation, globalToViewerTransform );
 
-		final double factor = 0.5;
+		final double factor = 0.5 * brushDepth;
 		final double xRange = factor * projections[ 0 ];
 		final double yRange = factor * projections[ 1 ];
 		final double zRange = factor * projections[ 2 ];

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/Paint2D.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/Paint2D.java
@@ -43,15 +43,15 @@ public class Paint2D
 		// get maximum extent of pixels along z
 		final double[] projections = PaintUtils.maximumVoxelDiagonalLengthPerDimension( labelToGlobalTransformWithoutTranslation, globalToViewerTransform );
 
-		final double factor = 0.5 + brushDepth - 1;
+		final double factor = 0.5;
 		final double xRange = factor * projections[ 0 ];
 		final double yRange = factor * projections[ 1 ];
-		final double zRange = factor * projections[ 2 ];
+		final double zRange = ( factor + brushDepth - 1 ) * projections[ 2 ];
 		LOG.debug( "range is {}", zRange );
 
 		final double viewerRadius = Affine3DHelpers.extractScale( globalToViewerTransform, 0 ) * radius;
-		final double radiusX = Math.max( xRange, yRange ) + viewerRadius;
-		final double radiusY = Math.max( xRange, yRange ) + viewerRadius;
+		final double radiusX = xRange + viewerRadius;
+		final double radiusY = yRange + viewerRadius;
 		final double[] fillMin = { x - viewerRadius, y - viewerRadius, -zRange };
 		final double[] fillMax = { x + viewerRadius, y + viewerRadius, +zRange };
 		labelToViewerTransform.applyInverse( fillMin, fillMin );

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/Paint2D.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/Paint2D.java
@@ -2,266 +2,38 @@ package org.janelia.saalfeldlab.paintera.control.paint;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
-import java.util.Optional;
-import java.util.concurrent.ExecutorService;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
 
-import org.janelia.saalfeldlab.fx.event.MouseDragFX;
-import org.janelia.saalfeldlab.paintera.data.DataSource;
-import org.janelia.saalfeldlab.paintera.data.mask.MaskInUse;
-import org.janelia.saalfeldlab.paintera.data.mask.MaskInfo;
-import org.janelia.saalfeldlab.paintera.data.mask.MaskedSource;
-import org.janelia.saalfeldlab.paintera.state.GlobalTransformManager;
-import org.janelia.saalfeldlab.paintera.state.SourceInfo;
-import org.janelia.saalfeldlab.paintera.state.SourceState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import bdv.fx.viewer.ViewerPanelFX;
-import bdv.fx.viewer.ViewerState;
 import bdv.util.Affine3DHelpers;
-import bdv.viewer.Source;
-import javafx.beans.property.DoubleProperty;
-import javafx.beans.property.SimpleDoubleProperty;
-import javafx.beans.property.SimpleObjectProperty;
-import javafx.scene.input.MouseEvent;
 import net.imglib2.FinalInterval;
 import net.imglib2.FinalRealInterval;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccess;
-import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RandomAccessible;
 import net.imglib2.RealPoint;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.type.numeric.integer.UnsignedLongType;
 import net.imglib2.util.AccessBoxRandomAccessibleOnGet;
 import net.imglib2.util.Intervals;
-import net.imglib2.util.LinAlgHelpers;
-import net.imglib2.view.ExtendedRandomAccessibleInterval;
-import net.imglib2.view.Views;
 
 public class Paint2D
 {
 
 	private static Logger LOG = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
 
-	private static final class ForegroundCheck implements Predicate< UnsignedLongType >
+	public static Interval paint(
+			final RandomAccessible< UnsignedLongType > labels,
+			final long fillLabel,
+			final double x,
+			final double y,
+			final double radius,
+			final AffineTransform3D labelToViewerTransform,
+			final AffineTransform3D globalToViewerTransform,
+			final AffineTransform3D labelToGlobalTransform )
 	{
 
-		@Override
-		public boolean test( final UnsignedLongType t )
-		{
-			return t.getIntegerLong() > 0;
-		}
-
-	}
-
-	private static final ForegroundCheck FOREGROUND_CHECK = new ForegroundCheck();
-
-	private final ViewerPanelFX viewer;
-
-	private final SourceInfo sourceInfo;
-
-	private final BrushOverlay brushOverlay;
-
-	private final SimpleDoubleProperty brushRadius = new SimpleDoubleProperty( 5.0 );
-
-	private final SimpleDoubleProperty brushRadiusIncrement = new SimpleDoubleProperty( 1.0 );
-
-	private final AffineTransform3D labelToViewerTransform = new AffineTransform3D();
-
-	private final AffineTransform3D labelToGlobalTransform = new AffineTransform3D();
-
-	private final AffineTransform3D globalToViewerTransform = new AffineTransform3D();
-
-	private final SimpleObjectProperty< MaskedSource< ?, ? > > maskedSource = new SimpleObjectProperty<>();
-
-	private final SimpleObjectProperty< RandomAccessibleInterval< UnsignedLongType > > canvas = new SimpleObjectProperty<>();
-
-	private final SimpleObjectProperty< Interval > interval = new SimpleObjectProperty<>();
-
-	private final Runnable repaintRequest;
-
-	private final ExecutorService paintQueue;
-
-	private int fillLabel;
-
-	public Paint2D(
-			final ViewerPanelFX viewer,
-			final SourceInfo sourceInfo,
-			final GlobalTransformManager manager,
-			final Runnable repaintRequest,
-			final ExecutorService paintQueue )
-	{
-		super();
-		this.viewer = viewer;
-		this.sourceInfo = sourceInfo;
-		this.brushOverlay = new BrushOverlay( this.viewer, manager );
-		this.brushOverlay.physicalRadiusProperty().bind( brushRadius );
-		this.repaintRequest = repaintRequest;
-		this.paintQueue = paintQueue;
-	}
-
-	public void hideBrushOverlay()
-	{
-		setBrushOverlayVisible( false );
-	}
-
-	public void showBrushOverlay()
-	{
-		setBrushOverlayVisible( true );
-	}
-
-	public void setBrushOverlayVisible( final boolean visible )
-	{
-		this.brushOverlay.setVisible( visible );
-		viewer.getDisplay().drawOverlays();
-	}
-
-	public void changeBrushRadius( final double sign )
-	{
-		if ( sign > 0 )
-		{
-			decreaseBrushRadius();
-		}
-		else if ( sign < 0 )
-		{
-			increaseBrushRadius();
-		}
-	}
-
-	public void decreaseBrushRadius()
-	{
-		setBrushRadius( brushRadius.get() - brushRadiusIncrement.get() );
-	}
-
-	public void increaseBrushRadius()
-	{
-		setBrushRadius( brushRadius.get() + brushRadiusIncrement.get() );
-	}
-
-	public void setBrushRadius( final double radius )
-	{
-		if ( radius > 0 && radius < Math.min( viewer.getWidth(), viewer.getHeight() ) )
-		{
-			this.brushRadius.set( radius );
-		}
-	}
-
-	public MouseDragFX dragPaintLabel( final String name, final Supplier< Long > id, final Predicate< MouseEvent > eventFilter )
-	{
-		return new PaintDrag( name, eventFilter, true, this, id );
-	}
-
-	public void prepareAndPaint( final MouseEvent event, final Long id ) throws MaskInUse
-	{
-		prepareForPainting( id );
-		paintQueue.submit( () -> paint( event ) );
-		paintQueue.submit( () -> applyMask() );
-	}
-
-	public void prepareAndPaintUnchecked( final MouseEvent event, final Long id )
-	{
-		if ( id == null )
-		{
-			LOG.debug( "Id is nullpointer: {}", id );
-			return;
-		}
-		try
-		{
-			prepareAndPaint( event, id );
-		}
-		catch ( final MaskInUse e )
-		{
-			throw new RuntimeException( e );
-		}
-	}
-
-	public void paint( final MouseEvent event )
-	{
-		paint( event, true );
-	}
-
-	private void paint( final MouseEvent event, final boolean consume )
-	{
-		paint( event.getX(), event.getY() );
-		if ( consume )
-		{
-			event.consume();
-		}
-		repaintRequest.run();
-//		applyMask();
-
-	}
-
-	private void prepareForPainting( final Long id ) throws MaskInUse
-	{
-		if ( id == null )
-		{
-			LOG.debug( "Do not a valid id to paint: {} -- will not paint.", id );
-			return;
-		}
-		final ViewerState state = viewer.getState();
-		final Source< ? > viewerSource = sourceInfo.currentSourceProperty().get();
-		final int currentSource = sourceInfo.currentSourceIndexInVisibleSources().get();
-		this.canvas.set( null );
-		this.maskedSource.set( null );
-		this.interval.set( null );
-
-		LOG.debug( "Prepare for painting with source {}", viewerSource );
-
-		if ( viewerSource == null || !( viewerSource instanceof DataSource< ?, ? > ) || !sourceInfo.getState( viewerSource ).isVisibleProperty().get() ) { return; }
-
-		final SourceState< ?, ? > currentSourceState = sourceInfo.getState( viewerSource );
-		final DataSource< ?, ? > source = currentSourceState.getDataSource();
-
-		if ( !( source instanceof MaskedSource< ?, ? > ) ) { return; }
-
-		final MaskedSource< ?, ? > maskedSource = ( MaskedSource< ?, ? > ) source;
-
-		final AffineTransform3D viewerTransform = new AffineTransform3D();
-		state.getViewerTransform( viewerTransform );
-		final AffineTransform3D screenScaleTransform = new AffineTransform3D();
-		final int level = state.getBestMipMapLevel( screenScaleTransform, currentSource );
-		maskedSource.getSourceTransform( 0, level, labelToGlobalTransform );
-		this.labelToViewerTransform.set( viewerTransform.copy().concatenate( labelToGlobalTransform ) );
-		this.globalToViewerTransform.set( viewerTransform );
-
-		final UnsignedLongType value = new UnsignedLongType( id );
-
-		final MaskInfo< UnsignedLongType > mask = new MaskInfo<>( 0, level, value );
-		final RandomAccessibleInterval< UnsignedLongType > canvas = maskedSource.generateMask( mask, FOREGROUND_CHECK );
-		// canvasSource.getDataSource( state.getCurrentTimepoint(), level );
-		LOG.debug( "Setting canvas to {}", canvas );
-		this.canvas.set( canvas );
-		this.maskedSource.set( maskedSource );
-		this.fillLabel = 1;
-	}
-
-//	private void paint( final double x, final double y )
-//	{
-//
-//		setCoordinates( x, y, labelToGlobalTransform );
-//		paint( this.labelLocation, x, y );
-//
-//	}
-
-	private void paint( final double viewerX, final double viewerY )
-	{
-		paint( viewerX, viewerY, 0, 0 );
-	}
-
-	private void paint( final double viewerX, final double viewerY, final double shiftX, final double shiftY )
-	{
-
-//		LOG.warn( "At {} {}", viewerX, viewerY );
-
-		final RandomAccessibleInterval< UnsignedLongType > labels = this.canvas.get();
-		if ( labels == null ) { return; }
-
-		final AffineTransform3D labelToViewerTransform = this.labelToViewerTransform;
-		final AffineTransform3D globalToViewerTransform = this.globalToViewerTransform;
-		final AffineTransform3D labelToGlobalTransform = this.labelToGlobalTransform;
 		final AffineTransform3D labelToGlobalTransformWithoutTranslation = labelToGlobalTransform.copy();
 		final AffineTransform3D viewerTransformWithoutTranslation = globalToViewerTransform.copy();
 		labelToGlobalTransformWithoutTranslation.setTranslation( 0.0, 0.0, 0.0 );
@@ -276,12 +48,11 @@ public class Paint2D
 		final double zRange = factor * projections[ 2 ];
 		LOG.debug( "range is {}", zRange );
 
-		final double radius = this.brushRadius.get();
 		final double viewerRadius = Affine3DHelpers.extractScale( globalToViewerTransform, 0 ) * radius;
 		final double radiusX = Math.max( xRange, yRange ) + viewerRadius;
 		final double radiusY = Math.max( xRange, yRange ) + viewerRadius;
-		final double[] fillMin = { viewerX - viewerRadius, viewerY - viewerRadius, -zRange };
-		final double[] fillMax = { viewerX + viewerRadius, viewerY + viewerRadius, +zRange };
+		final double[] fillMin = { x - viewerRadius, y - viewerRadius, -zRange };
+		final double[] fillMax = { x + viewerRadius, y + viewerRadius, +zRange };
 		labelToViewerTransform.applyInverse( fillMin, fillMin );
 		labelToViewerTransform.applyInverse( fillMax, fillMax );
 		final double[] transformedFillMin = new double[ 3 ];
@@ -291,116 +62,17 @@ public class Paint2D
 
 		// containingInterval might be too small
 		final Interval conatiningInterval = Intervals.smallestContainingInterval( new FinalRealInterval( transformedFillMin, transformedFillMax ) );
-		final ExtendedRandomAccessibleInterval< UnsignedLongType, RandomAccessibleInterval< UnsignedLongType > > extendedLabels = Views.extendValue( labels, new UnsignedLongType( fillLabel ) );
-		final AccessBoxRandomAccessibleOnGet< UnsignedLongType > accessTracker = new AccessBoxRandomAccessibleOnGet<>( extendedLabels );
+		final AccessBoxRandomAccessibleOnGet< UnsignedLongType > accessTracker = labels instanceof AccessBoxRandomAccessibleOnGet< ? >
+				? ( AccessBoxRandomAccessibleOnGet< UnsignedLongType > ) labels
+				: new AccessBoxRandomAccessibleOnGet<>( labels );
 		accessTracker.initAccessBox();
 		final RandomAccess< UnsignedLongType > access = accessTracker.randomAccess( conatiningInterval );
-		final RealPoint seed = new RealPoint( viewerX, viewerY, 0.0 );
+		final RealPoint seed = new RealPoint( x, y, 0.0 );
 
 		FloodFillTransformedCylinder3D.fill( labelToViewerTransform, radiusX, radiusY, zRange, access, seed, fillLabel );
 
 		final FinalInterval trackedInterval = new FinalInterval( accessTracker.getMin(), accessTracker.getMax() );
-		this.interval.set( Intervals.union( trackedInterval, Optional.ofNullable( this.interval.get() ).orElse( trackedInterval ) ) );
-		++this.fillLabel;
-
-	}
-
-	private class PaintDrag extends MouseDragFX
-	{
-
-		private final Supplier< Long > id;
-
-		public PaintDrag(
-				final String name,
-				final Predicate< MouseEvent > eventFilter,
-				final boolean consume,
-				final Object transformLock,
-				final Supplier< Long > id )
-		{
-			super( name, eventFilter, consume, transformLock, false );
-			this.id = id;
-		}
-
-		@Override
-		public void initDrag( final MouseEvent event )
-		{
-			try
-			{
-				prepareForPainting( id.get() );
-			}
-			catch ( final MaskInUse e )
-			{
-				LOG.info( "{} -- will not paint.", e.getMessage() );
-				return;
-			}
-			paintQueue.submit( () -> paint( event, consume ) );
-		}
-
-		@Override
-		public void drag( final MouseEvent event )
-		{
-			// TODO we assume that no changes to current source or viewer/global
-			// transform can happen during this drag.
-			final double x = event.getX();
-			final double y = event.getY();
-
-			if ( x != startX || y != startY )
-			{
-				final double[] p1 = new double[] { startX, startY };
-
-//			LOG.warn( "Drag: paint at screen=({},{}) / start=({},{})", x, y, startX, startY );
-
-				final double[] d = new double[] { x, y };
-
-				LinAlgHelpers.subtract( d, p1, d );
-
-				final double l = LinAlgHelpers.length( d );
-				LinAlgHelpers.normalize( d );
-
-				final double radius = brushOverlay.viewerRadiusProperty().get();
-				final double shiftX = d[ 0 ] * radius;
-				final double shiftY = d[ 1 ] * radius;
-
-				LOG.debug( "Number of paintings triggered {}", l + 1 );
-				paintQueue.submit( () -> {
-
-					final long t0 = System.currentTimeMillis();
-					for ( int i = 0; i < l; ++i )
-					{
-						paint( p1[ 0 ], p1[ 1 ], shiftX, shiftY );
-						LinAlgHelpers.add( p1, d, p1 );
-					}
-					paint( x, y, shiftX, shiftY );
-					final long t1 = System.currentTimeMillis();
-					LOG.debug( "Painting {} times with radius {} took a total of {}ms", l + 1, brushRadius.get(), t1 - t0 );
-					repaintRequest.run();
-				} );
-			}
-			startX = x;
-			startY = y;
-		}
-
-		@Override
-		public void endDrag( final MouseEvent event )
-		{
-			paintQueue.submit( () -> applyMask() );
-		}
-
-	}
-
-	public DoubleProperty brushRadiusProperty()
-	{
-		return this.brushRadius;
-	}
-
-	public DoubleProperty brushRadiusIncrementProperty()
-	{
-		return this.brushRadiusIncrement;
-	}
-
-	private void applyMask()
-	{
-		Optional.ofNullable( maskedSource.get() ).ifPresent( ms -> ms.applyMask( canvas.get(), interval.get(), FOREGROUND_CHECK ) );
+		return trackedInterval;
 	}
 
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/Paint2D.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/Paint2D.java
@@ -370,7 +370,7 @@ public class Paint2D
 						paint( p1[ 0 ], p1[ 1 ], shiftX, shiftY );
 						LinAlgHelpers.add( p1, d, p1 );
 					}
-//					paint( x, y, shiftX, shiftY );
+					paint( x, y, shiftX, shiftY );
 					final long t1 = System.currentTimeMillis();
 					LOG.debug( "Painting {} times with radius {} took a total of {}ms", l + 1, brushRadius.get(), t1 - t0 );
 					repaintRequest.run();

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/PaintActions2D.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/PaintActions2D.java
@@ -1,0 +1,366 @@
+package org.janelia.saalfeldlab.paintera.control.paint;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import org.janelia.saalfeldlab.fx.event.EventFX;
+import org.janelia.saalfeldlab.fx.event.MouseDragFX;
+import org.janelia.saalfeldlab.paintera.data.DataSource;
+import org.janelia.saalfeldlab.paintera.data.mask.MaskInUse;
+import org.janelia.saalfeldlab.paintera.data.mask.MaskInfo;
+import org.janelia.saalfeldlab.paintera.data.mask.MaskedSource;
+import org.janelia.saalfeldlab.paintera.state.GlobalTransformManager;
+import org.janelia.saalfeldlab.paintera.state.SourceInfo;
+import org.janelia.saalfeldlab.paintera.state.SourceState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import bdv.fx.viewer.ViewerPanelFX;
+import bdv.fx.viewer.ViewerState;
+import bdv.viewer.Source;
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.SimpleDoubleProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.scene.input.MouseEvent;
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.label.Label;
+import net.imglib2.type.numeric.integer.UnsignedLongType;
+import net.imglib2.util.Intervals;
+import net.imglib2.util.LinAlgHelpers;
+import net.imglib2.view.Views;
+
+public class PaintActions2D
+{
+
+	private static Logger LOG = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
+
+	private static final class ForegroundCheck implements Predicate< UnsignedLongType >
+	{
+
+		@Override
+		public boolean test( final UnsignedLongType t )
+		{
+			return t.getIntegerLong() > 0;
+		}
+
+	}
+
+	private class PaintEventHandler
+	{
+
+		protected final AffineTransform3D labelToViewerTransform = new AffineTransform3D();
+
+		protected final AffineTransform3D labelToGlobalTransform = new AffineTransform3D();
+
+		protected final AffineTransform3D globalToViewerTransform = new AffineTransform3D();
+
+		protected final SimpleObjectProperty< MaskedSource< ?, ? > > maskedSource = new SimpleObjectProperty<>();
+
+		protected final SimpleObjectProperty< RandomAccessibleInterval< UnsignedLongType > > canvas = new SimpleObjectProperty<>();
+
+		protected final SimpleObjectProperty< Interval > interval = new SimpleObjectProperty<>();
+
+		private int fillLabel = 1;
+
+		public void prepareForPainting( final Long id ) throws MaskInUse
+		{
+			if ( id == null )
+			{
+				LOG.debug( "Do not a valid id to paint: {} -- will not paint.", id );
+				return;
+			}
+			final ViewerState state = viewer.getState();
+			final Source< ? > viewerSource = sourceInfo.currentSourceProperty().get();
+			final int currentSource = sourceInfo.currentSourceIndexInVisibleSources().get();
+			this.canvas.set( null );
+			this.maskedSource.set( null );
+			this.interval.set( null );
+
+			LOG.debug( "Prepare for painting with source {}", viewerSource );
+
+			if ( viewerSource == null || !( viewerSource instanceof DataSource< ?, ? > ) || !sourceInfo.getState( viewerSource ).isVisibleProperty().get() ) { return; }
+
+			final SourceState< ?, ? > currentSourceState = sourceInfo.getState( viewerSource );
+			final DataSource< ?, ? > source = currentSourceState.getDataSource();
+
+			if ( !( source instanceof MaskedSource< ?, ? > ) ) { return; }
+
+			final MaskedSource< ?, ? > maskedSource = ( MaskedSource< ?, ? > ) source;
+
+			final AffineTransform3D viewerTransform = new AffineTransform3D();
+			state.getViewerTransform( viewerTransform );
+			final AffineTransform3D screenScaleTransform = new AffineTransform3D();
+			final int level = state.getBestMipMapLevel( screenScaleTransform, currentSource );
+			maskedSource.getSourceTransform( 0, level, labelToGlobalTransform );
+			this.labelToViewerTransform.set( viewerTransform.copy().concatenate( labelToGlobalTransform ) );
+			this.globalToViewerTransform.set( viewerTransform );
+
+			final UnsignedLongType value = new UnsignedLongType( id );
+
+			final MaskInfo< UnsignedLongType > mask = new MaskInfo<>( 0, level, value );
+			final RandomAccessibleInterval< UnsignedLongType > canvas = maskedSource.generateMask( mask, FOREGROUND_CHECK );
+			// canvasSource.getDataSource( state.getCurrentTimepoint(), level );
+			LOG.debug( "Setting canvas to {}", canvas );
+			this.canvas.set( canvas );
+			this.maskedSource.set( maskedSource );
+			this.fillLabel = 1;
+		}
+
+		public void paint( final double viewerX, final double viewerY )
+		{
+
+//		LOG.warn( "At {} {}", viewerX, viewerY );
+
+			final RandomAccessibleInterval< UnsignedLongType > labels = this.canvas.get();
+			if ( labels == null ) { return; }
+			final Interval trackedInterval = Paint2D.paint(
+					Views.extendValue( labels, new UnsignedLongType( Label.INVALID ) ),
+					fillLabel,
+					viewerX,
+					viewerY,
+					brushRadius.get(),
+					brushDepth.get(),
+					labelToViewerTransform,
+					globalToViewerTransform,
+					labelToGlobalTransform );
+			this.interval.set( Intervals.union( trackedInterval, Optional.ofNullable( this.interval.get() ).orElse( trackedInterval ) ) );
+			++this.fillLabel;
+			repaintRequest.run();
+
+		}
+
+		public void applyMask()
+		{
+			Optional.ofNullable( maskedSource.get() ).ifPresent( ms -> ms.applyMask( canvas.get(), interval.get(), FOREGROUND_CHECK ) );
+		}
+
+	}
+
+	private static final ForegroundCheck FOREGROUND_CHECK = new ForegroundCheck();
+
+	protected final ViewerPanelFX viewer;
+
+	protected final SourceInfo sourceInfo;
+
+	protected final BrushOverlay brushOverlay;
+
+	protected final SimpleDoubleProperty brushRadius = new SimpleDoubleProperty( 5.0 );
+
+	protected final SimpleDoubleProperty brushRadiusIncrement = new SimpleDoubleProperty( 1.0 );
+
+	protected final SimpleDoubleProperty brushDepth = new SimpleDoubleProperty( 1.0 );
+
+	private final Runnable repaintRequest;
+
+	private final ExecutorService paintQueue;
+
+	public PaintActions2D(
+			final ViewerPanelFX viewer,
+			final SourceInfo sourceInfo,
+			final GlobalTransformManager manager,
+			final Runnable repaintRequest,
+			final ExecutorService paintQueue )
+	{
+		super();
+		this.viewer = viewer;
+		this.sourceInfo = sourceInfo;
+		this.brushOverlay = new BrushOverlay( this.viewer, manager );
+		this.brushOverlay.physicalRadiusProperty().bind( brushRadius );
+		this.brushOverlay.brushDepthProperty().bind( brushDepth );
+		this.repaintRequest = repaintRequest;
+		this.paintQueue = paintQueue;
+	}
+
+	public void hideBrushOverlay()
+	{
+		setBrushOverlayVisible( false );
+	}
+
+	public void showBrushOverlay()
+	{
+		setBrushOverlayVisible( true );
+	}
+
+	public void setBrushOverlayVisible( final boolean visible )
+	{
+		this.brushOverlay.setVisible( visible );
+		viewer.getDisplay().drawOverlays();
+	}
+
+	public void changeBrushRadius( final double sign )
+	{
+		if ( sign > 0 )
+		{
+			decreaseBrushRadius();
+		}
+		else if ( sign < 0 )
+		{
+			increaseBrushRadius();
+		}
+	}
+
+	public void changeBrushDepth( final double sign )
+	{
+		final double newDepth = brushDepth.get() + ( sign > 0 ? -1 : 1 );
+		this.brushDepth.set( Math.max( Math.min( newDepth, 2.0 ), 1.0 ) );
+	}
+
+	public void decreaseBrushRadius()
+	{
+		setBrushRadius( brushRadius.get() - brushRadiusIncrement.get() );
+	}
+
+	public void increaseBrushRadius()
+	{
+		setBrushRadius( brushRadius.get() + brushRadiusIncrement.get() );
+	}
+
+	public void setBrushRadius( final double radius )
+	{
+		if ( radius > 0 && radius < Math.min( viewer.getWidth(), viewer.getHeight() ) )
+		{
+			this.brushRadius.set( radius );
+		}
+	}
+
+	public MouseDragFX dragPaintLabel( final String name, final Supplier< Long > id, final Predicate< MouseEvent > eventFilter )
+	{
+		return new PaintDrag( name, eventFilter, true, this, id );
+	}
+
+	public EventFX< MouseEvent > clickPaintLabel( final String name, final Supplier< Long > id, final Predicate< MouseEvent > eventFilter )
+	{
+		return EventFX.MOUSE_PRESSED( name, e -> new PaintClick( id ).paint( e.getX(), e.getY() ), eventFilter );
+	}
+
+	private class PaintClick
+	{
+		private final PaintEventHandler handler = new PaintEventHandler();
+
+		private final Supplier< Long > id;
+
+		public PaintClick( final Supplier< Long > id )
+		{
+			super();
+			this.id = id;
+		}
+
+		public void paint( final double x, final double y )
+		{
+			try
+			{
+				handler.prepareForPainting( id.get() );
+				handler.paint( x, y );
+				handler.applyMask();
+			}
+			catch ( final MaskInUse e )
+			{
+				LOG.error( "Already painting into mask -- no action taken" );
+			}
+		}
+
+	}
+
+	private class PaintDrag extends MouseDragFX
+	{
+
+		PaintEventHandler handler = new PaintEventHandler();
+
+		private final Supplier< Long > id;
+
+		public PaintDrag(
+				final String name,
+				final Predicate< MouseEvent > eventFilter,
+				final boolean consume,
+				final Object transformLock,
+				final Supplier< Long > id )
+		{
+			super( name, eventFilter, consume, transformLock, false );
+			this.id = id;
+		}
+
+		@Override
+		public void initDrag( final MouseEvent event )
+		{
+			LOG.debug( "Init drag for {}", this.getClass().getSimpleName() );
+			event.consume();
+			try
+			{
+				handler.prepareForPainting( id.get() );
+			}
+			catch ( final MaskInUse e )
+			{
+				LOG.info( "{} -- will not paint.", e.getMessage() );
+				return;
+			}
+			paintQueue.submit( () -> handler.paint( event.getX(), event.getY() ) );
+		}
+
+		@Override
+		public void drag( final MouseEvent event )
+		{
+			// TODO we assume that no changes to current source or viewer/global
+			// transform can happen during this drag.
+			final double x = event.getX();
+			final double y = event.getY();
+
+			if ( x != startX || y != startY )
+			{
+				final double[] p1 = new double[] { startX, startY };
+
+//			LOG.warn( "Drag: paint at screen=({},{}) / start=({},{})", x, y, startX, startY );
+
+				final double[] d = new double[] { x, y };
+
+				LinAlgHelpers.subtract( d, p1, d );
+
+				final double l = LinAlgHelpers.length( d );
+				LinAlgHelpers.normalize( d );
+
+				LOG.debug( "Number of paintings triggered {}", l + 1 );
+				paintQueue.submit( () -> {
+
+					final long t0 = System.currentTimeMillis();
+					for ( int i = 0; i < l; ++i )
+					{
+						handler.paint( p1[ 0 ], p1[ 1 ] );
+						LinAlgHelpers.add( p1, d, p1 );
+					}
+					handler.paint( x, y );
+					final long t1 = System.currentTimeMillis();
+					LOG.debug( "Painting {} times with radius {} took a total of {}ms", l + 1, brushRadius.get(), t1 - t0 );
+				} );
+			}
+			startX = x;
+			startY = y;
+		}
+
+		@Override
+		public void endDrag( final MouseEvent event )
+		{
+			paintQueue.submit( () -> handler.applyMask() );
+		}
+
+	}
+
+	public DoubleProperty brushRadiusProperty()
+	{
+		return this.brushRadius;
+	}
+
+	public DoubleProperty brushRadiusIncrementProperty()
+	{
+		return this.brushRadiusIncrement;
+	}
+
+	public DoubleProperty brushDepthProperty()
+	{
+		return this.brushDepth;
+	}
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/PaintActions2D.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/PaintActions2D.java
@@ -143,17 +143,17 @@ public class PaintActions2D
 
 	private static final ForegroundCheck FOREGROUND_CHECK = new ForegroundCheck();
 
-	protected final ViewerPanelFX viewer;
+	private final ViewerPanelFX viewer;
 
-	protected final SourceInfo sourceInfo;
+	private final SourceInfo sourceInfo;
 
-	protected final BrushOverlay brushOverlay;
+	private final BrushOverlay brushOverlay;
 
-	protected final SimpleDoubleProperty brushRadius = new SimpleDoubleProperty( 5.0 );
+	private final SimpleDoubleProperty brushRadius = new SimpleDoubleProperty( 5.0 );
 
-	protected final SimpleDoubleProperty brushRadiusIncrement = new SimpleDoubleProperty( 1.0 );
+	private final SimpleDoubleProperty brushRadiusIncrement = new SimpleDoubleProperty( 1.0 );
 
-	protected final SimpleDoubleProperty brushDepth = new SimpleDoubleProperty( 1.0 );
+	private final SimpleDoubleProperty brushDepth = new SimpleDoubleProperty( 1.0 );
 
 	private final Runnable repaintRequest;
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/PaintUtils.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/PaintUtils.java
@@ -6,11 +6,51 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.util.LinAlgHelpers;
 
 public class PaintUtils
 {
 
 	private static final Logger LOG = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
+
+	/**
+	 *
+	 * This should be equivalent to
+	 * {@link #maximumVoxelDiagonalLengthPerDimension(AffineTransform3D, AffineTransform3D)}.
+	 *
+	 * @param labelToGlobalTransform
+	 * @param viewerTransform
+	 * @return
+	 */
+	public static double[] labelUnitLengthAlongViewerAxis(
+			final AffineTransform3D labelToGlobalTransform,
+			final AffineTransform3D viewerTransform )
+	{
+		final double[] unitX = { 1.0, 0.0, 0.0 };
+		final double[] unitY = { 0.0, 1.0, 0.0 };
+		final double[] unitZ = { 0.0, 0.0, 1.0 };
+		final AffineTransform3D labelToGlobalTransformWithoutTranslation = duplicateWithoutTranslation( labelToGlobalTransform );
+		final AffineTransform3D viewerTransformWithoutTranslation = duplicateWithoutTranslation( viewerTransform );
+		final AffineTransform3D labelToViewerTransformWithoutTranslation = labelToGlobalTransformWithoutTranslation.preConcatenate( viewerTransformWithoutTranslation );
+		labelToViewerTransformWithoutTranslation.applyInverse( unitX, unitX );
+		labelToViewerTransformWithoutTranslation.applyInverse( unitY, unitY );
+		labelToViewerTransformWithoutTranslation.applyInverse( unitZ, unitZ );
+
+		LinAlgHelpers.normalize( unitX );
+		LinAlgHelpers.normalize( unitY );
+		LinAlgHelpers.normalize( unitZ );
+
+		labelToViewerTransformWithoutTranslation.apply( unitX, unitX );
+		labelToViewerTransformWithoutTranslation.apply( unitY, unitY );
+		labelToViewerTransformWithoutTranslation.apply( unitZ, unitZ );
+
+		return new double[] {
+				unitX[ 0 ],
+				unitY[ 1 ],
+				unitZ[ 2 ]
+		};
+
+	}
 
 	public static double[] maximumVoxelDiagonalLengthPerDimension(
 			final AffineTransform3D labelToGlobalTransform,

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/PaintUtils.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/PaintUtils.java
@@ -1,0 +1,52 @@
+package org.janelia.saalfeldlab.paintera.control.paint;
+
+import java.lang.invoke.MethodHandles;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.imglib2.realtransform.AffineTransform3D;
+
+public class PaintUtils
+{
+
+	private static final Logger LOG = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
+
+	public static double[] maximumVoxelDiagonalLengthPerDimension(
+			final AffineTransform3D labelToGlobalTransform,
+			final AffineTransform3D viewerTransform )
+	{
+		final double[] unitX = { 1.0, 0.0, 0.0 };
+		final double[] unitY = { 0.0, 1.0, 0.0 };
+		final double[] unitZ = { 0.0, 0.0, 1.0 };
+		final AffineTransform3D labelToGlobalTransformWithoutTranslation = duplicateWithoutTranslation( labelToGlobalTransform );
+		final AffineTransform3D viewerTransformWithoutTranslation = duplicateWithoutTranslation( viewerTransform );
+		labelToGlobalTransformWithoutTranslation.apply( unitX, unitX );
+		labelToGlobalTransformWithoutTranslation.apply( unitY, unitY );
+		labelToGlobalTransformWithoutTranslation.apply( unitZ, unitZ );
+		viewerTransformWithoutTranslation.apply( unitX, unitX );
+		viewerTransformWithoutTranslation.apply( unitY, unitY );
+		viewerTransformWithoutTranslation.apply( unitZ, unitZ );
+		LOG.debug( "Transformed unit vectors x={} y={} z={}", unitX, unitY, unitZ );
+		final double[] projections = new double[] {
+				( Math.abs( unitX[ 0 ] ) + Math.abs( unitY[ 0 ] ) + Math.abs( unitZ[ 0 ] ) ),
+				( Math.abs( unitX[ 1 ] ) + Math.abs( unitY[ 1 ] ) + Math.abs( unitZ[ 1 ] ) ),
+				( Math.abs( unitX[ 2 ] ) + Math.abs( unitY[ 2 ] ) + Math.abs( unitZ[ 2 ] ) )
+		};
+		LOG.debug( "Projections={}", projections );
+		return projections;
+	}
+
+	public static AffineTransform3D duplicateWithoutTranslation( final AffineTransform3D transform )
+	{
+		final AffineTransform3D duplicate = transform.copy();
+		removeTranslation( duplicate );
+		return duplicate;
+	}
+
+	public static void removeTranslation( final AffineTransform3D transform )
+	{
+		transform.setTranslation( 0.0, 0.0, 0.0 );
+	}
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/RestrictPainting.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/RestrictPainting.java
@@ -196,6 +196,7 @@ public class RestrictPainting
 
 		final RandomAccessible< Pair< T, UnsignedLongType > > paired = Views.pair( Views.extendBorder( background ), Views.extendValue( canvas, new UnsignedLongType( Label.INVALID ) ) );
 
+		restrictTo( paired, accessTracker, seed, new DiamondShape( 1 ), bg -> bg.valueEquals( backgroundSeed ), cv -> cv.valueEquals( paintedLabel ) );
 		restrictTo( paired, accessTracker, seed, new DiamondShape( 1 ), bg -> bg.equals( backgroundSeed ), cv -> cv.equals( paintedLabel ) );
 
 		requestRepaint.run();

--- a/src/main/java/org/janelia/saalfeldlab/paintera/data/mask/MaskedSource.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/data/mask/MaskedSource.java
@@ -12,6 +12,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
@@ -74,9 +75,7 @@ import net.imglib2.type.label.Label;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.logic.BoolType;
 import net.imglib2.type.numeric.IntegerType;
-import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.type.numeric.integer.UnsignedLongType;
-import net.imglib2.type.volatiles.VolatileUnsignedByteType;
 import net.imglib2.type.volatiles.VolatileUnsignedLongType;
 import net.imglib2.util.AccessedBlocksRandomAccessible;
 import net.imglib2.util.ConstantUtils;
@@ -100,7 +99,7 @@ public class MaskedSource< D extends Type< D >, T extends Type< T > > implements
 
 	private final RandomAccessibleInterval< VolatileUnsignedLongType >[] canvases;
 
-	private final HashMap< RandomAccessibleInterval< UnsignedByteType >, MaskInfo< UnsignedLongType > > masks;
+	private final HashMap< RandomAccessibleInterval< UnsignedLongType >, MaskInfo< UnsignedLongType > > masks;
 
 	private final RandomAccessible< UnsignedLongType >[] dMasks;
 
@@ -224,12 +223,12 @@ public class MaskedSource< D extends Type< D >, T extends Type< T > > implements
 
 	}
 
-	public RandomAccessibleInterval< UnsignedByteType > generateMask( final int t, final int level, final UnsignedLongType value ) throws MaskInUse
+	public RandomAccessibleInterval< UnsignedLongType > generateMask( final int t, final int level, final UnsignedLongType value, final Predicate< UnsignedLongType > isPaintedForeground ) throws MaskInUse
 	{
-		return generateMask( new MaskInfo<>( t, level, value ) );
+		return generateMask( new MaskInfo<>( t, level, value ), isPaintedForeground );
 	}
 
-	public RandomAccessibleInterval< UnsignedByteType > generateMask( final MaskInfo< UnsignedLongType > mask ) throws MaskInUse
+	public RandomAccessibleInterval< UnsignedLongType > generateMask( final MaskInfo< UnsignedLongType > mask, final Predicate< UnsignedLongType > isPaintedForeground ) throws MaskInUse
 	{
 
 		synchronized ( this )
@@ -248,14 +247,14 @@ public class MaskedSource< D extends Type< D >, T extends Type< T > > implements
 				.cacheDirectory( null )
 				.deleteCacheDirectoryOnExit( true )
 				.volatileAccesses( true )
-				.dirtyAccesses( true )
+				.dirtyAccesses( false )
 				.cellDimensions( this.blockSizes[ mask.level ] );
 
-		final CachedCellImg< UnsignedByteType, ? > store = new DiskCachedCellImgFactory<>( new UnsignedByteType(), maskOpts )
+		final CachedCellImg< UnsignedLongType, ? > store = new DiskCachedCellImgFactory<>( new UnsignedLongType(), maskOpts )
 				.create( source.getSource( 0, mask.level ) );
-		final RandomAccessibleInterval< VolatileUnsignedByteType > vstore = VolatileViews.wrapAsVolatile( store );
+		final RandomAccessibleInterval< VolatileUnsignedLongType > vstore = VolatileViews.wrapAsVolatile( store );
 		final UnsignedLongType INVALID = new UnsignedLongType( Label.INVALID );
-		this.dMasks[ mask.level ] = Converters.convert( Views.extendZero( store ), ( input, output ) -> output.set( input.get() > 0 ? mask.value : INVALID ), new UnsignedLongType() );
+		this.dMasks[ mask.level ] = Converters.convert( Views.extendZero( store ), ( input, output ) -> output.set( isPaintedForeground.test( input ) ? mask.value : INVALID ), new UnsignedLongType() );
 		this.tMasks[ mask.level ] = Converters.convert( Views.extendZero( vstore ), ( input, output ) -> {
 			final boolean isValid = input.isValid();
 			output.setValid( isValid );
@@ -276,12 +275,12 @@ public class MaskedSource< D extends Type< D >, T extends Type< T > > implements
 				this.tMasks[ level ] = RealViews.affine( tMaskInterpolated, scale3D.inverse() );
 			}
 		}
-		final AccessedBlocksRandomAccessible< UnsignedByteType > trackingStore = new AccessedBlocksRandomAccessible<>( store, store.getCellGrid() );
+		final AccessedBlocksRandomAccessible< UnsignedLongType > trackingStore = new AccessedBlocksRandomAccessible<>( store, store.getCellGrid() );
 		this.masks.put( trackingStore, mask );
 		return trackingStore;
 	}
 
-	public void applyMask( final RandomAccessibleInterval< UnsignedByteType > mask, final Interval paintedInterval )
+	public void applyMask( final RandomAccessibleInterval< UnsignedLongType > mask, final Interval paintedInterval, final Predicate< UnsignedLongType > acceptAsPainted )
 	{
 		new Thread( () -> {
 			synchronized ( this )
@@ -303,7 +302,7 @@ public class MaskedSource< D extends Type< D >, T extends Type< T > > implements
 
 				paintAffectedPixels(
 						affectedBlocks,
-						Converters.convert( Views.extendZero( mask ), ( s, t ) -> t.set( s.get() > 0 ), new BitType() ),
+						Converters.convert( Views.extendZero( mask ), ( s, t ) -> t.set( acceptAsPainted.test( s ) ), new BitType() ),
 						canvas,
 						maskInfo.value,
 						canvas.getCellGrid(),
@@ -325,7 +324,8 @@ public class MaskedSource< D extends Type< D >, T extends Type< T > > implements
 							affectedBlocks,
 							maskInfo.level,
 							maskInfo.value,
-							paintedInterval );
+							paintedInterval,
+							acceptAsPainted );
 					setMasksConstant();
 				} );
 
@@ -684,11 +684,12 @@ public class MaskedSource< D extends Type< D >, T extends Type< T > > implements
 	}
 
 	private void propagateMask(
-			final RandomAccessibleInterval< UnsignedByteType > mask,
+			final RandomAccessibleInterval< UnsignedLongType > mask,
 			final TLongSet paintedBlocksAtPaintedScale,
 			final int paintedLevel,
 			final UnsignedLongType label,
-			final Interval intervalAtPaintedScale )
+			final Interval intervalAtPaintedScale,
+			final Predicate< UnsignedLongType > isPaintedForeground )
 	{
 
 		for ( int level = paintedLevel + 1; level < getNumMipmapLevels(); ++level )
@@ -721,7 +722,7 @@ public class MaskedSource< D extends Type< D >, T extends Type< T > > implements
 					intervalAtHigherLevel );
 		}
 
-		final RealRandomAccessible< UnsignedByteType > interpolatedMask = Views.interpolate( Views.extendZero( mask ), new NearestNeighborInterpolatorFactory<>() );
+		final RealRandomAccessible< UnsignedLongType > interpolatedMask = Views.interpolate( Views.extendZero( mask ), new NearestNeighborInterpolatorFactory<>() );
 
 		for ( int level = paintedLevel - 1; level >= 0; --level )
 		{
@@ -745,7 +746,7 @@ public class MaskedSource< D extends Type< D >, T extends Type< T > > implements
 			final long[] minPainted = new long[ minTarget.length ];
 			final long[] maxPainted = new long[ minTarget.length ];
 			final Scale3D scaleTransform = new Scale3D( currentRelativeScaleFromTargetToPainted );
-			final RealRandomAccessible< UnsignedByteType > scaledMask = RealViews.transformReal( interpolatedMask, scaleTransform );
+			final RealRandomAccessible< UnsignedLongType > scaledMask = RealViews.transformReal( interpolatedMask, scaleTransform );
 			for ( final TLongIterator blockIterator = affectedBlocksAtLowerLevel.iterator(); blockIterator.hasNext(); )
 			{
 				final long blockId = blockIterator.next();
@@ -780,7 +781,7 @@ public class MaskedSource< D extends Type< D >, T extends Type< T > > implements
 							Intervals.maxAsLongArray( mask ) );
 
 					final IntervalView< BoolType > relevantBlockAtPaintedResolution = Views.interval(
-							Converters.convert( mask, ( s, t ) -> t.set( s.get() > 0 ), new BoolType() ),
+							Converters.convert( mask, ( s, t ) -> t.set( isPaintedForeground.test( s ) ), new BoolType() ),
 							minPainted,
 							maxPainted );
 
@@ -792,11 +793,11 @@ public class MaskedSource< D extends Type< D >, T extends Type< T > > implements
 					LOG.debug( "Upsampling for level {} and intersected intervals ({} {})", level, intersectionMin, intersectionMax );
 					final Interval interval = new FinalInterval( intersectionMin, intersectionMax );
 					final Cursor< UnsignedLongType > canvasCursor = Views.flatIterable( Views.interval( canvasAtTargetLevel, interval ) ).cursor();
-					final Cursor< UnsignedByteType > maskCursor = Views.flatIterable( Views.interval( Views.raster( scaledMask ), interval ) ).cursor();
+					final Cursor< UnsignedLongType > maskCursor = Views.flatIterable( Views.interval( Views.raster( scaledMask ), interval ) ).cursor();
 					while ( maskCursor.hasNext() )
 					{
 						canvasCursor.fwd();
-						final boolean wasPainted = maskCursor.next().get() > 0;
+						final boolean wasPainted = isPaintedForeground.test( maskCursor.next() );
 						if ( wasPainted )
 						{
 							canvasCursor.get().set( label );

--- a/src/main/java/org/janelia/saalfeldlab/paintera/data/mask/MaskedSource.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/data/mask/MaskedSource.java
@@ -255,13 +255,13 @@ public class MaskedSource< D extends Type< D >, T extends Type< T > > implements
 				.create( source.getSource( 0, mask.level ) );
 		final RandomAccessibleInterval< VolatileUnsignedByteType > vstore = VolatileViews.wrapAsVolatile( store );
 		final UnsignedLongType INVALID = new UnsignedLongType( Label.INVALID );
-		this.dMasks[ mask.level ] = Converters.convert( Views.extendZero( store ), ( input, output ) -> output.set( input.get() == 1 ? mask.value : INVALID ), new UnsignedLongType() );
+		this.dMasks[ mask.level ] = Converters.convert( Views.extendZero( store ), ( input, output ) -> output.set( input.get() > 0 ? mask.value : INVALID ), new UnsignedLongType() );
 		this.tMasks[ mask.level ] = Converters.convert( Views.extendZero( vstore ), ( input, output ) -> {
 			final boolean isValid = input.isValid();
 			output.setValid( isValid );
 			if ( isValid )
 			{
-				output.get().set( input.get().get() == 1 ? mask.value : INVALID );
+				output.get().set( input.get().get() > 0 ? mask.value : INVALID );
 			}
 		}, new VolatileUnsignedLongType() );
 		final RealRandomAccessible< UnsignedLongType > dMaskInterpolated = Views.interpolate( this.dMasks[ mask.level ], new NearestNeighborInterpolatorFactory<>() );
@@ -303,7 +303,7 @@ public class MaskedSource< D extends Type< D >, T extends Type< T > > implements
 
 				paintAffectedPixels(
 						affectedBlocks,
-						Converters.convert( Views.extendZero( mask ), ( s, t ) -> t.set( s.get() == 1 ), new BitType() ),
+						Converters.convert( Views.extendZero( mask ), ( s, t ) -> t.set( s.get() > 0 ), new BitType() ),
 						canvas,
 						maskInfo.value,
 						canvas.getCellGrid(),
@@ -796,7 +796,7 @@ public class MaskedSource< D extends Type< D >, T extends Type< T > > implements
 					while ( maskCursor.hasNext() )
 					{
 						canvasCursor.fwd();
-						final boolean wasPainted = maskCursor.next().get() == 1;
+						final boolean wasPainted = maskCursor.next().get() > 0;
 						if ( wasPainted )
 						{
 							canvasCursor.get().set( label );


### PR DESCRIPTION
Use special case implementation of flood fill to avoid touching too many pixels. This requires that we increment the mask foreground indicator for a mask with each paint action, starting at `1`. Mask type is therefore changed to `UnsignedLongType` to give a lot of room for foregorund indicators.

Minor feature additions and fixes included.

Fixes #104 
Fixes #100 
Fixes #106