### PR TITLE
Fix shift scroll issues

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/ControlUtils.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/ControlUtils.java
@@ -1,0 +1,22 @@
+package org.janelia.saalfeldlab.paintera.control;
+
+import javafx.scene.input.ScrollEvent;
+
+public class ControlUtils {
+
+	/**
+	 *
+	 * @param e event
+	 * @return {@code e.getDeltaX()} if {@code e.getDeltaX() > e.getDeltaY()}, {@code e.getDeltaY()} otherwise.
+	 */
+	public static double getBiggestScroll(ScrollEvent e)
+	{
+		return getArgMaxWithRespectToAbs(e.getDeltaX(), e.getDeltaY());
+	}
+
+	private static double getArgMaxWithRespectToAbs(double v1, double v2)
+	{
+		return Math.abs(Math.abs(v1)) > Math.abs(v2) ? v1 : v2;
+	}
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/Navigation.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/Navigation.java
@@ -219,7 +219,7 @@ public class Navigation implements ToOnEnterOnExit
 				final Zoom zoom = new Zoom(zoomSpeed::get, manager, viewerTransform, manager);
 				iars.add(EventFX.SCROLL(
 						"zoom",
-						event -> zoom.zoomCenteredAt(-event.getDeltaY(), event.getX(), event.getY()),
+						event -> zoom.zoomCenteredAt(Math.abs(event.getDeltaY()) > Math.abs(event.getDeltaX()) ? -event.getDeltaY() : -event.getDeltaX(), event.getX(), event.getY()),
 						event -> keyTracker.areOnlyTheseKeysDown(KeyCode.META) ||
 								keyTracker.areOnlyTheseKeysDown(KeyCode.CONTROL, KeyCode.SHIFT)
 				                       ));

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/Navigation.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/Navigation.java
@@ -159,17 +159,17 @@ public class Navigation implements ToOnEnterOnExit
 
 				iars.add(EventFX.SCROLL(
 						"translate along normal",
-						e -> scrollDefault.scroll(-e.getDeltaY()),
+						e -> scrollDefault.scroll(-ControlUtils.getBiggestScroll(e)),
 						event -> keyTracker.noKeysActive()
 				                       ));
 				iars.add(EventFX.SCROLL(
 						"translate along normal fast",
-						e -> scrollFast.scroll(-e.getDeltaY()),
+						e -> scrollFast.scroll(-ControlUtils.getBiggestScroll(e)),
 						event -> keyTracker.areOnlyTheseKeysDown(KeyCode.SHIFT)
 				                       ));
 				iars.add(EventFX.SCROLL(
 						"translate along normal slow",
-						e -> scrollSlow.scroll(-e.getDeltaY()),
+						e -> scrollSlow.scroll(-ControlUtils.getBiggestScroll(e)),
 						event -> keyTracker.areOnlyTheseKeysDown(KeyCode.CONTROL)
 				                       ));
 
@@ -219,7 +219,7 @@ public class Navigation implements ToOnEnterOnExit
 				final Zoom zoom = new Zoom(zoomSpeed::get, manager, viewerTransform, manager);
 				iars.add(EventFX.SCROLL(
 						"zoom",
-						event -> zoom.zoomCenteredAt(Math.abs(event.getDeltaY()) > Math.abs(event.getDeltaX()) ? -event.getDeltaY() : -event.getDeltaX(), event.getX(), event.getY()),
+						event -> zoom.zoomCenteredAt(-ControlUtils.getBiggestScroll(event), event.getX(), event.getY()),
 						event -> keyTracker.areOnlyTheseKeysDown(KeyCode.META) ||
 								keyTracker.areOnlyTheseKeysDown(KeyCode.CONTROL, KeyCode.SHIFT)
 				                       ));

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/Paint.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/Paint.java
@@ -152,7 +152,7 @@ public class Paint implements ToOnEnterOnExit
 					                       ));
 					iars.add(EventFX.SCROLL(
 							"change brush depth",
-							event -> paint2D.changeBrushDepth(event.getDeltaY()),
+							event -> paint2D.changeBrushDepth(Math.abs(event.getDeltaY()) > Math.abs(event.getDeltaX()) ? -event.getDeltaY() : -event.getDeltaX()),
 							event -> keyTracker.areOnlyTheseKeysDown(
 									KeyCode.SPACE,
 									KeyCode.SHIFT

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/Paint.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/Paint.java
@@ -152,7 +152,7 @@ public class Paint implements ToOnEnterOnExit
 					                       ));
 					iars.add(EventFX.SCROLL(
 							"change brush depth",
-							event -> paint2D.changeBrushDepth(Math.abs(event.getDeltaY()) > Math.abs(event.getDeltaX()) ? -event.getDeltaY() : -event.getDeltaX()),
+							event -> paint2D.changeBrushDepth(-ControlUtils.getBiggestScroll(event)),
 							event -> keyTracker.areOnlyTheseKeysDown(
 									KeyCode.SPACE,
 									KeyCode.SHIFT

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/navigation/Zoom.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/navigation/Zoom.java
@@ -34,6 +34,12 @@ public class Zoom
 
 	public void zoomCenteredAt(final double delta, final double x, final double y)
 	{
+
+		if (delta == 0.0)
+		{
+			return;
+		}
+
 		final AffineTransform3D global = new AffineTransform3D();
 		synchronized (lock)
 		{


### PR DESCRIPTION
OpenJFX 11 and Oracle's JFX treat `shift scroll` as horizontal scroll, breaking zoom out and brush depth. For any scroll control, use the scroll direction that has the largest absolute value.

https://twitter.com/hanslovsky/status/1050485945940791303
https://bugs.openjdk.java.net/browse/JDK-8179102