### PR TITLE
Add support for label datasets without maxId

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/Paintera.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/Paintera.java
@@ -59,6 +59,7 @@ import org.janelia.saalfeldlab.paintera.meshes.InterruptibleFunction;
 import org.janelia.saalfeldlab.paintera.meshes.MeshManagerWithAssignmentForSegments;
 import org.janelia.saalfeldlab.paintera.serialization.GsonHelpers;
 import org.janelia.saalfeldlab.paintera.serialization.Properties;
+import org.janelia.saalfeldlab.paintera.state.HasSelectedIds;
 import org.janelia.saalfeldlab.paintera.state.LabelSourceState;
 import org.janelia.saalfeldlab.paintera.state.RawSourceState;
 import org.janelia.saalfeldlab.paintera.state.SourceState;
@@ -262,8 +263,8 @@ public class Paintera extends Application
 				.trackSources()
 				.stream()
 				.map(properties.sourceInfo::getState)
-				.filter(state -> state instanceof LabelSourceState<?, ?>)
-				.map(state -> (LabelSourceState<?, ?>) state)
+				.filter(state -> state instanceof HasSelectedIds)
+				.map(state -> (HasSelectedIds) state)
 				.forEach(state -> {
 					final long[] selIds = state.selectedIds().getActiveIds();
 					final long   lastId = state.selectedIds().getLastSelection();

--- a/src/main/java/org/janelia/saalfeldlab/paintera/Paintera.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/Paintera.java
@@ -589,7 +589,7 @@ public class Paintera extends Application
 	public static interface GetN5IDService
 	{
 
-		public IdService getIdService(final N5Writer writer, final String dataset) throws IOException;
+		public IdService getIdService(final N5Writer writer, final String dataset) throws IOException, N5Helpers.MaxIDNotSpecified;
 
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/CurrentSourceRefreshMeshes.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/CurrentSourceRefreshMeshes.java
@@ -3,6 +3,7 @@ package org.janelia.saalfeldlab.paintera.control;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import org.janelia.saalfeldlab.paintera.state.HasMeshes;
 import org.janelia.saalfeldlab.paintera.state.LabelSourceState;
 import org.janelia.saalfeldlab.paintera.state.SourceState;
 
@@ -21,14 +22,14 @@ public class CurrentSourceRefreshMeshes
 	{
 		Optional
 				.ofNullable(currentState.get())
-				.filter(state -> state instanceof LabelSourceState<?, ?>)
-				.map(state -> (LabelSourceState<?, ?>) state)
+				.filter(state -> state instanceof HasMeshes<?>)
+				.map(state -> (HasMeshes<?>) state)
 				.ifPresent(this::refresh);
 	}
 
-	private void refresh(final LabelSourceState<?, ?> state)
+	private void refresh(final HasMeshes<?> hasMeshes)
 	{
-		state.refreshMeshes();
+		hasMeshes.refreshMeshes();
 	}
 
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/Paint.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/Paint.java
@@ -35,6 +35,7 @@ import org.janelia.saalfeldlab.paintera.control.paint.RestrictPainting;
 import org.janelia.saalfeldlab.paintera.control.paint.SelectNextId;
 import org.janelia.saalfeldlab.paintera.control.selection.SelectedIds;
 import org.janelia.saalfeldlab.paintera.state.GlobalTransformManager;
+import org.janelia.saalfeldlab.paintera.state.HasSelectedIds;
 import org.janelia.saalfeldlab.paintera.state.LabelSourceState;
 import org.janelia.saalfeldlab.paintera.state.SourceInfo;
 import org.janelia.saalfeldlab.paintera.state.SourceState;
@@ -281,8 +282,8 @@ public class Paint implements ToOnEnterOnExit
 
 	public SelectedIds selectedIdsFromState(final SourceState<?, ?> state)
 	{
-		return state instanceof LabelSourceState<?, ?>
-		       ? ((LabelSourceState<?, ?>) state).selectedIds()
+		return state instanceof HasSelectedIds
+		       ? ((HasSelectedIds) state).selectedIds()
 		       : null;
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/ShowOnlySelectedInStreamToggle.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/ShowOnlySelectedInStreamToggle.java
@@ -7,6 +7,7 @@ import bdv.viewer.Source;
 import gnu.trove.map.hash.TObjectIntHashMap;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
+import org.janelia.saalfeldlab.paintera.state.HasHighlightingStreamConverter;
 import org.janelia.saalfeldlab.paintera.state.LabelSourceState;
 import org.janelia.saalfeldlab.paintera.state.SourceState;
 import org.janelia.saalfeldlab.paintera.stream.AbstractHighlightingARGBStream;
@@ -40,16 +41,12 @@ public class ShowOnlySelectedInStreamToggle
 	{
 		Optional
 				.ofNullable(currentState.get())
-				.filter(state -> state instanceof LabelSourceState<?, ?>)
-				.map(state -> (LabelSourceState<?, ?>) state)
-				.ifPresent(this::toggleNonSelectionVisibility);
+				.filter(state -> state instanceof HasHighlightingStreamConverter<?>)
+				.ifPresent(state -> this.toggleNonSelectionVisibility(state.getDataSource(), ((HasHighlightingStreamConverter<?>)state).highlightingStreamConverter().getStream()));
 	}
 
-	private void toggleNonSelectionVisibility(final LabelSourceState<?, ?> state)
+	private void toggleNonSelectionVisibility(Source<?> source, AbstractHighlightingARGBStream stream)
 	{
-		final AbstractHighlightingARGBStream stream = state.converter().getStream();
-		final Source<?>                      source = state.getDataSource();
-
 		if (alphaMemory.contains(source))
 		{
 			stream.setAlpha(alphaMemory.remove(source));

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFill.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFill.java
@@ -39,6 +39,7 @@ import org.janelia.saalfeldlab.paintera.data.mask.Mask;
 import org.janelia.saalfeldlab.paintera.data.mask.exception.MaskInUse;
 import org.janelia.saalfeldlab.paintera.data.mask.MaskInfo;
 import org.janelia.saalfeldlab.paintera.data.mask.MaskedSource;
+import org.janelia.saalfeldlab.paintera.state.HasMaskForLabel;
 import org.janelia.saalfeldlab.paintera.state.LabelSourceState;
 import org.janelia.saalfeldlab.paintera.state.SourceInfo;
 import org.janelia.saalfeldlab.paintera.state.SourceState;
@@ -109,15 +110,15 @@ public class FloodFill
 
 		final SourceState<?, ?> currentSourceState = sourceInfo.getState(currentSource);
 
-		if (!(currentSourceState instanceof LabelSourceState<?, ?>))
+		if (!(currentSourceState instanceof HasMaskForLabel<?>))
 		{
-			LOG.info("Selected source is not a label source -- will not fill");
+			LOG.info("Selected source cannot provide mask for label -- will not fill");
 			return;
 		}
 
-		final LabelSourceState<?, ?> state = (LabelSourceState<?, ?>) currentSourceState;
+		final HasMaskForLabel<?> hasMaskForLabel = (HasMaskForLabel<?>) currentSourceState;
 
-		if (!state.isVisibleProperty().get())
+		if (!currentSourceState.isVisibleProperty().get())
 		{
 			LOG.info("Selected source is not visible -- will not fill");
 			return;
@@ -129,7 +130,7 @@ public class FloodFill
 			return;
 		}
 
-		final LongFunction<?> maskForLabel = state.maskForLabel();
+		final LongFunction<?> maskForLabel = hasMaskForLabel.maskForLabel();
 		if (maskForLabel == null)
 		{
 			LOG.info("Cannot generate boolean mask for this source -- will not fill");

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFill2D.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFill2D.java
@@ -38,6 +38,7 @@ import org.janelia.saalfeldlab.paintera.data.mask.Mask;
 import org.janelia.saalfeldlab.paintera.data.mask.exception.MaskInUse;
 import org.janelia.saalfeldlab.paintera.data.mask.MaskInfo;
 import org.janelia.saalfeldlab.paintera.data.mask.MaskedSource;
+import org.janelia.saalfeldlab.paintera.state.HasMaskForLabel;
 import org.janelia.saalfeldlab.paintera.state.LabelSourceState;
 import org.janelia.saalfeldlab.paintera.state.SourceInfo;
 import org.janelia.saalfeldlab.paintera.state.SourceState;
@@ -111,15 +112,15 @@ public class FloodFill2D
 				.getState(
 				currentSource);
 
-		if (!(currentSourceState instanceof LabelSourceState<?, ?>))
+		if (!(currentSourceState instanceof HasMaskForLabel<?>))
 		{
-			LOG.info("Selected source is not a label source -- will not fill");
+			LOG.info("Selected source cannot provide mask for label -- will not fill");
 			return;
 		}
 
-		final LabelSourceState<T, ?> state = (LabelSourceState<T, ?>) currentSourceState;
+		final HasMaskForLabel<T> hasMaskForLabel = (HasMaskForLabel<T>) currentSourceState;
 
-		if (!state.isVisibleProperty().get())
+		if (!currentSourceState.isVisibleProperty().get())
 		{
 			LOG.info("Selected source is not visible -- will not fill");
 			return;
@@ -131,7 +132,7 @@ public class FloodFill2D
 			return;
 		}
 
-		final LongFunction<Converter<T, BoolType>> maskForLabel = state.maskForLabel();
+		final LongFunction<Converter<T, BoolType>> maskForLabel = hasMaskForLabel.maskForLabel();
 		if (maskForLabel == null)
 		{
 			LOG.info("Cannot generate boolean mask for this source -- will not fill");
@@ -142,9 +143,9 @@ public class FloodFill2D
 
 		final T t = source.getDataType();
 
-		if (!(t instanceof RealType<?>) && !(t instanceof LabelMultisetType))
+		if (t == null)
 		{
-			LOG.debug("Data type is not real or LabelMultisetType type -- will not fill");
+			LOG.debug("Data type is null -- will not fill");
 			return;
 		}
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/data/n5/N5DataSourceDeserializer.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/data/n5/N5DataSourceDeserializer.java
@@ -50,14 +50,12 @@ public class N5DataSourceDeserializer implements JsonDeserializer<N5DataSource<?
 		{
 			LOG.debug("Deserializing from {}", el);
 			final String            clazz     = el.getAsJsonObject().get(META_CLASS_KEY).getAsString();
-			final N5Meta            meta      = (N5Meta) context.deserialize(
+			final N5Meta            meta      = context.deserialize(
 					el.getAsJsonObject().get(META_KEY),
-					Class.forName(clazz)
-			                                                                );
+					Class.forName(clazz));
 			final AffineTransform3D transform = context.deserialize(
 					el.getAsJsonObject().get(TRANSFORM_KEY),
-					AffineTransform3D.class
-			                                                       );
+					AffineTransform3D.class);
 
 			LOG.debug("Deserialized transform: {}", transform);
 			return new N5DataSource<>(meta, transform, globalCache, "", priority);

--- a/src/main/java/org/janelia/saalfeldlab/paintera/id/IdService.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/id/IdService.java
@@ -84,6 +84,29 @@ public interface IdService
 		return new Dummy();
 	}
 
+	class IdServiceNotProvided implements IdService {
+
+		@Override
+		public void invalidate(long id) {
+			throw new UnsupportedOperationException(String.format("%s does not support any operation at all!", this.getClass().getName()));
+		}
+
+		@Override
+		public long next() {
+			throw new UnsupportedOperationException(String.format("%s does not support any operation at all!", this.getClass().getName()));
+		}
+
+		@Override
+		public long[] next(int n) {
+			throw new UnsupportedOperationException(String.format("%s does not support any operation at all!", this.getClass().getName()));
+		}
+
+		@Override
+		public boolean isInvalidated(long id) {
+			throw new UnsupportedOperationException(String.format("%s does not support any operation at all!", this.getClass().getName()));
+		}
+	}
+
 	public static class Dummy implements IdService
 	{
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/serialization/sourcestate/LabelSourceStateDeserializer.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/serialization/sourcestate/LabelSourceStateDeserializer.java
@@ -127,7 +127,7 @@ public class LabelSourceStateDeserializer<C extends HighlightingStreamConverter<
 				.map(el -> (long[]) context.deserialize(el, long[].class))
 				.orElseGet(() -> new long[] {});
 		final JsonObject assignmentMap = map.get(ASSIGNMENT_KEY).getAsJsonObject();
-		final IdService  idService     = N5Helpers.idService(writer, dataset);
+		final IdService  idService     = getIdService(writer, dataset);
 		final FragmentSegmentAssignmentState assignment = N5Helpers.assignments(
 				writer,
 				dataset
@@ -196,6 +196,20 @@ public class LabelSourceStateDeserializer<C extends HighlightingStreamConverter<
 			state.managedMeshSettings().set(meshSettings);
 		}
 		return state;
+
+	}
+
+	private static IdService getIdService(final N5Writer writer, final String dataset) throws IOException {
+		try {
+			return N5Helpers.idService(writer, dataset);
+		}
+		catch (final N5Helpers.MaxIDNotSpecified e) {
+			LOG.warn("Max id was not specified -- will not use an id service. " +
+					"If that is not the intended behavior, please check the attributes of data set {}",
+					dataset,
+					e);
+			return new IdService.IdServiceNotProvided();
+		}
 
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/HasFragmentSegmentAssignments.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/HasFragmentSegmentAssignments.java
@@ -1,0 +1,8 @@
+package org.janelia.saalfeldlab.paintera.state;
+
+import org.janelia.saalfeldlab.paintera.control.assignment.FragmentSegmentAssignmentState;
+
+public interface HasFragmentSegmentAssignments {
+
+	public FragmentSegmentAssignmentState assignment();
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/HasHighlightingStreamConverter.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/HasHighlightingStreamConverter.java
@@ -1,0 +1,9 @@
+package org.janelia.saalfeldlab.paintera.state;
+
+import org.janelia.saalfeldlab.paintera.stream.HighlightingStreamConverter;
+
+public interface HasHighlightingStreamConverter<T> {
+
+	HighlightingStreamConverter<T> highlightingStreamConverter();
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/HasIdService.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/HasIdService.java
@@ -1,0 +1,9 @@
+package org.janelia.saalfeldlab.paintera.state;
+
+import org.janelia.saalfeldlab.paintera.id.IdService;
+
+public interface HasIdService {
+
+	IdService idService();
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/HasLockedSegments.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/HasLockedSegments.java
@@ -1,0 +1,9 @@
+package org.janelia.saalfeldlab.paintera.state;
+
+import org.janelia.saalfeldlab.paintera.control.lock.LockedSegmentsState;
+
+public interface HasLockedSegments {
+
+	LockedSegmentsState lockedSegments();
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/HasMaskForLabel.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/HasMaskForLabel.java
@@ -1,0 +1,13 @@
+package org.janelia.saalfeldlab.paintera.state;
+
+import net.imglib2.converter.Converter;
+import net.imglib2.type.logic.BoolType;
+import net.imglib2.type.numeric.IntegerType;
+
+import java.util.function.LongFunction;
+
+public interface HasMaskForLabel<T extends IntegerType<T>> {
+
+	LongFunction<Converter<T, BoolType>> maskForLabel();
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/HasMeshCache.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/HasMeshCache.java
@@ -5,9 +5,9 @@ import java.util.function.Predicate;
 public interface HasMeshCache<T>
 {
 
-	public void invalidateAll();
+	void invalidateAll();
 
-	public default void invalidateMatching(final Predicate<T> filter)
+	default void invalidateMatching(final Predicate<T> filter)
 	{
 		throw new UnsupportedOperationException("Not implemented yet. Requires updates on imglib2 cache first");
 	}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/HasMeshes.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/HasMeshes.java
@@ -6,8 +6,10 @@ import org.janelia.saalfeldlab.paintera.meshes.MeshManager;
 public interface HasMeshes<T>
 {
 
-	public MeshManager<Long, T> meshManager();
+	MeshManager<Long, T> meshManager();
 
-	public ManagedMeshSettings managedMeshSettings();
+	ManagedMeshSettings managedMeshSettings();
+
+	void refreshMeshes();
 
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/HasSelectedIds.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/HasSelectedIds.java
@@ -1,0 +1,9 @@
+package org.janelia.saalfeldlab.paintera.state;
+
+import org.janelia.saalfeldlab.paintera.control.selection.SelectedIds;
+
+public interface HasSelectedIds {
+
+	SelectedIds selectedIds();
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceState.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceState.java
@@ -58,7 +58,13 @@ public class LabelSourceState<D extends IntegerType<D>, T>
 		MinimalSourceState<D, T, DataSource<D, T>, HighlightingStreamConverter<T>>
 		implements
 		HasMeshes<TLongHashSet>,
-		HasMeshCache<TLongHashSet>
+		HasMeshCache<TLongHashSet>,
+		HasIdService,
+		HasSelectedIds,
+		HasHighlightingStreamConverter<T>,
+		HasMaskForLabel<D>,
+		HasFragmentSegmentAssignments,
+		HasLockedSegments
 {
 
 	private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -155,6 +161,7 @@ public class LabelSourceState<D extends IntegerType<D>, T>
 //		this.clearBlockCaches.run();
 	}
 
+	@Override
 	public void refreshMeshes()
 	{
 		this.invalidateAll();
@@ -163,6 +170,11 @@ public class LabelSourceState<D extends IntegerType<D>, T>
 		this.selectedIds.deactivateAll();
 		this.selectedIds.activate(selection);
 		this.selectedIds.activateAlso(lastSelection);
+	}
+
+	@Override
+	public HighlightingStreamConverter<T> highlightingStreamConverter() {
+		return converter();
 	}
 
 	public static <D extends IntegerType<D> & NativeType<D>, T extends Volatile<D> & IntegerType<T>>

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/SourceInfo.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/SourceInfo.java
@@ -247,23 +247,15 @@ public class SourceInfo
 		}
 
 		this.states.remove(source);
-		if (state != null && state instanceof LabelSourceState<?, ?>)
+		if (state instanceof HasMeshes)
 		{
-			((LabelSourceState<?, ?>) state).meshManager().removeAllMeshes();
+			((HasMeshes) state).meshManager().removeAllMeshes();
 		}
 		this.sources.remove(source);
 		this.currentSource.set(this.sources.size() == 0 ? null : this.sources.get(Math.max(currentSourceIndex - 1,
 				0)));
 		this.composites.remove(source);
 		this.removedSources.add(source);
-	}
-
-	public synchronized Optional<FragmentSegmentAssignmentState> assignment(final Source<?> source)
-	{
-		final SourceState<?, ?> state = states.get(source);
-		return state instanceof LabelSourceState<?, ?>
-		       ? Optional.of(((LabelSourceState<?, ?>) state).assignment())
-		       : Optional.empty();
 	}
 
 	public SourceState<?, ?> getState(final Source<?> source)

--- a/src/main/java/org/janelia/saalfeldlab/paintera/ui/dialogs/create/CreateDatasetHandler.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/ui/dialogs/create/CreateDatasetHandler.java
@@ -26,8 +26,11 @@ import org.janelia.saalfeldlab.paintera.stream.HighlightingStreamConverter;
 import org.janelia.saalfeldlab.paintera.stream.ModalGoldenAngleSaturatedHighlightingARGBStream;
 import org.janelia.saalfeldlab.util.MakeUnchecked;
 import org.janelia.saalfeldlab.util.n5.N5Helpers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -35,6 +38,8 @@ import java.util.stream.IntStream;
 
 public class CreateDatasetHandler
 {
+
+	private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
 	public static void createAndAddNewLabelDataset(
 			final PainteraBaseView pbv,
@@ -82,10 +87,9 @@ public class CreateDatasetHandler
 					canvasDirUpdater.get(),
 					canvasDirUpdater,
 					commitCanvas,
-					pbv.getMeshWorkerExecutorService()
-			                                                                                        );
+					pbv.getMeshWorkerExecutorService());
 
-			final IdService                      idService      = N5Helpers.idService(meta.writer(), group);
+			final IdService                      idService      = N5Helpers.idService(meta.writer(), group, 1);
 			final SelectedIds                    selectedIds    = new SelectedIds();
 			final FragmentSegmentAssignmentState assignment     = N5Helpers.assignments(meta.writer(), group);
 			final LockedSegmentsOnlyLocal        lockedSegments = new LockedSegmentsOnlyLocal(locked -> {});
@@ -127,6 +131,7 @@ public class CreateDatasetHandler
 					selectedIds,
 					meshManager);
 
+			LOG.warn("Adding label state {}", state);
 			pbv.addLabelSource(state);
 		}
 	}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/ui/opendialog/menu/n5/GenericBackendDialogN5.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/ui/opendialog/menu/n5/GenericBackendDialogN5.java
@@ -4,9 +4,14 @@ import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.binding.ObjectBinding;
 import javafx.beans.binding.StringBinding;
+import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.LongProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleLongProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
@@ -18,27 +23,43 @@ import javafx.collections.ObservableList;
 import javafx.event.Event;
 import javafx.scene.Group;
 import javafx.scene.Node;
+import javafx.scene.control.Alert;
 import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
 import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextArea;
 import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+import net.imglib2.Cursor;
 import net.imglib2.Interval;
 import net.imglib2.Volatile;
+import net.imglib2.algorithm.util.Grids;
+import net.imglib2.cache.img.CachedCellImg;
 import net.imglib2.converter.ARGBColorConverter.InvertingImp1;
 import net.imglib2.converter.ARGBCompositeColorConverter;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.type.NativeType;
+import net.imglib2.type.label.LabelUtils;
 import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.volatiles.AbstractVolatileRealType;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.Views;
 import net.imglib2.view.composite.RealComposite;
+import org.controlsfx.control.StatusBar;
 import org.janelia.saalfeldlab.fx.ui.ExceptionNode;
+import org.janelia.saalfeldlab.fx.ui.NumberField;
+import org.janelia.saalfeldlab.fx.ui.ObjectField;
 import org.janelia.saalfeldlab.fx.util.InvokeOnJavaFXApplicationThread;
 import org.janelia.saalfeldlab.labels.blocks.LabelBlockLookup;
 import org.janelia.saalfeldlab.n5.DataType;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.N5Writer;
+import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
 import org.janelia.saalfeldlab.paintera.cache.global.GlobalCache;
 import org.janelia.saalfeldlab.paintera.composition.ARGBCompositeAlphaAdd;
 import org.janelia.saalfeldlab.paintera.composition.ARGBCompositeAlphaYCbCr;
@@ -55,6 +76,7 @@ import org.janelia.saalfeldlab.paintera.data.n5.N5ChannelDataSource;
 import org.janelia.saalfeldlab.paintera.data.n5.N5Meta;
 import org.janelia.saalfeldlab.paintera.data.n5.VolatileWithSet;
 import org.janelia.saalfeldlab.paintera.id.IdService;
+import org.janelia.saalfeldlab.paintera.id.N5IdService;
 import org.janelia.saalfeldlab.paintera.meshes.InterruptibleFunction;
 import org.janelia.saalfeldlab.paintera.meshes.MeshManagerWithAssignmentForSegments;
 import org.janelia.saalfeldlab.paintera.state.ChannelSourceState;
@@ -62,9 +84,11 @@ import org.janelia.saalfeldlab.paintera.state.LabelSourceState;
 import org.janelia.saalfeldlab.paintera.state.RawSourceState;
 import org.janelia.saalfeldlab.paintera.stream.HighlightingStreamConverter;
 import org.janelia.saalfeldlab.paintera.stream.ModalGoldenAngleSaturatedHighlightingARGBStream;
+import org.janelia.saalfeldlab.paintera.ui.PainteraAlerts;
 import org.janelia.saalfeldlab.paintera.ui.opendialog.DatasetInfo;
 import org.janelia.saalfeldlab.paintera.ui.opendialog.meta.ChannelInformation;
 import org.janelia.saalfeldlab.util.MakeUnchecked;
+import org.janelia.saalfeldlab.util.NamedThreadFactory;
 import org.janelia.saalfeldlab.util.n5.N5Data;
 import org.janelia.saalfeldlab.util.n5.N5Helpers;
 import org.janelia.saalfeldlab.util.n5.N5Types;
@@ -78,10 +102,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.IntFunction;
+import java.util.function.LongConsumer;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
@@ -229,8 +258,7 @@ public class GenericBackendDialogN5
 		dataset.addListener((obs, oldv, newv) -> Optional.ofNullable(newv).filter(v -> v.length() > 0).ifPresent(v ->
 				updateDatasetInfo(
 				v,
-				this.datasetInfo
-		                                                                                                                               )));
+				this.datasetInfo)));
 
 		this.isN5Valid.addListener((obs, oldv, newv) -> {
 			synchronized (directoryTraversalThreads)
@@ -323,7 +351,122 @@ public class GenericBackendDialogN5
 
 	public IdService idService() throws IOException
 	{
-		return N5Helpers.idService(this.n5.get(), this.dataset.get());
+		try {
+			LOG.warn("Getting id service for {} -- {}", this.n5.get(), this.dataset.get());
+			return N5Helpers.idService(this.n5.get(), this.dataset.get());
+		} catch (final N5Helpers.MaxIDNotSpecified e) {
+			final Alert alert = PainteraAlerts.alert(Alert.AlertType.CONFIRMATION);
+			alert.setHeaderText("maxId not specified in dataset.");
+			final TextArea ta = new TextArea("Could not read maxId attribute from data set. " +
+					"You can specify the max id manually, or read it from the data set (this can take a long time if your data is big).\n" +
+					"Alternatively, press cancel to load the data set without an id service. " +
+					"Fragment-segment-assignments and selecting new (wrt to the data) labels require an id service " +
+					"and will not be available if you press cancel.");
+			ta.setEditable(false);
+			ta.setWrapText(true);
+			final NumberField<LongProperty> nextIdField = NumberField.longField(0, v -> true, ObjectField.SubmitOn.ENTER_PRESSED, ObjectField.SubmitOn.FOCUS_LOST);
+			final Button scanButton = new Button("Scan Data");
+			scanButton.setOnAction(event -> {
+				event.consume();
+				try {
+					findMaxId(this.n5.get(), this.dataset.getValue(), nextIdField.valueProperty()::set);
+				} catch (IOException e1) {
+					throw new RuntimeException(e1);
+				}
+			});
+			final HBox maxIdBox = new HBox(new Label("Max Id:"), nextIdField.textField(), scanButton);
+			HBox.setHgrow(nextIdField.textField(), Priority.ALWAYS);
+			alert.getDialogPane().setContent(new VBox(ta, maxIdBox));
+			final Optional<ButtonType> bt = alert.showAndWait();
+			if (bt.isPresent() && ButtonType.OK.equals(bt.get())) {
+				long maxId = nextIdField.valueProperty().get() + 1;
+				this.n5.get().setAttribute(dataset.get(), "maxId", maxId);
+				return new N5IdService(this.n5.get(), this.dataset.get(), maxId);
+			}
+			else
+				return new IdService.IdServiceNotProvided();
+		}
+	}
+
+	private static <I extends IntegerType<I> & NativeType<I>> void findMaxId(
+			final N5Reader reader,
+			String dataset,
+			final LongConsumer maxIdTarget
+			) throws IOException {
+		final int numProcessors = Runtime.getRuntime().availableProcessors();
+		final ExecutorService es = Executors.newFixedThreadPool(numProcessors, new NamedThreadFactory("max-id-discovery-%d", true));
+		dataset = N5Helpers.isPainteraDataset(reader, dataset) ? dataset + "/data" : dataset;
+		dataset = N5Helpers.isMultiScale(reader, dataset) ? N5Helpers.getFinestLevel(reader, dataset) : dataset;
+		final boolean isLabelMultiset = N5Helpers.getBooleanAttribute(reader, dataset, N5Helpers.IS_LABEL_MULTISET_KEY, false);
+		final CachedCellImg<I, ?> img = isLabelMultiset ? (CachedCellImg<I, ?>) (CachedCellImg) LabelUtils.openVolatile(reader, dataset) : (CachedCellImg<I, ?>)N5Utils.open(reader, dataset);
+		final int[] blockSize = new  int[img.numDimensions()];
+		img.getCellGrid().cellDimensions(blockSize);
+		final List<Interval> blocks = Grids.collectAllContainedIntervals(img.getCellGrid().getImgDimensions(), blockSize);
+		final IntegerProperty completedTasks = new SimpleIntegerProperty(0);
+		final LongProperty maxId = new SimpleLongProperty(0);
+		final BooleanProperty wasCanceled = new SimpleBooleanProperty(false);
+		LOG.debug("Scanning for max id over {} blocks of size {} (total size {}).", blocks.size(), blockSize, img.getCellGrid().getImgDimensions());
+		final Thread t = new Thread(() -> {
+			List<Callable<Long>> tasks = new ArrayList<>();
+			for (final Interval block : blocks) {
+				tasks.add(() -> {
+					long localMaxId = 0;
+					try {
+						final IntervalView<I> interval = Views.interval(img, block);
+						final Cursor<I> cursor = interval.cursor();
+						while (cursor.hasNext() && !wasCanceled.get()) {
+							final long id = cursor.next().getIntegerLong();
+							if (id > localMaxId)
+								localMaxId = id;
+						}
+						return localMaxId;
+					}
+					finally {
+						synchronized (completedTasks) {
+							if (!wasCanceled.get()) {
+								LOG.trace("Incrementing completed tasks ({}/{}) and maxId ({}) with {}", completedTasks, blocks.size(), maxId, localMaxId);
+								maxId.setValue(Math.max(maxId.getValue(), localMaxId));
+								completedTasks.set(completedTasks.get() + 1);
+							}
+						}
+					}
+				});
+			}
+			try {
+				final List<Future<Long>> futures = es.invokeAll(tasks);
+				for (final Future<Long> future : futures) {
+					final Long id = future.get();
+				}
+			} catch (final InterruptedException | ExecutionException e) {
+				synchronized (completedTasks) {
+					completedTasks.set(-1);
+					wasCanceled.set(true);
+				}
+				LOG.error("Was interrupted while finding max id.", e);
+			}
+		});
+		t.setName("max-id-discovery-main-thread");
+		t.setDaemon(true);
+		t.start();
+		final Alert alert = PainteraAlerts.alert(Alert.AlertType.CONFIRMATION, true);
+		alert.setWidth(500);
+		alert.setHeaderText("Finding max id...");
+		final BooleanBinding stillRuning = Bindings.createBooleanBinding(() -> completedTasks.get() < blocks.size(), completedTasks);
+		alert.getDialogPane().lookupButton(ButtonType.OK).disableProperty().bind(stillRuning);
+		final StatusBar statusBar = new StatusBar();
+		completedTasks.addListener((obs, oldv, newv) -> InvokeOnJavaFXApplicationThread.invoke(() -> statusBar.setProgress(newv.doubleValue() / blocks.size())));
+		completedTasks.addListener((obs, oldv, newv) -> InvokeOnJavaFXApplicationThread.invoke(() -> statusBar.setText(String.format("%s/%d", newv, blocks.size()))));
+		alert.getDialogPane().setContent(statusBar);
+		wasCanceled.addListener((obs, oldv, newv) -> InvokeOnJavaFXApplicationThread.invoke(() -> alert.setHeaderText("Cancelled")));
+		completedTasks.addListener((obs, oldv, newv) -> InvokeOnJavaFXApplicationThread.invoke(() -> alert.setHeaderText(newv.intValue() < blocks.size() ? "Finding max id: " + maxId.getValue() : "Found max id: " + maxId.getValue())));
+		final Optional<ButtonType> bt = alert.showAndWait();
+		if (bt.isPresent() && ButtonType.OK.equals(bt.get())) {
+			LOG.warn("Setting max id to {}", maxId.get());
+			maxIdTarget.accept(maxId.get());
+		} else {
+			wasCanceled.set(true);
+		}
+
 	}
 
 	public ChannelInformation getChannelInformation()

--- a/src/main/java/org/janelia/saalfeldlab/util/n5/N5Helpers.java
+++ b/src/main/java/org/janelia/saalfeldlab/util/n5/N5Helpers.java
@@ -383,7 +383,7 @@ public class N5Helpers
 					}
 					if (isMipmapGroup)
 					{
-						LOG.debug(
+						LOG.warn(
 								"Found multi-scale group without {} tag. Implicit multi-scale detection will be " +
 										"removed in the future. Please add \"{}\":{} to attributes.json.",
 								MULTI_SCALE_KEY,
@@ -405,7 +405,7 @@ public class N5Helpers
 					{
 						final String groupPathName = pathName + "/" + group;
 						final int    numThreads    = counter.incrementAndGet();
-						LOG.debug("entering {}, {} threads created", groupPathName, numThreads);
+						LOG.trace("entering {}, {} threads created", groupPathName, numThreads);
 						exec.submit(() -> discoverSubdirectories(n5, groupPathName, datasets, exec, counter));
 					}
 				}
@@ -415,7 +415,7 @@ public class N5Helpers
 			LOG.debug(e.toString(), e);
 		}
 		final int numThreads = counter.decrementAndGet();
-		LOG.debug("leaving {}, {} threads remaining", pathName, numThreads);
+		LOG.trace("leaving {}, {} threads remaining", pathName, numThreads);
 	}
 
 


### PR DESCRIPTION
When trying to open a Label dataset that has no `maxId` attribute, show dialog, with choices
 1. manually enter `maxId`,
 2. scan data for `maxId`, or
 3. not use an `IdService` (and subsequently no painting of new label and no merge/detach actions).

This should fix #155, albeit solved a little different than proposed in the issue.