### PR TITLE
Priority executor service

### DIFF
--- a/src/main/java/bdv/fx/viewer/PriorityExecutorService.java
+++ b/src/main/java/bdv/fx/viewer/PriorityExecutorService.java
@@ -1,0 +1,131 @@
+package bdv.fx.viewer;
+
+import org.janelia.saalfeldlab.util.MakeUnchecked;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class PriorityExecutorService {
+
+	private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+	public static double DEFAULT_PRIORITY = 0.0;
+
+	interface TaskWithPriority extends Comparable<TaskWithPriority>, Runnable
+	{
+		double priority();
+
+		default boolean isValid()
+		{
+			return true;
+		}
+
+		default void cancel()
+		{
+
+		}
+
+		@Override
+		default int compareTo(@NotNull final TaskWithPriority that)
+		{
+			return Double.compare(that.priority(), this.priority());
+		}
+	}
+
+	public static class WrapAsTask implements TaskWithPriority
+	{
+
+		private final double priority;
+
+		private final Runnable r;
+
+		public WrapAsTask(final Runnable r, final double priority) {
+			this.r = r;
+			this.priority = priority;
+		}
+
+		@Override
+		public void run() {
+			r.run();
+		}
+
+		@Override
+		public double priority() {
+			return this.priority;
+		}
+	}
+
+	private final PriorityBlockingQueue<TaskWithPriority> queue = new PriorityBlockingQueue<>();
+
+	private final ExecutorService es;
+
+	public PriorityExecutorService(final ExecutorService es)
+	{
+		this.es = es;
+		Thread managerThread = new Thread(() -> {
+			while (!es.isShutdown() && !es.isTerminated()) {
+				TaskWithPriority nextTask = null;
+				try {
+					synchronized (this.queue) {
+						nextTask = queue.take();
+					}
+				} catch (InterruptedException ignored) {
+
+				}
+				if (nextTask != null) {
+					if (nextTask.isValid())
+						es.submit(nextTask);
+					else
+						nextTask.cancel();
+				}
+			}
+		});
+		managerThread.setDaemon(true);
+		managerThread.start();
+	}
+
+
+	public void submit(final TaskWithPriority task)
+	{
+		LOG.trace("Submmiting task {}", task);
+		this.queue.add(task);
+	}
+
+	public void submit(Runnable r, double priority)
+	{
+		this.submit(new WrapAsTask(r, priority));
+	}
+
+	public void submit(Runnable r)
+	{
+		this.submit(r, DEFAULT_PRIORITY);
+	}
+
+	public void shutdown()
+	{
+		this.es.shutdown();
+	}
+
+	public static void main(String[] args) throws InterruptedException {
+		Runnable t1 = MakeUnchecked.runnable(() -> {Thread.sleep(50); System.out.println("t1");});
+		Runnable t2 = MakeUnchecked.runnable(() -> {Thread.sleep(50); System.out.println("t2");});
+		Runnable t3 = MakeUnchecked.runnable(() -> {Thread.sleep(50); System.out.println("t3");});
+		Runnable t4 = MakeUnchecked.runnable(() -> {Thread.sleep(50); System.out.println("t4");});
+		final PriorityExecutorService es = new PriorityExecutorService(Executors.newFixedThreadPool(1));
+		es.submit(t1, 5.0);
+		es.submit(t2, 3.0);
+		es.submit(t3, 3.1);
+		es.submit(t4, 5.0);
+		System.out.println("123");
+		Thread.sleep(1000);
+	}
+
+}

--- a/src/main/java/bdv/fx/viewer/PriorityExecutorService.java
+++ b/src/main/java/bdv/fx/viewer/PriorityExecutorService.java
@@ -28,8 +28,7 @@ public class PriorityExecutorService {
 			return true;
 		}
 
-		default void cancel()
-		{
+		default void cancel() {
 
 		}
 
@@ -47,9 +46,18 @@ public class PriorityExecutorService {
 
 		private final Runnable r;
 
-		public WrapAsTask(final Runnable r, final double priority) {
+		private boolean isValid;
+
+		public WrapAsTask(
+				final Runnable r,
+				final double priority) {
 			this.r = r;
 			this.priority = priority;
+			this.isValid = true;
+		}
+
+		public void invalidate() {
+			this.isValid = false;
 		}
 
 		@Override
@@ -60,6 +68,11 @@ public class PriorityExecutorService {
 		@Override
 		public double priority() {
 			return this.priority;
+		}
+
+		@Override
+		public boolean isValid() {
+			return this.isValid;
 		}
 	}
 

--- a/src/main/java/bdv/fx/viewer/PriorityThreadPoolExecutor.java
+++ b/src/main/java/bdv/fx/viewer/PriorityThreadPoolExecutor.java
@@ -1,0 +1,91 @@
+package bdv.fx.viewer;
+
+import org.janelia.saalfeldlab.util.MakeUnchecked;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class PriorityThreadPoolExecutor {
+
+	interface TaskWithPriority<T> extends Comparable<TaskWithPriority>, Runnable
+	{
+		double priority();
+
+		@Override
+		default int compareTo(@NotNull final TaskWithPriority that)
+		{
+			return Double.compare(that.priority(), this.priority());
+		}
+	}
+
+	public static class WrapAsTask implements TaskWithPriority
+	{
+
+		private final double priority;
+
+		private final Runnable r;
+
+		public WrapAsTask(final Runnable r, final double priority) {
+			this.r = r;
+			this.priority = priority;
+		}
+
+		@Override
+		public void run() {
+			r.run();
+		}
+
+		@Override
+		public double priority() {
+			return this.priority;
+		}
+
+		@Override
+		public int compareTo(@NotNull Object o) {
+			return 0;
+		}
+	}
+
+	private final PriorityBlockingQueue<Runnable> queue = new PriorityBlockingQueue<>();
+
+	private final ThreadPoolExecutor executor;
+
+	public PriorityThreadPoolExecutor(
+			final int corePoolSize,
+			final int maximumPoolSize,
+			final long keepAliveTime,
+			final TimeUnit unit,
+			final ThreadFactory factory
+			)
+	{
+		this.executor = new ThreadPoolExecutor(
+				corePoolSize,
+				maximumPoolSize,
+				keepAliveTime,
+				unit,
+				queue,
+				factory);
+	}
+
+	public void execute(final Runnable command, final double priority)
+	{
+		this.executor.execute(new WrapAsTask(command, priority));
+	}
+
+	public static void main(String[] args) {
+		Runnable t1 = MakeUnchecked.runnable(() -> {Thread.sleep(50); System.out.println("t1");});
+		Runnable t2 = MakeUnchecked.runnable(() -> {Thread.sleep(50); System.out.println("t2");});
+		Runnable t3 = MakeUnchecked.runnable(() -> {Thread.sleep(50); System.out.println("t3");});
+		Runnable t4 = MakeUnchecked.runnable(() -> {Thread.sleep(50); System.out.println("t4");});
+		final PriorityThreadPoolExecutor es = new PriorityThreadPoolExecutor(1, 1, 100_000, TimeUnit.MILLISECONDS, Thread::new);
+		es.execute(t1, 0.0);
+		es.execute(t2, 0.0);
+		es.execute(t3, 0.0);
+		es.execute(t4, 0.0);
+		System.out.println("123");
+	}
+
+}

--- a/src/main/java/bdv/fx/viewer/ViewerOptions.java
+++ b/src/main/java/bdv/fx/viewer/ViewerOptions.java
@@ -1,0 +1,335 @@
+/*
+ * #%L
+ * BigDataViewer core classes with minimal dependencies
+ * %%
+ * Copyright (C) 2012 - 2016 Tobias Pietzsch, Stephan Saalfeld, Stephan Preibisch,
+ * Jean-Yves Tinevez, HongKee Moon, Johannes Schindelin, Curtis Rueden, John Bogovic
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package bdv.fx.viewer;
+
+import bdv.BehaviourTransformEventHandler3D;
+import bdv.fx.viewer.project.AccumulateProjectorFactory;
+import bdv.viewer.ViewerPanel;
+import bdv.viewer.animate.MessageOverlayAnimator;
+import bdv.viewer.render.AccumulateProjector;
+import bdv.viewer.render.AccumulateProjectorARGB;
+import bdv.viewer.render.MultiResolutionRenderer;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.ui.TransformEventHandlerFactory;
+import org.scijava.ui.behaviour.KeyPressedManager;
+import org.scijava.ui.behaviour.io.InputTriggerConfig;
+
+import java.awt.event.KeyListener;
+
+/**
+ * Optional parameters for {@link ViewerPanel}.
+ *
+ * @author Tobias Pietzsch &lt;tobias.pietzsch@gmail.com&gt;
+ */
+public class ViewerOptions
+{
+	public final Values values = new Values();
+
+	/**
+	 * Create default {@link ViewerOptions}.
+	 * @return default {@link ViewerOptions}.
+	 */
+	public static ViewerOptions options()
+	{
+		return new ViewerOptions();
+	}
+
+	/**
+	 * Set width of {@link ViewerPanel} canvas.
+	 */
+	public ViewerOptions width(final int w )
+	{
+		values.width = w;
+		return this;
+	}
+
+	/**
+	 * Set height of {@link ViewerPanel} canvas.
+	 */
+	public ViewerOptions height(final int h )
+	{
+		values.height = h;
+		return this;
+	}
+
+	/**
+	 * Set the number and scale factors for scaled screen images.
+	 *
+	 * @param s
+	 *            Scale factors from the viewer canvas to screen images of
+	 *            different resolutions. A scale factor of 1 means 1 pixel in
+	 *            the screen image is displayed as 1 pixel on the canvas, a
+	 *            scale factor of 0.5 means 1 pixel in the screen image is
+	 *            displayed as 2 pixel on the canvas, etc.
+	 * @see MultiResolutionRenderer
+	 */
+	public ViewerOptions screenScales(final double[] s )
+	{
+		values.screenScales = s;
+		return this;
+	}
+
+	/**
+	 * Set target rendering time in nanoseconds.
+	 *
+	 * @param t
+	 *            Target rendering time in nanoseconds. The rendering time for
+	 *            the coarsest rendered scale should be below this threshold.
+	 * @see MultiResolutionRenderer
+	 */
+	public ViewerOptions targetRenderNanos(final long t )
+	{
+		values.targetRenderNanos = t;
+		return this;
+	}
+
+	/**
+	 * Set whether to used double buffered rendering.
+	 *
+	 * @param d
+	 *            Whether to use double buffered rendering.
+	 * @see MultiResolutionRenderer
+	 */
+	public ViewerOptions doubleBuffered(final boolean d )
+	{
+		values.doubleBuffered = d;
+		return this;
+	}
+
+	/**
+	 * Set how many threads to use for rendering.
+	 *
+	 * @param n
+	 *            How many threads to use for rendering.
+	 * @see MultiResolutionRenderer
+	 */
+	public ViewerOptions numRenderingThreads(final int n )
+	{
+		values.numRenderingThreads = n;
+		return this;
+	}
+
+	/**
+	 * Set how many source groups there are initially.
+	 *
+	 * @param n
+	 *            How many source groups to create initially.
+	 */
+	public ViewerOptions numSourceGroups(final int n )
+	{
+		values.numSourceGroups = n;
+		return this;
+	}
+
+	/**
+	 * Set whether volatile versions of sources should be used if available.
+	 *
+	 * @param v
+	 *            whether volatile versions of sources should be used if
+	 *            available.
+	 * @see MultiResolutionRenderer
+	 */
+	public ViewerOptions useVolatileIfAvailable(final boolean v )
+	{
+		values.useVolatileIfAvailable = v;
+		return this;
+	}
+
+	public ViewerOptions msgOverlay(final MessageOverlayAnimator o )
+	{
+		values.msgOverlay = o;
+		return this;
+	}
+
+	public ViewerOptions transformEventHandlerFactory(final TransformEventHandlerFactory< AffineTransform3D > f )
+	{
+		values.transformEventHandlerFactory = f;
+		return this;
+	}
+
+	/**
+	 * Set the factory for creating {@link AccumulateProjector}. This can be
+	 * used to customize how sources are combined.
+	 *
+	 * @param f
+	 *            factory for creating {@link AccumulateProjector}.
+	 * @see MultiResolutionRenderer
+	 */
+	public ViewerOptions accumulateProjectorFactory(final AccumulateProjectorFactory< ARGBType > f )
+	{
+		values.accumulateProjectorFactory = f;
+		return this;
+	}
+
+	/**
+	 * Set the {@link InputTriggerConfig} from which keyboard and mouse action mapping is loaded.
+	 *
+	 * @param c the {@link InputTriggerConfig} from which keyboard and mouse action mapping is loaded
+	 */
+	public ViewerOptions inputTriggerConfig(final InputTriggerConfig c )
+	{
+		values.inputTriggerConfig = c;
+		return this;
+	}
+
+	/**
+	 * Set the {@link KeyPressedManager} to share
+	 * {@link KeyListener#keyPressed(java.awt.event.KeyEvent)} events with other
+	 * ui-behaviour windows.
+	 * <p>
+	 * The goal is to make keyboard click/drag behaviours work like mouse
+	 * click/drag: When a behaviour is initiated with a key press, the window
+	 * under the mouse receives focus and the behaviour is handled there.
+	 * </p>
+	 *
+	 * @param manager
+	 * @return
+	 */
+	public ViewerOptions shareKeyPressedEvents(final KeyPressedManager manager )
+	{
+		values.keyPressedManager = manager;
+		return this;
+	}
+
+	/**
+	 * Read-only {@link ViewerOptions} values.
+	 */
+	public static class Values
+	{
+		private int width = 800;
+
+		private int height = 600;
+
+		private double[] screenScales = new double[] { 1, 0.75, 0.5, 0.25, 0.125 };
+
+		private long targetRenderNanos = 30 * 1000000l;
+
+		private boolean doubleBuffered = true;
+
+		private int numRenderingThreads = 3;
+
+		private int numSourceGroups = 10;
+
+		private boolean useVolatileIfAvailable = true;
+
+		private MessageOverlayAnimator msgOverlay = new MessageOverlayAnimator( 800 );
+
+		private TransformEventHandlerFactory< AffineTransform3D > transformEventHandlerFactory = BehaviourTransformEventHandler3D.factory();
+
+		private AccumulateProjectorFactory< ARGBType > accumulateProjectorFactory = null;
+
+		private InputTriggerConfig inputTriggerConfig = null;
+
+		private KeyPressedManager keyPressedManager = null;
+
+		public ViewerOptions optionsFromValues()
+		{
+			return new ViewerOptions().
+				width( width ).
+				height( height ).
+				screenScales( screenScales ).
+				targetRenderNanos( targetRenderNanos ).
+				doubleBuffered( doubleBuffered ).
+				numRenderingThreads( numRenderingThreads ).
+				numSourceGroups( numSourceGroups ).
+				useVolatileIfAvailable( useVolatileIfAvailable ).
+				msgOverlay( msgOverlay ).
+				transformEventHandlerFactory( transformEventHandlerFactory ).
+				accumulateProjectorFactory( accumulateProjectorFactory ).
+				inputTriggerConfig( inputTriggerConfig );
+		}
+
+		public int getWidth()
+		{
+			return width;
+		}
+
+		public int getHeight()
+		{
+			return height;
+		}
+
+		public double[] getScreenScales()
+		{
+			return screenScales;
+		}
+
+		public long getTargetRenderNanos()
+		{
+			return targetRenderNanos;
+		}
+
+		public boolean isDoubleBuffered()
+		{
+			return doubleBuffered;
+		}
+
+		public int getNumRenderingThreads()
+		{
+			return numRenderingThreads;
+		}
+
+		public int getNumSourceGroups()
+		{
+			return numSourceGroups;
+		}
+
+		public boolean isUseVolatileIfAvailable()
+		{
+			return useVolatileIfAvailable;
+		}
+
+		public MessageOverlayAnimator getMsgOverlay()
+		{
+			return msgOverlay;
+		}
+
+		public TransformEventHandlerFactory< AffineTransform3D > getTransformEventHandlerFactory()
+		{
+			return transformEventHandlerFactory;
+		}
+
+		public AccumulateProjectorFactory< ARGBType > getAccumulateProjectorFactory()
+		{
+			return accumulateProjectorFactory;
+		}
+
+		public InputTriggerConfig getInputTriggerConfig()
+		{
+			return inputTriggerConfig;
+		}
+
+		public KeyPressedManager getKeyPressedManager()
+		{
+			return keyPressedManager;
+		}
+	}
+}

--- a/src/main/java/bdv/fx/viewer/ViewerPanelFX.java
+++ b/src/main/java/bdv/fx/viewer/ViewerPanelFX.java
@@ -390,13 +390,17 @@ public class ViewerPanelFX
 	@Override
 	public void requestRepaint()
 	{
-		renderUnit.requestRepaint(iterateOverBlocksInOrder());
+		final int[] blocks = iterateOverBlocksInOrder();
+		for (int i = 0; i < blocks.length; ++i) {
+			renderUnit.requestRepaintSingleTile(blocks[i], PriorityExecutorService.DEFAULT_PRIORITY - i);
+		}
+//		renderUnit.requestRepaint(iterateOverBlocksInOrder(), PriorityExecutorService.DEFAULT_PRIORITY);
 	}
 
 
-	public void requestRepaint(final long[] min, final long[] max)
+	public void requestRepaint(final long[] min, final long[] max, final double priority)
 	{
-		renderUnit.requestRepaint(min, max);
+		renderUnit.requestRepaint(min, max, priority);
 	}
 
 	private int[] iterateOverBlocksInOrder()

--- a/src/main/java/bdv/fx/viewer/ViewerPanelFX.java
+++ b/src/main/java/bdv/fx/viewer/ViewerPanelFX.java
@@ -36,7 +36,6 @@ import bdv.viewer.Interpolation;
 import bdv.viewer.RequestRepaint;
 import bdv.viewer.Source;
 import bdv.viewer.SourceAndConverter;
-import bdv.viewer.ViewerOptions;
 import gnu.trove.list.array.TIntArrayList;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyBooleanProperty;
@@ -117,7 +116,7 @@ public class ViewerPanelFX
 	/**
 	 * The {@link ExecutorService} used for rendereing.
 	 */
-	protected final ExecutorService renderingExecutorService;
+	protected final PriorityExecutorService renderingExecutorService;
 
 	/**
 	 * These listeners will be notified about changes to the {@link #viewerTransform}. This is done <em>before</em>
@@ -207,7 +206,7 @@ public class ViewerPanelFX
 	{
 		super();
 		this.setCenter(this.center);
-		this.renderingExecutorService = Executors.newFixedThreadPool(optional.values.getNumRenderingThreads(), new RenderThreadFactory());
+		this.renderingExecutorService = new PriorityExecutorService(Executors.newFixedThreadPool(optional.values.getNumRenderingThreads(), new RenderThreadFactory()));
 		options = optional.values;
 
 		this.state = new ViewerState(axisOrder);

--- a/src/main/java/bdv/fx/viewer/project/AbstractInterruptibleProjector.java
+++ b/src/main/java/bdv/fx/viewer/project/AbstractInterruptibleProjector.java
@@ -1,0 +1,90 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package bdv.fx.viewer.project;
+
+import net.imglib2.AbstractInterval;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.converter.Converter;
+
+/**
+ * Abstract base implementation of a {@link InterruptibleProjector} mapping from
+ * some source to {@link RandomAccessibleInterval}.
+ * <p>
+ * Extends {@link AbstractInterval} such that derived classes can use
+ * <code>this</code> to obtain a
+ * {@link RandomAccessible#randomAccess(net.imglib2.Interval) constrained
+ * RandomAccess}
+ *
+ * @param <A>
+ *            pixel type of the source.
+ * @param <B>
+ *            pixel type of the target {@link RandomAccessibleInterval}.
+ *
+ * @author Tobias Pietzsch
+ * @author Stephan Saalfeld
+ */
+abstract public class AbstractInterruptibleProjector< A, B > extends AbstractInterval implements InterruptibleProjector
+{
+	/**
+	 * A converter from the source pixel type to the target pixel type.
+	 */
+	final protected Converter< ? super A, B > converter;
+
+	/**
+	 * The target interval. Pixels of the target interval should be set by
+	 * {@link InterruptibleProjector#map(double)}
+	 */
+	final protected RandomAccessibleInterval< B > target;
+
+	/**
+	 * Create new projector with a number of source dimensions and a converter
+	 * from source to target pixel type. The new projector's
+	 * {@link #numDimensions()} will be equal the number of source dimensions,
+	 * allowing it to act as an interval on the source.
+	 * 
+	 * @param numSourceDimensions
+	 *            number of dimensions of the source.
+	 * @param converter
+	 *            converts from the source pixel type to the target pixel type.
+	 * @param target
+	 *            the target interval that this projector maps to
+	 */
+	public AbstractInterruptibleProjector(final int numSourceDimensions, final Converter< ? super A, B > converter, final RandomAccessibleInterval< B > target )
+	{
+		super( numSourceDimensions );
+		this.converter = converter;
+		this.target = target;
+	}
+}

--- a/src/main/java/bdv/fx/viewer/project/AccumulateProjector.java
+++ b/src/main/java/bdv/fx/viewer/project/AccumulateProjector.java
@@ -162,7 +162,7 @@ public abstract class AccumulateProjector< A, B > implements VolatileProjector
 		}
 		try
 		{
-			tasks.forEach(executorService::submit);
+			tasks.forEach(t -> executorService.submit(t, priority));
 			latch.await();
 		}
 		catch ( final InterruptedException e )

--- a/src/main/java/bdv/fx/viewer/project/AccumulateProjector.java
+++ b/src/main/java/bdv/fx/viewer/project/AccumulateProjector.java
@@ -1,0 +1,199 @@
+/*
+ * #%L
+ * BigDataViewer core classes with minimal dependencies
+ * %%
+ * Copyright (C) 2012 - 2016 Tobias Pietzsch, Stephan Saalfeld, Stephan Preibisch,
+ * Jean-Yves Tinevez, HongKee Moon, Johannes Schindelin, Curtis Rueden, John Bogovic
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package bdv.fx.viewer.project;
+
+import bdv.fx.viewer.PriorityExecutorService;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.ui.InterruptibleProjector;
+import net.imglib2.ui.util.StopWatch;
+import net.imglib2.view.Views;
+
+import java.util.ArrayList;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public abstract class AccumulateProjector< A, B > implements VolatileProjector
+{
+	protected final ArrayList< VolatileProjector > sourceProjectors;
+
+	protected final ArrayList< IterableInterval< ? extends A > > sources;
+
+	/**
+	 * The target interval. Pixels of the target interval should be set by
+	 * {@link InterruptibleProjector#map()}
+	 */
+	protected final RandomAccessibleInterval< B > target;
+
+	/**
+	 * A reference to the target image as an iterable.  Used for source-less
+	 * operations such as clearing its content.
+	 */
+	protected final IterableInterval< B > iterableTarget;
+
+	/**
+     * Number of threads to use for rendering
+     */
+    protected final int numThreads;
+
+	protected final PriorityExecutorService executorService;
+
+    /**
+     * Time needed for rendering the last frame, in nano-seconds.
+     */
+    protected long lastFrameRenderNanoTime;
+
+	protected final AtomicBoolean interrupted = new AtomicBoolean();
+
+	protected volatile boolean valid = false;
+
+	public AccumulateProjector(
+			final ArrayList< VolatileProjector > sourceProjectors,
+			final ArrayList< ? extends RandomAccessible< ? extends A > > sources,
+			final RandomAccessibleInterval< B > target,
+			final int numThreads,
+			final PriorityExecutorService executorService )
+	{
+		this.sourceProjectors = sourceProjectors;
+		this.sources = new ArrayList<>();
+		for ( final RandomAccessible< ? extends A > source : sources )
+			this.sources.add( Views.flatIterable( Views.interval( source, target ) ) );
+		this.target = target;
+		this.iterableTarget = Views.flatIterable( target );
+		this.numThreads = numThreads;
+		this.executorService = executorService;
+		lastFrameRenderNanoTime = -1;
+	}
+
+	@Override
+	public boolean map()
+	{
+		return map( true );
+	}
+
+	@Override
+	public boolean map( final boolean clearUntouchedTargetPixels )
+	{
+		interrupted.set( false );
+
+		final StopWatch stopWatch = new StopWatch();
+		stopWatch.start();
+
+		valid = true;
+		for ( final VolatileProjector p : sourceProjectors )
+			if ( !p.isValid() )
+				if ( !p.map( clearUntouchedTargetPixels ) )
+					return false;
+				else
+					valid &= p.isValid();
+
+		final int width = ( int ) target.dimension( 0 );
+		final int height = ( int ) target.dimension( 1 );
+		final int length = width * height;
+
+		final int numTasks = Math.min( numThreads * 10, height );
+		final double taskLength = ( double ) length / numTasks;
+		final int numSources = sources.size();
+		final ArrayList<Runnable> tasks = new ArrayList<>(numTasks);
+		final CountDownLatch latch = new CountDownLatch(numTasks);
+		for ( int taskNum = 0; taskNum < numTasks; ++taskNum )
+		{
+			final int myOffset = ( int ) ( taskNum * taskLength );
+			final int myLength = ( (taskNum == numTasks - 1 ) ? length : ( int ) ( ( taskNum + 1 ) * taskLength ) ) - myOffset;
+
+			final Runnable r = () -> {
+				try {
+					if (interrupted.get())
+						return;
+
+					final Cursor<? extends A>[] sourceCursors = new Cursor[numSources];
+					for (int s = 0; s < numSources; ++s) {
+						final Cursor<? extends A> c = sources.get(s).cursor();
+						c.jumpFwd(myOffset);
+						sourceCursors[s] = c;
+					}
+					final Cursor<B> targetCursor = iterableTarget.cursor();
+					targetCursor.jumpFwd(myOffset);
+
+					for (int i = 0; i < myLength; ++i) {
+						for (int s = 0; s < numSources; ++s)
+							sourceCursors[s].fwd();
+						accumulate(sourceCursors, targetCursor.next());
+					}
+					return;
+				}
+				finally {
+					latch.countDown();
+				}
+			};
+			tasks.add(r);
+		}
+		try
+		{
+			tasks.forEach(executorService::submit);
+			latch.await();
+		}
+		catch ( final InterruptedException e )
+		{
+			Thread.currentThread().interrupt();
+		}
+
+		lastFrameRenderNanoTime = stopWatch.nanoTime();
+
+		return !interrupted.get();
+	}
+
+	protected abstract void accumulate( final Cursor< ? extends A >[] accesses, final B target );
+
+	@Override
+	public void cancel()
+	{
+		interrupted.set( true );
+		for ( final VolatileProjector p : sourceProjectors )
+			p.cancel();
+	}
+
+	@Override
+	public long getLastFrameRenderNanoTime()
+	{
+		return lastFrameRenderNanoTime;
+	}
+
+	@Override
+	public boolean isValid()
+	{
+		return valid;
+	}
+}

--- a/src/main/java/bdv/fx/viewer/project/AccumulateProjector.java
+++ b/src/main/java/bdv/fx/viewer/project/AccumulateProjector.java
@@ -98,13 +98,13 @@ public abstract class AccumulateProjector< A, B > implements VolatileProjector
 	}
 
 	@Override
-	public boolean map()
+	public boolean map(final double priority)
 	{
-		return map( true );
+		return map(priority,true);
 	}
 
 	@Override
-	public boolean map( final boolean clearUntouchedTargetPixels )
+	public boolean map(final double priority, final boolean clearUntouchedTargetPixels)
 	{
 		interrupted.set( false );
 
@@ -114,7 +114,7 @@ public abstract class AccumulateProjector< A, B > implements VolatileProjector
 		valid = true;
 		for ( final VolatileProjector p : sourceProjectors )
 			if ( !p.isValid() )
-				if ( !p.map( clearUntouchedTargetPixels ) )
+				if (!p.map(priority, clearUntouchedTargetPixels))
 					return false;
 				else
 					valid &= p.isValid();

--- a/src/main/java/bdv/fx/viewer/project/AccumulateProjectorFactory.java
+++ b/src/main/java/bdv/fx/viewer/project/AccumulateProjectorFactory.java
@@ -1,0 +1,64 @@
+package bdv.fx.viewer.project;
+
+/*
+ * #%L
+ * BigDataViewer core classes with minimal dependencies
+ * %%
+ * Copyright (C) 2012 - 2016 Tobias Pietzsch, Stephan Saalfeld, Stephan Preibisch,
+ * Jean-Yves Tinevez, HongKee Moon, Johannes Schindelin, Curtis Rueden, John Bogovic
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+import java.util.ArrayList;
+import java.util.concurrent.ExecutorService;
+
+import bdv.fx.viewer.PriorityExecutorService;
+import bdv.viewer.Source;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+
+public interface AccumulateProjectorFactory< A >
+{
+	/**
+	 * @param sourceProjectors
+	 *            projectors that will be used to render {@code sources}.
+	 * @param sources
+	 *            sources to identify which channels are being rendered
+	 * @param sourceScreenImages
+	 *            rendered images that will be accumulated into
+	 *            {@code target}.
+	 * @param targetScreenImage
+	 *            final image to render.
+	 * @param numThreads
+	 *            how many threads to use for rendering.
+	 * @param executorService
+	 *            {@link ExecutorService} to use for rendering. may be null.
+	 */
+	public VolatileProjector createAccumulateProjector(
+			final ArrayList< VolatileProjector > sourceProjectors,
+			final ArrayList< Source< ? > > sources,
+			final ArrayList< ? extends RandomAccessible< ? extends A > > sourceScreenImages,
+			final RandomAccessibleInterval< A > targetScreenImage,
+			final int numThreads,
+			final PriorityExecutorService executorService );
+}

--- a/src/main/java/bdv/fx/viewer/project/EmptyProjector.java
+++ b/src/main/java/bdv/fx/viewer/project/EmptyProjector.java
@@ -47,17 +47,17 @@ public class EmptyProjector< T extends NumericType< T> > implements VolatileProj
 	}
 
 	@Override
-	public boolean map()
+	public boolean map(final double priority)
 	{
-		return map( false );
+		return map(priority,false);
 	}
 
 	@Override
-	public boolean map( final boolean clearUntouchedTargetPixels )
+	public boolean map(final double priority, final boolean clearUntouchedTargetPixels)
 	{
 		final StopWatch stopWatch = new StopWatch();
 		stopWatch.start();
-		if ( clearUntouchedTargetPixels )
+		if (clearUntouchedTargetPixels)
 			for ( final T t : Views.iterable( target ) )
 				t.setZero();
 		lastFrameRenderNanoTime = stopWatch.nanoTime();

--- a/src/main/java/bdv/fx/viewer/project/EmptyProjector.java
+++ b/src/main/java/bdv/fx/viewer/project/EmptyProjector.java
@@ -1,0 +1,82 @@
+/*
+ * #%L
+ * BigDataViewer core classes with minimal dependencies
+ * %%
+ * Copyright (C) 2012 - 2016 Tobias Pietzsch, Stephan Saalfeld, Stephan Preibisch,
+ * Jean-Yves Tinevez, HongKee Moon, Johannes Schindelin, Curtis Rueden, John Bogovic
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package bdv.fx.viewer.project;
+
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.numeric.NumericType;
+import net.imglib2.ui.util.StopWatch;
+import net.imglib2.view.Views;
+
+public class EmptyProjector< T extends NumericType< T> > implements VolatileProjector
+{
+	private final RandomAccessibleInterval< T > target;
+
+    protected long lastFrameRenderNanoTime;
+
+    public EmptyProjector(final RandomAccessibleInterval< T > screenImage )
+	{
+		this.target = screenImage;
+		lastFrameRenderNanoTime = -1;
+	}
+
+	@Override
+	public boolean map()
+	{
+		return map( false );
+	}
+
+	@Override
+	public boolean map( final boolean clearUntouchedTargetPixels )
+	{
+		final StopWatch stopWatch = new StopWatch();
+		stopWatch.start();
+		if ( clearUntouchedTargetPixels )
+			for ( final T t : Views.iterable( target ) )
+				t.setZero();
+		lastFrameRenderNanoTime = stopWatch.nanoTime();
+		return true;
+	}
+
+	@Override
+	public long getLastFrameRenderNanoTime()
+	{
+		return lastFrameRenderNanoTime;
+	}
+
+	@Override
+	public void cancel()
+	{}
+
+	@Override
+	public boolean isValid()
+	{
+		return true;
+	}
+}

--- a/src/main/java/bdv/fx/viewer/project/InterruptibleProjector.java
+++ b/src/main/java/bdv/fx/viewer/project/InterruptibleProjector.java
@@ -1,9 +1,13 @@
 /*
  * #%L
- * BigDataViewer core classes with minimal dependencies
+ * ImgLib2: a general-purpose, multidimensional image processing library.
  * %%
- * Copyright (C) 2012 - 2016 Tobias Pietzsch, Stephan Saalfeld, Stephan Preibisch,
- * Jean-Yves Tinevez, HongKee Moon, Johannes Schindelin, Curtis Rueden, John Bogovic
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -29,21 +33,37 @@
  */
 package bdv.fx.viewer.project;
 
-import net.imglib2.Volatile;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.display.projector.Projector;
 
-public interface VolatileProjector extends InterruptibleProjector
+/**
+ * Similar to a {@link Projector}, this renders a target image (usually a 2D
+ * {@link RandomAccessibleInterval}). In contrast to a {@link Projector},
+ * rendering can be interrupted, in which case {@link #map(double)} will return false.
+ * Also, the rendering time for the last {@link #map(double)} can be queried.
+ * 
+ * @author Tobias Pietzsch
+ * @author Stephan Saalfeld
+ */
+public interface InterruptibleProjector
 {
 	/**
 	 * Render the target image.
-	 *
-	 * @param clearUntouchedTargetPixels
+	 * 
 	 * @return true if rendering was completed (all target pixels written).
 	 *         false if rendering was interrupted.
 	 */
-	boolean map(double priority, boolean clearUntouchedTargetPixels);
+	boolean map(double priority);
 
 	/**
-	 * @return true if all mapped pixels were {@link Volatile#isValid() valid}.
+	 * Abort {@link #map(double)} if it is currently running.
 	 */
-	boolean isValid();
+	public void cancel();
+
+	/**
+	 * How many nano-seconds did the last {@link #map(double)} take.
+	 * 
+	 * @return time needed for rendering the last frame, in nano-seconds.
+	 */
+	long getLastFrameRenderNanoTime();
 }

--- a/src/main/java/bdv/fx/viewer/project/SimpleInterruptibleProjectorPreMultiply.java
+++ b/src/main/java/bdv/fx/viewer/project/SimpleInterruptibleProjectorPreMultiply.java
@@ -160,7 +160,7 @@ public class SimpleInterruptibleProjectorPreMultiply<A> extends AbstractInterrup
 		}
 		try
 		{
-			tasks.forEach(executorService::submit);
+			tasks.forEach(t -> executorService.submit(t, priority));
 			latch.await();
 		} catch (final InterruptedException e)
 		{

--- a/src/main/java/bdv/fx/viewer/project/SimpleInterruptibleProjectorPreMultiply.java
+++ b/src/main/java/bdv/fx/viewer/project/SimpleInterruptibleProjectorPreMultiply.java
@@ -1,12 +1,5 @@
 package bdv.fx.viewer.project;
 
-import java.util.ArrayList;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import bdv.fx.viewer.PriorityExecutorService;
 import com.sun.javafx.image.PixelUtils;
 import net.imglib2.RandomAccess;
@@ -14,9 +7,11 @@ import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.Converter;
 import net.imglib2.type.numeric.ARGBType;
-import net.imglib2.ui.AbstractInterruptibleProjector;
-import net.imglib2.ui.InterruptibleProjector;
 import net.imglib2.ui.util.StopWatch;
+
+import java.util.ArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * An {@link InterruptibleProjector}, that renders a target 2D {@link RandomAccessibleInterval} by copying values from a
@@ -93,7 +88,7 @@ public class SimpleInterruptibleProjectorPreMultiply<A> extends AbstractInterrup
 	 * @return true if rendering was completed (all target pixels written). false if rendering was interrupted.
 	 */
 	@Override
-	public boolean map()
+	public boolean map(final double priority)
 	{
 		interrupted.set(false);
 

--- a/src/main/java/bdv/fx/viewer/project/VolatileHierarchyProjector.java
+++ b/src/main/java/bdv/fx/viewer/project/VolatileHierarchyProjector.java
@@ -321,7 +321,7 @@ public class VolatileHierarchyProjector< A extends Volatile< ? >, B extends Nume
 			}
 			try
 			{
-				tasks.forEach(executorService::submit);
+				tasks.forEach(t -> executorService.submit(t, priority));
 				latch.await();
 			}
 			catch ( final InterruptedException e )

--- a/src/main/java/bdv/fx/viewer/project/VolatileHierarchyProjector.java
+++ b/src/main/java/bdv/fx/viewer/project/VolatileHierarchyProjector.java
@@ -44,7 +44,6 @@ import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.type.numeric.integer.ByteType;
-import net.imglib2.ui.AbstractInterruptibleProjector;
 import net.imglib2.ui.util.StopWatch;
 import net.imglib2.view.Views;
 
@@ -57,7 +56,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * {@link VolatileProjector} for a hierarchy of {@link Volatile} inputs.  After each
- * {@link #map()} call, the projector has a {@link #isValid() state} that
+ * {@link #map(double)} call, the projector has a {@link #isValid() state} that
  * signalizes whether all projected pixels were perfect.
  *
  * @author Stephan Saalfeld &lt;saalfeld@mpi-cbg.de&gt;
@@ -221,13 +220,13 @@ public class VolatileHierarchyProjector< A extends Volatile< ? >, B extends Nume
 	}
 
 	@Override
-	public boolean map()
+	public boolean map(final double priority)
 	{
-		return map( true );
+		return map(priority, true);
 	}
 
 	@Override
-	public boolean map( final boolean clearUntouchedTargetPixels )
+	public boolean map(final double priority, final boolean clearUntouchedTargetPixels)
 	{
 		interrupted.set( false );
 

--- a/src/main/java/bdv/fx/viewer/project/VolatileHierarchyProjector.java
+++ b/src/main/java/bdv/fx/viewer/project/VolatileHierarchyProjector.java
@@ -1,0 +1,359 @@
+package bdv.fx.viewer.project;
+
+/*
+ * #%L
+ * BigDataViewer core classes with minimal dependencies
+ * %%
+ * Copyright (C) 2012 - 2016 Tobias Pietzsch, Stephan Saalfeld, Stephan Preibisch,
+ * Jean-Yves Tinevez, HongKee Moon, Johannes Schindelin, Curtis Rueden, John Bogovic
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+import bdv.fx.viewer.PriorityExecutorService;
+import net.imglib2.Cursor;
+import net.imglib2.FinalInterval;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.Volatile;
+import net.imglib2.cache.iotiming.CacheIoTiming;
+import net.imglib2.cache.iotiming.IoStatistics;
+import net.imglib2.converter.Converter;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.NumericType;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.ui.AbstractInterruptibleProjector;
+import net.imglib2.ui.util.StopWatch;
+import net.imglib2.view.Views;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * {@link VolatileProjector} for a hierarchy of {@link Volatile} inputs.  After each
+ * {@link #map()} call, the projector has a {@link #isValid() state} that
+ * signalizes whether all projected pixels were perfect.
+ *
+ * @author Stephan Saalfeld &lt;saalfeld@mpi-cbg.de&gt;
+ * @author Tobias Pietzsch &lt;tobias.pietzsch@gmail.com&gt;
+ */
+public class VolatileHierarchyProjector< A extends Volatile< ? >, B extends NumericType< B > > extends AbstractInterruptibleProjector< A, B > implements VolatileProjector
+{
+	protected final ArrayList< RandomAccessible< A > > sources = new ArrayList<>();
+
+	private final byte[] maskArray;
+
+	protected final Img< ByteType > mask;
+
+	protected volatile boolean valid = false;
+
+	protected int numInvalidLevels;
+
+	/**
+	 * Extends of the source to be used for mapping.
+	 */
+	protected final FinalInterval sourceInterval;
+
+	/**
+	 * Target width
+	 */
+	protected final int width;
+
+	/**
+	 * Target height
+	 */
+	protected final int height;
+
+	/**
+	 * Steps for carriage return. Typically -{@link #width}
+	 */
+	protected final int cr;
+
+	/**
+	 * A reference to the target image as an iterable. Used for source-less
+	 * operations such as clearing its content.
+	 */
+	protected final IterableInterval< B > iterableTarget;
+
+	/**
+	 * Number of threads to use for rendering
+	 */
+	protected final int numThreads;
+
+	protected final PriorityExecutorService executorService;
+
+	/**
+	 * Time needed for rendering the last frame, in nano-seconds.
+	 * This does not include time spent in blocking IO.
+	 */
+	protected long lastFrameRenderNanoTime;
+
+	/**
+	 * Time spent in blocking IO rendering the last frame, in nano-seconds.
+	 */
+	protected long lastFrameIoNanoTime; // TODO move to derived implementation for local sources only
+
+	/**
+	 * temporary variable to store the number of invalid pixels in the current
+	 * rendering pass.
+	 */
+	protected final AtomicInteger numInvalidPixels = new AtomicInteger();
+
+	/**
+	 * Flag to indicate that someone is trying to interrupt rendering.
+	 */
+	protected final AtomicBoolean interrupted = new AtomicBoolean();
+
+	public VolatileHierarchyProjector(
+			final List< ? extends RandomAccessible< A > > sources,
+			final Converter< ? super A, B > converter,
+			final RandomAccessibleInterval< B > target,
+			final int numThreads,
+			final PriorityExecutorService executorService )
+	{
+		this( sources, converter, target, new byte[ ( int ) ( target.dimension( 0 ) * target.dimension( 1 ) ) ], numThreads, executorService );
+	}
+
+	public VolatileHierarchyProjector(
+			final List< ? extends RandomAccessible< A > > sources,
+			final Converter< ? super A, B > converter,
+			final RandomAccessibleInterval< B > target,
+			final byte[] maskArray,
+			final int numThreads,
+			final PriorityExecutorService executorService )
+	{
+		super( Math.max( 2, sources.get( 0 ).numDimensions() ), converter, target );
+
+		this.sources.addAll( sources );
+		numInvalidLevels = sources.size();
+
+		this.maskArray = maskArray;
+		mask = ArrayImgs.bytes( maskArray, target.dimension( 0 ), target.dimension( 1 ) );
+
+		iterableTarget = Views.iterable( target );
+
+		for ( int d = 2; d < min.length; ++d )
+			min[ d ] = max[ d ] = 0;
+
+		max[ 0 ] = target.max( 0 );
+		max[ 1 ] = target.max( 1 );
+		sourceInterval = new FinalInterval( min, max );
+
+		width = ( int )target.dimension( 0 );
+		height = ( int )target.dimension( 1 );
+		cr = -width;
+
+		this.numThreads = numThreads;
+		this.executorService = executorService;
+
+		lastFrameRenderNanoTime = -1;
+		clearMask();
+	}
+
+	@Override
+	public void cancel()
+	{
+		interrupted.set( true );
+	}
+
+	@Override
+	public long getLastFrameRenderNanoTime()
+	{
+		return lastFrameRenderNanoTime;
+	}
+
+	public long getLastFrameIoNanoTime()
+	{
+		return lastFrameIoNanoTime;
+	}
+
+	@Override
+	public boolean isValid()
+	{
+		return valid;
+	}
+
+	/**
+	 * Set all pixels in target to 100% transparent zero, and mask to all
+	 * Integer.MAX_VALUE.
+	 */
+	public void clearMask()
+	{
+		Arrays.fill( maskArray, 0, ( int ) mask.size(), Byte.MAX_VALUE );
+		numInvalidLevels = sources.size();
+	}
+
+	/**
+	 * Clear target pixels that were never written.
+	 */
+	protected void clearUntouchedTargetPixels()
+	{
+		final Cursor< ByteType > maskCursor = mask.cursor();
+		for ( final B t : iterableTarget )
+			if ( maskCursor.next().get() == Byte.MAX_VALUE )
+				t.setZero();
+	}
+
+	@Override
+	public boolean map()
+	{
+		return map( true );
+	}
+
+	@Override
+	public boolean map( final boolean clearUntouchedTargetPixels )
+	{
+		interrupted.set( false );
+
+		final StopWatch stopWatch = new StopWatch();
+		stopWatch.start();
+		final IoStatistics iostat = CacheIoTiming.getIoStatistics();
+		final long startTimeIo = iostat.getIoNanoTime();
+		final long startTimeIoCumulative = iostat.getCumulativeIoNanoTime();
+//		final long startIoBytes = iostat.getIoBytes();
+
+		final int numTasks;
+		if ( numThreads > 1 )
+		{
+			numTasks = Math.min( numThreads * 10, height );
+		}
+		else
+			numTasks = 1;
+		final double taskHeight = ( double )height / numTasks;
+
+		int i;
+
+		valid = false;
+
+		for ( i = 0; i < numInvalidLevels && !valid; ++i )
+		{
+			final byte iFinal = ( byte ) i;
+
+			valid = true;
+			numInvalidPixels.set( 0 );
+
+			final ArrayList<Runnable> tasks = new ArrayList<>( numTasks );
+			final CountDownLatch latch = new CountDownLatch(numTasks);
+			for ( int taskNum = 0; taskNum < numTasks; ++taskNum )
+			{
+				final int myOffset = width * ( int ) ( taskNum * taskHeight );
+				final long myMinY = min[ 1 ] + ( int ) ( taskNum * taskHeight );
+				final int myHeight = ( int ) ( ( (taskNum == numTasks - 1 ) ? height : ( int ) ( ( taskNum + 1 ) * taskHeight ) ) - myMinY - min[ 1 ] );
+
+				final Runnable r = () -> {
+					try {
+						if (interrupted.get())
+							return;
+
+						final RandomAccess<B> targetRandomAccess = target.randomAccess(target);
+						final Cursor<ByteType> maskCursor = mask.cursor();
+						final RandomAccess<A> sourceRandomAccess = sources.get(iFinal).randomAccess(sourceInterval);
+						int myNumInvalidPixels = 0;
+
+						final long[] smin = new long[n];
+						System.arraycopy(min, 0, smin, 0, n);
+						smin[1] = myMinY;
+						sourceRandomAccess.setPosition(smin);
+
+						targetRandomAccess.setPosition(min[0], 0);
+						targetRandomAccess.setPosition(myMinY, 1);
+
+						maskCursor.jumpFwd(myOffset);
+
+						for (int y = 0; y < myHeight; ++y) {
+							if (interrupted.get())
+								return;
+
+							for (int x = 0; x < width; ++x) {
+								final ByteType m = maskCursor.next();
+								if (m.get() > iFinal) {
+									final A a = sourceRandomAccess.get();
+									final boolean v = a.isValid();
+									if (v) {
+										converter.convert(a, targetRandomAccess.get());
+										m.set(iFinal);
+									} else
+										++myNumInvalidPixels;
+								}
+								sourceRandomAccess.fwd(0);
+								targetRandomAccess.fwd(0);
+							}
+							++smin[1];
+							sourceRandomAccess.setPosition(smin);
+							targetRandomAccess.move(cr, 0);
+							targetRandomAccess.fwd(1);
+						}
+						numInvalidPixels.addAndGet(myNumInvalidPixels);
+						if (myNumInvalidPixels != 0)
+							valid = false;
+						return;
+					}
+					finally {
+						latch.countDown();
+					}
+				};
+				tasks.add( r );
+			}
+			try
+			{
+				tasks.forEach(executorService::submit);
+				latch.await();
+			}
+			catch ( final InterruptedException e )
+			{
+				Thread.currentThread().interrupt();
+			}
+			if ( interrupted.get() )
+			{
+//				System.out.println( "interrupted" );
+				return false;
+			}
+//			System.out.println( "numInvalidPixels(" + i + ") = " + numInvalidPixels );
+		}
+		if ( clearUntouchedTargetPixels && !interrupted.get() )
+			clearUntouchedTargetPixels();
+
+		final long lastFrameTime = stopWatch.nanoTime();
+//		final long numIoBytes = iostat.getIoBytes() - startIoBytes;
+		lastFrameIoNanoTime = iostat.getIoNanoTime() - startTimeIo;
+		lastFrameRenderNanoTime = lastFrameTime - ( iostat.getCumulativeIoNanoTime() - startTimeIoCumulative ) / numThreads;
+
+//		System.out.println( "lastFrameTime = " + lastFrameTime / 1000000 );
+//		System.out.println( "lastFrameRenderNanoTime = " + lastFrameRenderNanoTime / 1000000 );
+
+		if ( valid )
+			numInvalidLevels = i - 1;
+		valid = numInvalidLevels == 0;
+
+//		System.out.println( "Mapping complete after " + ( s + 1 ) + " levels." );
+
+		return !interrupted.get();
+	}
+}
+

--- a/src/main/java/bdv/fx/viewer/project/VolatileHierarchyProjectorPreMultiply.java
+++ b/src/main/java/bdv/fx/viewer/project/VolatileHierarchyProjectorPreMultiply.java
@@ -302,7 +302,7 @@ public class VolatileHierarchyProjectorPreMultiply<A extends Volatile<?>>
 			}
 			try
 			{
-				tasks.forEach(executorService::submit);
+				tasks.forEach(t -> executorService.submit(t, priority));
 				latch.await();
 			} catch (final InterruptedException e)
 			{

--- a/src/main/java/bdv/fx/viewer/project/VolatileHierarchyProjectorPreMultiply.java
+++ b/src/main/java/bdv/fx/viewer/project/VolatileHierarchyProjectorPreMultiply.java
@@ -16,7 +16,6 @@ import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.type.numeric.integer.ByteType;
-import net.imglib2.ui.AbstractInterruptibleProjector;
 import net.imglib2.ui.util.StopWatch;
 import net.imglib2.view.Views;
 
@@ -28,7 +27,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * {@link VolatileProjector} for a hierarchy of {@link Volatile} inputs. After each {@link #map()} call, the projector
+ * {@link VolatileProjector} for a hierarchy of {@link Volatile} inputs. After each {@link #map(double)} call, the projector
  * has a {@link #isValid() state} that signalizes whether all projected pixels were perfect.
  *
  * @author Stephan Saalfeld &lt;saalfeld@mpi-cbg.de&gt;
@@ -199,13 +198,13 @@ public class VolatileHierarchyProjectorPreMultiply<A extends Volatile<?>>
 	}
 
 	@Override
-	public boolean map()
+	public boolean map(final double priority)
 	{
-		return map(true);
+		return map(priority,true);
 	}
 
 	@Override
-	public boolean map(final boolean clearUntouchedTargetPixels)
+	public boolean map(final double priority, final boolean clearUntouchedTargetPixels)
 	{
 		interrupted.set(false);
 

--- a/src/main/java/bdv/fx/viewer/project/VolatileProjector.java
+++ b/src/main/java/bdv/fx/viewer/project/VolatileProjector.java
@@ -1,0 +1,50 @@
+/*
+ * #%L
+ * BigDataViewer core classes with minimal dependencies
+ * %%
+ * Copyright (C) 2012 - 2016 Tobias Pietzsch, Stephan Saalfeld, Stephan Preibisch,
+ * Jean-Yves Tinevez, HongKee Moon, Johannes Schindelin, Curtis Rueden, John Bogovic
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package bdv.fx.viewer.project;
+
+import net.imglib2.Volatile;
+import net.imglib2.ui.InterruptibleProjector;
+
+public interface VolatileProjector extends InterruptibleProjector
+{
+	/**
+	 * Render the target image.
+	 *
+	 * @param clearUntouchedTargetPixels
+	 * @return true if rendering was completed (all target pixels written).
+	 *         false if rendering was interrupted.
+	 */
+	public boolean map(boolean clearUntouchedTargetPixels);
+
+	/**
+	 * @return true if all mapped pixels were {@link Volatile#isValid() valid}.
+	 */
+	public boolean isValid();
+}

--- a/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererFX.java
+++ b/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererFX.java
@@ -55,7 +55,7 @@ import net.imglib2.ui.Renderer;
  * <p>
  * At any time, one of these screen scales is selected as the <em>highest screen scale</em>. Rendering starts with this
  * highest screen scale and then proceeds to lower screen scales (higher resolution images). Unless the highest screen
- * scale is currently rendering, {@link #requestRepaint() repaint request} will cancel rendering, such that display
+ * scale is currently rendering, {@link #requestRepaint(double) repaint request} will cancel rendering, such that display
  * remains interactive.
  * <p>
  * The renderer tries to maintain a per-frame rendering time close to a desired number of <code>targetRenderNanos</code>

--- a/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererFX.java
+++ b/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererFX.java
@@ -29,10 +29,9 @@
  */
 package bdv.fx.viewer.render;
 
-import java.util.concurrent.ExecutorService;
-
 import bdv.cache.CacheControl;
-import bdv.viewer.render.AccumulateProjectorFactory;
+import bdv.fx.viewer.PriorityExecutorService;
+import bdv.fx.viewer.project.AccumulateProjectorFactory;
 import net.imglib2.Volatile;
 import net.imglib2.img.array.ArrayImg;
 import net.imglib2.type.numeric.ARGBType;
@@ -120,7 +119,7 @@ public class MultiResolutionRendererFX extends MultiResolutionRendererGeneric<Bu
 			final long targetRenderNanos,
 			final boolean doubleBuffered,
 			final int numRenderingThreads,
-			final ExecutorService renderingExecutorService,
+			final PriorityExecutorService renderingExecutorService,
 			final boolean useVolatileIfAvailable,
 			final AccumulateProjectorFactory<ARGBType> accumulateProjectorFactory,
 			final CacheControl cacheControl)

--- a/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererGeneric.java
+++ b/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererGeneric.java
@@ -30,21 +30,22 @@
 package bdv.fx.viewer.render;
 
 import bdv.cache.CacheControl;
+import bdv.fx.viewer.PriorityExecutorService;
+import bdv.fx.viewer.project.AccumulateProjectorFactory;
+import bdv.fx.viewer.project.EmptyProjector;
 import bdv.fx.viewer.project.SimpleInterruptibleProjectorPreMultiply;
+import bdv.fx.viewer.project.VolatileHierarchyProjector;
 import bdv.fx.viewer.project.VolatileHierarchyProjectorPreMultiply;
+import bdv.fx.viewer.project.VolatileProjector;
 import bdv.util.MipmapTransforms;
 import bdv.viewer.Interpolation;
 import bdv.viewer.Source;
 import bdv.viewer.SourceAndConverter;
-import bdv.viewer.render.AccumulateProjectorFactory;
 import bdv.viewer.render.DefaultMipmapOrdering;
-import bdv.viewer.render.EmptyProjector;
 import bdv.viewer.render.MipmapOrdering;
 import bdv.viewer.render.MipmapOrdering.Level;
 import bdv.viewer.render.MipmapOrdering.MipmapHints;
 import bdv.viewer.render.Prefetcher;
-import bdv.viewer.render.VolatileHierarchyProjector;
-import bdv.viewer.render.VolatileProjector;
 import net.imglib2.Dimensions;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
@@ -207,7 +208,7 @@ public class MultiResolutionRendererGeneric<T>
 	/**
 	 * {@link ExecutorService} used for rendering.
 	 */
-	private final ExecutorService renderingExecutorService;
+	private final PriorityExecutorService renderingExecutorService;
 
 	/**
 	 * TODO
@@ -282,7 +283,7 @@ public class MultiResolutionRendererGeneric<T>
 			final long targetRenderNanos,
 			final boolean doubleBuffered,
 			final int numRenderingThreads,
-			final ExecutorService renderingExecutorService,
+			final PriorityExecutorService renderingExecutorService,
 			final boolean useVolatileIfAvailable,
 			final AccumulateProjectorFactory<ARGBType> accumulateProjectorFactory,
 			final CacheControl cacheControl,
@@ -652,7 +653,7 @@ public class MultiResolutionRendererGeneric<T>
 				final Converter<? super A, ARGBType> converter,
 				final RandomAccessibleInterval<ARGBType> target,
 				final int numThreads,
-				final ExecutorService executorService)
+				final PriorityExecutorService executorService)
 		{
 			super(source, converter, target, numThreads, executorService);
 		}

--- a/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererGeneric.java
+++ b/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererGeneric.java
@@ -491,7 +491,7 @@ public class MultiResolutionRendererGeneric<T>
 		}
 
 		// try rendering
-		final boolean success    = p.map(createProjector);
+		final boolean success    = p.map(PriorityExecutorService.DEFAULT_PRIORITY, createProjector);
 		final long    rendertime = p.getLastFrameRenderNanoTime();
 
 		synchronized (this)
@@ -659,9 +659,9 @@ public class MultiResolutionRendererGeneric<T>
 		}
 
 		@Override
-		public boolean map(final boolean clearUntouchedTargetPixels)
+		public boolean map(final double priority, final boolean clearUntouchedTargetPixels)
 		{
-			final boolean success = super.map();
+			final boolean success = super.map(priority);
 			valid |= success;
 			return success;
 		}

--- a/src/main/java/bdv/fx/viewer/render/RenderUnit.java
+++ b/src/main/java/bdv/fx/viewer/render/RenderUnit.java
@@ -2,11 +2,12 @@ package bdv.fx.viewer.render;
 
 import bdv.cache.CacheControl;
 import bdv.fx.viewer.ImagePane;
+import bdv.fx.viewer.PriorityExecutorService;
 import bdv.fx.viewer.ViewerState;
+import bdv.fx.viewer.project.AccumulateProjectorFactory;
 import bdv.viewer.Interpolation;
 import bdv.viewer.Source;
 import bdv.viewer.SourceAndConverter;
-import bdv.viewer.render.AccumulateProjectorFactory;
 import javafx.beans.property.ObjectProperty;
 import javafx.scene.Node;
 import javafx.scene.image.Image;
@@ -65,7 +66,7 @@ public class RenderUnit implements TransformListener<AffineTransform3D> {
 
 	private final long targetRenderNanos;
 
-	private final ExecutorService renderingExecutorService;
+	private final PriorityExecutorService renderingExecutorService;
 
 	private final List<Runnable> updateListeners = new ArrayList<>();
 
@@ -79,7 +80,7 @@ public class RenderUnit implements TransformListener<AffineTransform3D> {
 			final AccumulateProjectorFactory<ARGBType> accumulateProjectorFactory,
 			final CacheControl cacheControl,
 			final long targetRenderNanos,
-			final ExecutorService renderingExecutorService) {
+			final PriorityExecutorService renderingExecutorService) {
 		this.threadGroup = threadGroup;
 		this.viewerState = viewerState;
 		this.axisOrder = axisOrder;

--- a/src/main/java/bdv/fx/viewer/render/RenderUnit.java
+++ b/src/main/java/bdv/fx/viewer/render/RenderUnit.java
@@ -106,54 +106,54 @@ public class RenderUnit implements TransformListener<AffineTransform3D> {
 		update();
 	}
 
-	public synchronized void requestRepaintSingleTile(final int screenScaleIndex, final int tileIndex)
+	public synchronized void requestRepaintSingleTile(final int screenScaleIndex, final int tileIndex, final double priority)
 	{
-		renderers[tileIndex].requestRepaint(screenScaleIndex);
+		renderers[tileIndex].requestRepaint(priority, screenScaleIndex);
 	}
 
-	public synchronized void requestRepaintSingleTile(final int tileIndex)
+	public synchronized void requestRepaintSingleTile(final int tileIndex, final double priority)
 	{
-		renderers[tileIndex].requestRepaint();
+		renderers[tileIndex].requestRepaint(priority);
 	}
 
-	public synchronized void requestRepaint(final int screenScaleIndex, final int[] tileIndices)
-	{
-		for (final int b : tileIndices)
-			renderers[b].requestRepaint(screenScaleIndex);
-	}
-
-	public synchronized void requestRepaint(final int[] tileIndices)
+	public synchronized void requestRepaint(final int screenScaleIndex, final int[] tileIndices, final double priority)
 	{
 		for (final int b : tileIndices)
-			renderers[b].requestRepaint();
+			renderers[b].requestRepaint(priority, screenScaleIndex);
 	}
 
-	public synchronized void requestRepaint(final int screenScaleIndex)
+	public synchronized void requestRepaint(final int[] tileIndices, final double priority)
+	{
+		for (final int b : tileIndices)
+			renderers[b].requestRepaint(priority);
+	}
+
+	public synchronized void requestRepaint(final int screenScaleIndex, final double priority)
 	{
 		for (int b = 0; b < renderers.length; ++b)
-			renderers[b].requestRepaint(screenScaleIndex);
+			renderers[b].requestRepaint(priority, screenScaleIndex);
 	}
 
-	public synchronized void requestRepaint()
+	public synchronized void requestRepaint(final double priority)
 	{
 		for (int b = 0; b < renderers.length; ++b)
-			renderers[b].requestRepaint();
+			renderers[b].requestRepaint(priority);
 	}
 
-	public synchronized void requestRepaint(final int screenScaleIndex, final long[] min, final long[] max)
+	public synchronized void requestRepaint(final int screenScaleIndex, final long[] min, final long[] max, final double priority)
 	{
 
 		long[] relevantBlocks = org.janelia.saalfeldlab.util.grids.Grids.getIntersectingBlocks(min, max, this.grid);
 		for (final long b : relevantBlocks)
-			renderers[(int)b].requestRepaint(screenScaleIndex);
+			renderers[(int)b].requestRepaint(priority, screenScaleIndex);
 	}
 
-	public synchronized void requestRepaint(final long[] min, final long[] max)
+	public synchronized void requestRepaint(final long[] min, final long[] max, final double priority)
 	{
 
 		long[] relevantBlocks = org.janelia.saalfeldlab.util.grids.Grids.getIntersectingBlocks(min, max, this.grid);
 		for (final long b : relevantBlocks)
-			renderers[(int)b].requestRepaint();
+			renderers[(int)b].requestRepaint(priority);
 	}
 
 	public synchronized void setScreenScales(final double[] screenScales)

--- a/src/main/java/org/janelia/saalfeldlab/fx/ortho/OrthogonalViews.java
+++ b/src/main/java/org/janelia/saalfeldlab/fx/ortho/OrthogonalViews.java
@@ -6,12 +6,11 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import bdv.cache.CacheControl;
+import bdv.fx.viewer.ViewerOptions;
 import bdv.fx.viewer.ViewerPanelFX;
-import bdv.util.volatiles.SharedQueue;
 import bdv.viewer.Interpolation;
 import bdv.viewer.Source;
 import bdv.viewer.SourceAndConverter;
-import bdv.viewer.ViewerOptions;
 import javafx.event.Event;
 import javafx.event.EventHandler;
 import javafx.event.EventType;

--- a/src/main/java/org/janelia/saalfeldlab/fx/ortho/OrthogonalViews.java
+++ b/src/main/java/org/janelia/saalfeldlab/fx/ortho/OrthogonalViews.java
@@ -6,6 +6,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import bdv.cache.CacheControl;
+import bdv.fx.viewer.PriorityExecutorService;
 import bdv.fx.viewer.ViewerOptions;
 import bdv.fx.viewer.ViewerPanelFX;
 import bdv.viewer.Interpolation;
@@ -153,7 +154,7 @@ public class OrthogonalViews<BR extends Node>
 
 	public void requestRepaint(final long[] min, final long[] max)
 	{
-		applyToAll(vp -> vp.requestRepaint(min, max));
+		applyToAll(vp -> vp.requestRepaint(min, max, PriorityExecutorService.DEFAULT_PRIORITY));
 	}
 
 	public void setAllSources(final Collection<? extends SourceAndConverter<?>> sources)

--- a/src/main/java/org/janelia/saalfeldlab/paintera/Paintera.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/Paintera.java
@@ -1,16 +1,6 @@
 package org.janelia.saalfeldlab.paintera;
 
-import java.io.File;
-import java.io.IOException;
-import java.lang.invoke.MethodHandles;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.Supplier;
-import java.util.regex.Pattern;
-import java.util.stream.IntStream;
-
-import bdv.viewer.ViewerOptions;
+import bdv.fx.viewer.ViewerOptions;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import javafx.application.Application;
@@ -50,9 +40,8 @@ import org.janelia.saalfeldlab.paintera.control.assignment.UnableToPersist;
 import org.janelia.saalfeldlab.paintera.control.lock.LockedSegmentsOnlyLocal;
 import org.janelia.saalfeldlab.paintera.control.selection.SelectedIds;
 import org.janelia.saalfeldlab.paintera.data.DataSource;
-import org.janelia.saalfeldlab.paintera.data.axisorder.AxisOrder;
-import org.janelia.saalfeldlab.paintera.data.mask.exception.CannotPersist;
 import org.janelia.saalfeldlab.paintera.data.mask.Masks;
+import org.janelia.saalfeldlab.paintera.data.mask.exception.CannotPersist;
 import org.janelia.saalfeldlab.paintera.data.n5.CommitCanvasN5;
 import org.janelia.saalfeldlab.paintera.id.IdService;
 import org.janelia.saalfeldlab.paintera.meshes.InterruptibleFunction;
@@ -71,6 +60,16 @@ import org.janelia.saalfeldlab.util.n5.N5Helpers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+import java.util.stream.IntStream;
 
 public class Paintera extends Application
 {

--- a/src/main/java/org/janelia/saalfeldlab/paintera/PainteraBaseView.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/PainteraBaseView.java
@@ -12,10 +12,10 @@ import java.util.function.Function;
 import java.util.function.LongFunction;
 
 import bdv.cache.CacheControl;
+import bdv.fx.viewer.ViewerOptions;
 import bdv.viewer.Interpolation;
 import bdv.viewer.Source;
 import bdv.viewer.SourceAndConverter;
-import bdv.viewer.ViewerOptions;
 import gnu.trove.set.hash.TLongHashSet;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;

--- a/src/main/java/org/janelia/saalfeldlab/paintera/composition/ClearingCompositeProjector.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/composition/ClearingCompositeProjector.java
@@ -1,16 +1,16 @@
 package org.janelia.saalfeldlab.paintera.composition;
 
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
-
+import bdv.fx.viewer.PriorityExecutorService;
+import bdv.fx.viewer.project.AccumulateProjectorFactory;
+import bdv.fx.viewer.project.VolatileProjector;
 import bdv.viewer.Source;
-import bdv.viewer.render.AccumulateProjectorFactory;
-import bdv.viewer.render.VolatileProjector;
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.Type;
+
+import java.util.ArrayList;
+import java.util.Map;
 
 public class ClearingCompositeProjector<A extends Type<A>> extends CompositeProjector<A>
 {
@@ -39,7 +39,7 @@ public class ClearingCompositeProjector<A extends Type<A>> extends CompositeProj
 				final ArrayList<? extends RandomAccessible<? extends A>> sourceScreenImages,
 				final RandomAccessibleInterval<A> targetScreenImage,
 				final int numThreads,
-				final ExecutorService executorService)
+				final PriorityExecutorService executorService)
 		{
 			final ClearingCompositeProjector<A> projector = new ClearingCompositeProjector<>(
 					sourceProjectors,
@@ -68,7 +68,7 @@ public class ClearingCompositeProjector<A extends Type<A>> extends CompositeProj
 			final RandomAccessibleInterval<A> target,
 			final A clearValue,
 			final int numThreads,
-			final ExecutorService executorService)
+			final PriorityExecutorService executorService)
 	{
 		super(sourceProjectors, sources, target, numThreads, executorService);
 		this.clearValue = clearValue;

--- a/src/main/java/org/janelia/saalfeldlab/paintera/composition/CompositeProjector.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/composition/CompositeProjector.java
@@ -1,18 +1,18 @@
 package org.janelia.saalfeldlab.paintera.composition;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
-
+import bdv.fx.viewer.PriorityExecutorService;
+import bdv.fx.viewer.project.AccumulateProjector;
+import bdv.fx.viewer.project.AccumulateProjectorFactory;
+import bdv.fx.viewer.project.VolatileProjector;
 import bdv.viewer.Source;
-import bdv.viewer.render.AccumulateProjector;
-import bdv.viewer.render.AccumulateProjectorFactory;
-import bdv.viewer.render.VolatileProjector;
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.Type;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author Stephan Saalfeld
@@ -41,7 +41,7 @@ public class CompositeProjector<A extends Type<A>> extends AccumulateProjector<A
 				final ArrayList<? extends RandomAccessible<? extends A>> sourceScreenImages,
 				final RandomAccessibleInterval<A> targetScreenImage,
 				final int numThreads,
-				final ExecutorService executorService)
+				final PriorityExecutorService executorService)
 		{
 			final CompositeProjector<A> projector = new CompositeProjector<>(
 					sourceProjectors,
@@ -68,7 +68,7 @@ public class CompositeProjector<A extends Type<A>> extends AccumulateProjector<A
 			final ArrayList<? extends RandomAccessible<? extends A>> sources,
 			final RandomAccessibleInterval<A> target,
 			final int numThreads,
-			final ExecutorService executorService)
+			final PriorityExecutorService executorService)
 	{
 		super(sourceProjectors, sources, target, numThreads, executorService);
 	}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/composition/CompositeProjectorPreMultiply.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/composition/CompositeProjectorPreMultiply.java
@@ -6,10 +6,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
+import bdv.fx.viewer.PriorityExecutorService;
+import bdv.fx.viewer.project.AccumulateProjector;
+import bdv.fx.viewer.project.AccumulateProjectorFactory;
+import bdv.fx.viewer.project.VolatileProjector;
 import bdv.viewer.Source;
-import bdv.viewer.render.AccumulateProjector;
-import bdv.viewer.render.AccumulateProjectorFactory;
-import bdv.viewer.render.VolatileProjector;
 import com.sun.javafx.image.PixelUtils;
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccessible;
@@ -49,7 +50,7 @@ public class CompositeProjectorPreMultiply extends AccumulateProjector<ARGBType,
 				final ArrayList<? extends RandomAccessible<? extends ARGBType>> sourceScreenImages,
 				final RandomAccessibleInterval<ARGBType> targetScreenImage,
 				final int numThreads,
-				final ExecutorService executorService)
+				final PriorityExecutorService executorService)
 		{
 			final CompositeProjectorPreMultiply projector = new CompositeProjectorPreMultiply(
 					sourceProjectors,
@@ -76,7 +77,7 @@ public class CompositeProjectorPreMultiply extends AccumulateProjector<ARGBType,
 			final ArrayList<? extends RandomAccessible<? extends ARGBType>> sources,
 			final RandomAccessibleInterval<ARGBType> target,
 			final int numThreads,
-			final ExecutorService executorService)
+			final PriorityExecutorService executorService)
 	{
 		super(sourceProjectors, sources, target, numThreads, executorService);
 		LOG.debug("Creating {}", this.getClass().getName());

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/Paint.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/Paint.java
@@ -103,7 +103,7 @@ public class Paint implements ToOnEnterOnExit
 							t,
 							sourceInfo,
 							manager,
-							t::requestRepaint,
+							(m, M) -> t.requestRepaint(m, M, Double.MAX_VALUE),
 							paintQueue
 					);
 					paint2D.brushRadiusProperty().bindBidirectional(this.brushRadius);


### PR DESCRIPTION
Use a priority queue to render data to screen instead of a plain `ExecutorService`. That way, tiles of interest can be rendered first, and more important render jobs will run sooner, even if submitted later. This will eliminate the forced delay for painting after navigation actions or similar.
See also the [priority-executor-service-experimental(https://github.com/saalfeldlab/paintera/tree/priority-executor-service-experimental) branch.

This is WIP and not yet ready to merge but this is to track process.