### PR TITLE
Build fixes: Eclipse Oxygen, Oracle JDK 10

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/fx/MenuFromHandlers.java
+++ b/src/main/java/org/janelia/saalfeldlab/fx/MenuFromHandlers.java
@@ -144,29 +144,4 @@ public class MenuFromHandlers {
 		}
 
 	}
-
-	public static void main(String[] args)
-	{
-		PlatformImpl.startup(() -> {});
-
-		Pair<String, Consumer<ActionEvent>> h1 = new Pair<>("bla>3>4", e -> System.out.println("bla 3 4"));
-		Pair<String, Consumer<ActionEvent>> h2 = new Pair<>("bla>3", e -> System.out.println("bla 3"));
-		Pair<String, Consumer<ActionEvent>> h3 = new Pair<>("tl", e -> System.out.println("top level"));
-
-		ContextMenu menu = new MenuFromHandlers(Arrays.asList(h1, h2, h3)).asContextMenu("MENU");
-
-		Platform.runLater(() -> {
-			Stage stage = new Stage();
-			StackPane root = new StackPane();
-			root.addEventHandler(MouseEvent.MOUSE_PRESSED, e -> menu.show(root, e.getScreenX(), e.getScreenY()));
-			Scene scene = new Scene(root, 800, 600);
-			stage.setScene(scene);
-			stage.show();
-		});
-
-
-	}
-
-
-
 }

--- a/src/main/java/org/janelia/saalfeldlab/fx/MenuFromHandlers.java
+++ b/src/main/java/org/janelia/saalfeldlab/fx/MenuFromHandlers.java
@@ -149,12 +149,11 @@ public class MenuFromHandlers {
 	{
 		PlatformImpl.startup(() -> {});
 
-		ContextMenu menu = new MenuFromHandlers(Arrays.asList(
-				new Pair<>("bla>3>4", e -> System.out.println("bla 3 4")),
-				new Pair<>("bla>3", e -> System.out.println("bla 3")),
-				new Pair<>("tl", e -> System.out.println("top level"))
-		)).asContextMenu("MENU");
+		Pair<String, Consumer<ActionEvent>> h1 = new Pair<>("bla>3>4", e -> System.out.println("bla 3 4"));
+		Pair<String, Consumer<ActionEvent>> h2 = new Pair<>("bla>3", e -> System.out.println("bla 3"));
+		Pair<String, Consumer<ActionEvent>> h3 = new Pair<>("tl", e -> System.out.println("top level"));
 
+		ContextMenu menu = new MenuFromHandlers(Arrays.asList(h1, h2, h3)).asContextMenu("MENU");
 
 		Platform.runLater(() -> {
 			Stage stage = new Stage();

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/IntersectingSourceState.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/IntersectingSourceState.java
@@ -62,6 +62,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -132,7 +133,7 @@ public class IntersectingSourceState
 				new SimpleIntegerProperty(),
 				manager,
 				workers,
-				TLongHashSet::toArray,
+				(Function<TLongHashSet, long[]>)TLongHashSet::toArray,
 				hs -> hs
 		);
 		final ObjectBinding<Color> colorProperty = Bindings.createObjectBinding(


### PR DESCRIPTION
This PR fixes the build in the latest version of Eclipse Oxygen & Oracle JDK 10. The reason is likely a compiler bug because the code was certainly valid but the implicit conversions seemed to trigger false positive compiler errors.