### PR TITLE
Commit canvas for scalar label types

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/data/n5/BackgroundCanvasIterable.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/data/n5/BackgroundCanvasIterable.java
@@ -30,6 +30,7 @@ public class BackgroundCanvasIterable implements Iterable<LabelMultisetType> {
 		this.backgroundAndCanvas = backgroundAndCanvas;
 	}
 
+	@Override
 	public Iterator<LabelMultisetType> iterator() {
 		return new Iterator<LabelMultisetType>() {
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/serialization/converter/HighlightingStreamConverterSerializer.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/serialization/converter/HighlightingStreamConverterSerializer.java
@@ -69,10 +69,12 @@ public class HighlightingStreamConverterSerializer implements PainteraSerializat
 
 			@SuppressWarnings("unchecked") final Class<? extends HighlightingStreamConverter<?>> converterClass =
 					(Class<? extends HighlightingStreamConverter<?>>) Class.forName(map.get(TYPE_KEY).getAsString());
+			LOG.debug("Converter class is {}", converterClass);
 			final HighlightingStreamConverter<?> converter = converterClass.getConstructor(
 					AbstractHighlightingARGBStream.class).newInstance(stream);
 			Optional.ofNullable(map.get(SEED_KEY)).map(JsonElement::getAsLong).ifPresent(converter.seedProperty()
 					::set);
+			LOG.debug("Returning converter {}", converter);
 			return converter;
 		} catch (InstantiationException
 				| IllegalAccessException

--- a/src/main/java/org/janelia/saalfeldlab/paintera/serialization/sourcestate/LabelSourceStateDeserializer.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/serialization/sourcestate/LabelSourceStateDeserializer.java
@@ -174,6 +174,7 @@ public class LabelSourceStateDeserializer<C extends HighlightingStreamConverter<
 				arguments.meshWorkersExecutors
 		);
 
+		LOG.debug("Creating state with converter {}", converter);
 		final LabelSourceState state = new LabelSourceState(
 				source,
 				converter,

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceState.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceState.java
@@ -334,7 +334,7 @@ public class LabelSourceState<D extends IntegerType<D>, T>
 
 		return new LabelSourceState<>(
 				dataSource,
-				new HighlightingStreamConverterIntegerType<>(stream, toLong),
+				new HighlightingStreamConverterIntegerType<>(stream),
 				new ARGBCompositeAlphaYCbCr(),
 				name,
 				assignment,

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/MinimalSourceState.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/MinimalSourceState.java
@@ -1,5 +1,6 @@
 package org.janelia.saalfeldlab.paintera.state;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
 
 import bdv.viewer.Interpolation;
@@ -15,10 +16,14 @@ import net.imglib2.type.numeric.ARGBType;
 import org.janelia.saalfeldlab.paintera.composition.Composite;
 import org.janelia.saalfeldlab.paintera.data.DataSource;
 import org.janelia.saalfeldlab.paintera.data.axisorder.AxisOrder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MinimalSourceState<D, T, S extends DataSource<D, T>, C extends Converter<T, ARGBType>>
 		implements SourceState<D, T>
 {
+
+	private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
 	private final S dataSource;
 
@@ -46,6 +51,13 @@ public class MinimalSourceState<D, T, S extends DataSource<D, T>, C extends Conv
 			final SourceState<?, ?>... dependsOn)
 	{
 		super();
+		LOG.debug(
+				"Creating minimal source state with dataSource={} converter={} composite={} name={} dependsOn={}",
+				dataSource,
+				converter,
+				composite,
+				name,
+				dependsOn);
 		this.dataSource = dataSource;
 		this.converter = converter;
 		this.composite = new SimpleObjectProperty<>(composite);

--- a/src/main/java/org/janelia/saalfeldlab/paintera/stream/HighlightingStreamConverter.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/stream/HighlightingStreamConverter.java
@@ -16,6 +16,7 @@ import javafx.beans.property.SimpleLongProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableMap;
 import javafx.scene.paint.Color;
+import net.imglib2.Volatile;
 import net.imglib2.converter.Converter;
 import net.imglib2.type.label.LabelMultisetType;
 import net.imglib2.type.label.VolatileLabelMultisetType;
@@ -126,20 +127,12 @@ public abstract class HighlightingStreamConverter<T>
 			final AbstractHighlightingARGBStream stream,
 			final T t)
 	{
-		if (t instanceof IntegerType<?>) {
-			return (org.janelia.saalfeldlab.paintera.stream.HighlightingStreamConverter<T>)
-					HighlightingStreamConverterIntegerType.forInteger(
-					stream);
+		LOG.debug("Getting {} for type {}", HighlightingStreamConverter.class.getSimpleName(), t);
+		if (t instanceof VolatileLabelMultisetType) {
+			return (HighlightingStreamConverter<T>) new HighlightingStreamConverterLabelMultisetType(stream);
 		}
-		if (t instanceof RealType<?>) {
-			return (org.janelia.saalfeldlab.paintera.stream.HighlightingStreamConverter<T>)
-					HighlightingStreamConverterIntegerType.forRealType(
-					stream);
-		}
-		if (t instanceof LabelMultisetType || t instanceof VolatileLabelMultisetType) {
-			return (org.janelia.saalfeldlab.paintera.stream.HighlightingStreamConverter<T>) new
-					HighlightingStreamConverterLabelMultisetType(
-					stream);
+		if (t instanceof Volatile<?> && ((Volatile<?>)t).get() instanceof IntegerType<?>) {
+			return (HighlightingStreamConverter<T>) new HighlightingStreamConverterIntegerType(stream);
 		}
 
 		return null;

--- a/src/main/java/org/janelia/saalfeldlab/paintera/stream/HighlightingStreamConverterIntegerType.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/stream/HighlightingStreamConverterIntegerType.java
@@ -1,39 +1,29 @@
 package org.janelia.saalfeldlab.paintera.stream;
 
-import java.util.function.ToLongFunction;
-
+import net.imglib2.Volatile;
 import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.type.numeric.IntegerType;
-import net.imglib2.type.numeric.RealType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public class HighlightingStreamConverterIntegerType<I extends RealType<I>> extends HighlightingStreamConverter<I>
+import java.lang.invoke.MethodHandles;
+
+public class HighlightingStreamConverterIntegerType<I extends IntegerType<I>, V extends Volatile<I>> extends HighlightingStreamConverter<V>
 {
 
-	private final ToLongFunction<I> toLong;
+	private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-	public HighlightingStreamConverterIntegerType(final AbstractHighlightingARGBStream stream, final ToLongFunction<I>
-			toLong)
+	public HighlightingStreamConverterIntegerType(final AbstractHighlightingARGBStream stream)
 	{
 		super(stream);
-		this.toLong = toLong;
+		LOG.debug("Created {} from stream {}", this.getClass(), stream);
 	}
 
 	@Override
-	public void convert(final I input, final ARGBType output)
+	public void convert(final V input, final ARGBType output)
 	{
-		output.set(stream.argb(toLong.applyAsLong(input)));
-	}
-
-	public static <I extends IntegerType<I>> HighlightingStreamConverterIntegerType<I> forInteger(
-			final AbstractHighlightingARGBStream stream)
-	{
-		return new HighlightingStreamConverterIntegerType<>(stream, I::getIntegerLong);
-	}
-
-	public static <I extends RealType<I>> HighlightingStreamConverterIntegerType<I> forRealType(
-			final AbstractHighlightingARGBStream stream)
-	{
-		return new HighlightingStreamConverterIntegerType<>(stream, t -> (long) t.getRealDouble());
+		output.set(stream.argb(input.get().getIntegerLong()));
+//		LOG.trace("Converted input {} to output {}", input, output);
 	}
 
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/ui/opendialog/menu/n5/GenericBackendDialogN5.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/ui/opendialog/menu/n5/GenericBackendDialogN5.java
@@ -471,6 +471,7 @@ public class GenericBackendDialogN5
 		}
 		else
 		{
+			LOG.debug("Getting scalar data source");
 			source = (DataSource<D, T>) N5Data.openScalarAsSource(
 					reader,
 					dataset,

--- a/src/main/java/org/janelia/saalfeldlab/paintera/ui/source/state/SourceStateUIElementsDefaultFactory.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/ui/source/state/SourceStateUIElementsDefaultFactory.java
@@ -155,7 +155,7 @@ public class SourceStateUIElementsDefaultFactory implements SourceStateUIElement
 
 	private static BindUnbindAndNodeSupplier fromConverter(Converter converter)
 	{
-		LOG.warn("Getting supplier for converter {}", converter);
+		LOG.debug("Getting supplier for converter {}", converter);
 		return Optional
 				.ofNullable(getConverterSupplierFactory(converter.getClass()))
 				.map(s -> (Function<Converter, BindUnbindAndNodeSupplier>) (s::create))


### PR DESCRIPTION
This branch was initially started to make painting usable for scalar label types (i.e. not `LabelMultisetType`) by adding canvas-commit support for scalar label types (#118). Scalar label types have not been used and as such more bugs came to light while fixing this particular one. In particular, this PR
 - fixes #118,
 - fixes #162, and
 - fixes #163