### PR TITLE
Add --channels option to PainteraShowContainer

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/PainteraShowContainer.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/PainteraShowContainer.java
@@ -84,6 +84,8 @@ import picocli.CommandLine;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -96,6 +98,7 @@ import java.util.function.IntFunction;
 import java.util.function.LongConsumer;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 public class PainteraShowContainer extends Application {
 
@@ -171,7 +174,10 @@ public class PainteraShowContainer extends Application {
 		}
 
 		for (N5Meta channelMeta : channelDatasets) {
-			addChannelSource(viewer.baseView, channelMeta, clArgs.revertArrayAttributes, clArgs.channelAxis, clArgs.maxNumChannels);
+			if (clArgs.channels == null)
+				addChannelSource(viewer.baseView, channelMeta, clArgs.revertArrayAttributes, clArgs.channelAxis, clArgs.maxNumChannels);
+			else
+				addChannelSource(viewer.baseView, channelMeta, clArgs.revertArrayAttributes, clArgs.channelAxis, clArgs.channels);
 		}
 
 		for (final N5Meta labelMeta : labelDatasets) {
@@ -208,6 +214,27 @@ public class PainteraShowContainer extends Application {
 
 		@CommandLine.Option(names = {"--height"})
 		Integer height = 900;
+
+		@CommandLine.Option(names = {"--channels"}, arity = "1..*", converter = ChannelListConverter.class)
+		List<long[]> channels = null;
+
+		public static final class ChannelListConverter implements CommandLine.ITypeConverter<long[]> {
+
+			private final String splitString;
+
+			public ChannelListConverter() {
+				this(",");
+			}
+
+			public ChannelListConverter(String splitString) {
+				this.splitString = splitString;
+			}
+
+			@Override
+			public long[] convert(String s) throws Exception {
+				return Stream.of(s.split(this.splitString)).mapToLong(Long::parseLong).toArray();
+			}
+		}
 	}
 
 	/* *************************************************** */
@@ -406,6 +433,60 @@ public class PainteraShowContainer extends Application {
 					cmin,
 					cmax,
 					false);
+			ARGBCompositeColorConverter<V, RealComposite<V>, VolatileWithSet<RealComposite<V>>> conv = ARGBCompositeColorConverter.imp0((int) source.numChannels());
+
+			ChannelSourceState<T, V, RealComposite<V>, VolatileWithSet<RealComposite<V>>> state = new ChannelSourceState<>(
+					source,
+					conv,
+					new ARGBCompositeAlphaAdd(),
+					source.getName());
+
+
+			Set<String> attrs = meta.writer().listAttributes(meta.dataset()).keySet();
+			if (attrs.contains(VALUE_RANGE_KEY)) {
+				final double[] valueRange = meta.writer().getAttribute(meta.dataset(), VALUE_RANGE_KEY, double[].class);
+				final double min = valueRange[0];
+				final double max = valueRange[1];
+				IntStream.range(0, conv.numChannels()).mapToObj(conv::minProperty).forEach(p -> p.set(min));
+				IntStream.range(0, conv.numChannels()).mapToObj(conv::maxProperty).forEach(p -> p.set(max));
+			} else {
+				T t = source.getDataType().get(0);
+				if (t instanceof IntegerType<?>) {
+					for (int channel = 0; channel < conv.numChannels(); ++channel) {
+						conv.minProperty(channel).set(t.getMinValue());
+						conv.maxProperty(channel).set(t.getMaxValue());
+					}
+				} else {
+					for (int channel = 0; channel < conv.numChannels(); ++channel) {
+						conv.minProperty(channel).set(0.0);
+						conv.maxProperty(channel).set(1.0);
+					}
+				}
+			}
+			viewer.addState(state);
+		}
+	}
+
+	private static <T extends RealType<T> & NativeType<T>, V extends AbstractVolatileRealType<T, V> & NativeType<V>> void addChannelSource(
+			final PainteraBaseView viewer,
+			final N5Meta meta,
+			final boolean revertArrayAttributes,
+			final int channelDimension,
+			final Collection<? extends long[]> channelLists
+	) throws IOException, DataTypeNotSupported {
+
+		LOG.info("Adding channel source {}", meta);
+
+		for (long[] channels : channelLists) {
+
+			N5ChannelDataSource<T, V> source = N5ChannelDataSource.zeroExtended(
+					meta,
+					N5Helpers.getTransform(meta.writer(), meta.dataset(), revertArrayAttributes),
+					viewer.getGlobalCache(),
+					String.format("%s-channels-%s", meta.dataset(), Arrays.toString(channels)),
+					viewer.getGlobalCache().getNumPriorities() - 1,
+					channelDimension,
+					channels);
 			ARGBCompositeColorConverter<V, RealComposite<V>, VolatileWithSet<RealComposite<V>>> conv = ARGBCompositeColorConverter.imp0((int) source.numChannels());
 
 			ChannelSourceState<T, V, RealComposite<V>, VolatileWithSet<RealComposite<V>>> state = new ChannelSourceState<>(

--- a/src/main/java/org/janelia/saalfeldlab/paintera/PainteraTestMultiChannel.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/PainteraTestMultiChannel.java
@@ -44,7 +44,7 @@ public class PainteraTestMultiChannel extends Application {
 		final String prediction = "volumes/affinities/prediction";
 		final String loss = "volumes/loss_gradient";
 		N5HDF5Meta meta = new N5HDF5Meta(path, dataset, new int[] {64, 64, 64, 3}, true);
-		final AffineTransform3D transform = N5Helpers.getTransform(meta.reader(), meta.dataset(), true);
+		final AffineTransform3D transform = N5Helpers.getTransform(meta.writer(), meta.dataset(), true);
 		final PainteraBaseView.DefaultPainteraBaseView viewer = PainteraBaseView.defaultView();
 
 		N5ChannelDataSource<FloatType, VolatileFloatType> source = N5ChannelDataSource.zeroExtended(
@@ -60,7 +60,7 @@ public class PainteraTestMultiChannel extends Application {
 
 		N5ChannelDataSource<FloatType, VolatileFloatType> predictionSource = N5ChannelDataSource.zeroExtended(
 				new N5HDF5Meta(path, prediction, new int[] {64, 64, 64, 3}, true),
-				N5Helpers.getTransform(meta.reader(), prediction, true),
+				N5Helpers.getTransform(meta.writer(), prediction, true),
 				viewer.baseView.getGlobalCache(),
 				"prediction",
 				0,
@@ -74,9 +74,9 @@ public class PainteraTestMultiChannel extends Application {
 
 
 		DataSource<FloatType, VolatileFloatType> rawSource = N5Data.openRawAsSource(
-				meta.reader(),
+				meta.writer(),
 				raw,
-				N5Helpers.getTransform(meta.reader(), raw, true),
+				N5Helpers.getTransform(meta.writer(), raw, true),
 				viewer.baseView.getGlobalCache(),
 				0,
 				"raw");

--- a/src/main/java/org/janelia/saalfeldlab/paintera/data/n5/N5ChannelDataSourceDeserializer.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/data/n5/N5ChannelDataSourceDeserializer.java
@@ -63,11 +63,9 @@ public class N5ChannelDataSourceDeserializer implements JsonDeserializer<N5Chann
 
 			JsonObject obj = el.getAsJsonObject();
 			final int channelDimension = obj.get(N5ChannelDataSourceSerializer.CHANNEL_DIMENSION_KEY).getAsInt();
-			final long channelMin = Optional.ofNullable(obj.get(N5ChannelDataSourceSerializer.CHANNEL_MIN_KEY)).map(JsonElement::getAsLong).orElse(Long.MIN_VALUE);
-			final long channelMax = Optional.ofNullable(obj.get(N5ChannelDataSourceSerializer.CHANNEL_MAX_KEY)).map(JsonElement::getAsLong).orElse(Long.MAX_VALUE);
-			final boolean revertChannelOrder = Optional.ofNullable(obj.get(N5ChannelDataSourceSerializer.REVERT_CHANNEL_AXIS_KEY)).map(JsonElement::getAsBoolean).orElse(false);
+			final long[] channels = Optional.ofNullable(obj.get(N5ChannelDataSourceSerializer.CHANNELS_KEY)).map(e -> (long[]) context.deserialize(e, long[].class)).orElse(null);
 			LOG.debug("Deserialized transform: {}", transform);
-			return N5ChannelDataSource.zeroExtended(meta, transform, globalCache, "", priority, channelDimension, channelMin, channelMax, revertChannelOrder);
+			return N5ChannelDataSource.zeroExtended(meta, transform, globalCache, "", priority, channelDimension, channels);
 		} catch (IOException | ClassNotFoundException | DataTypeNotSupported e)
 		{
 			throw new JsonParseException(e);

--- a/src/main/java/org/janelia/saalfeldlab/paintera/data/n5/N5ChannelDataSourceSerializer.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/data/n5/N5ChannelDataSourceSerializer.java
@@ -27,11 +27,8 @@ public class N5ChannelDataSourceSerializer implements PainteraSerialization.Pain
 
 	public static final String CHANNEL_DIMENSION_KEY = "channelDimension";
 
-	public static final String CHANNEL_MIN_KEY = "channelMin";
+	public static final String CHANNELS_KEY = "channels";
 
-	public static final String CHANNEL_MAX_KEY = "channelMin";
-
-	public static final String REVERT_CHANNEL_AXIS_KEY = "revertChannelOrder";
 
 	@Override
 	public JsonElement serialize(
@@ -46,9 +43,7 @@ public class N5ChannelDataSourceSerializer implements PainteraSerialization.Pain
 		s.getSourceTransform(0, 0, transform);
 		map.add(TRANSFORM_KEY, context.serialize(transform));
 		map.addProperty(CHANNEL_DIMENSION_KEY, s.getChannelDimension());
-		map.addProperty(CHANNEL_MIN_KEY, s.getChannelMin());
-		map.addProperty(CHANNEL_MAX_KEY, s.getChannelMax());
-		map.addProperty(REVERT_CHANNEL_AXIS_KEY, s.doesRevertChannelOrder());
+		map.add(CHANNELS_KEY, context.serialize(s.getChannels()));
 		return map;
 	}
 


### PR DESCRIPTION
User can specify which channels to group via the `--channels` c1,c2,... [c1,c2,...] option. 
An example use-case is wide range affinities, where the channel dimension is ordered like this: `[z1, z2, z3, y1, y2, y3, x1, x2, x3]`. In order to visualize the channels in a meaningful way, we would like to group `z1,y1,x1`, `z2,y2,x2`, and `z3,y3,x3`. Example call:
```
PainteraShowContainer --revert-array-attributes --channels 0,3,6 1,4,7 2,5,8 /groups/saalfeld/home/hanslovskyp/experiments/quasi-isotropic/36/snapshots/batch_15001.hdf
```

This required some changes to the N5ChannelDataSource with breaking changes in the (de-)serializer. This could be handled with a legacy serializer but I strongly suggest we go with the breaking change:
 1. I am not aware of anyone using channel sources in project files (I use only `PainteraShowContainer` to look at training snapshots
 2. Updating project files is very easy: Simply add an appropriate `channels: [c1, c2, ...]` attribute to each channel source in the project.
 3. If project file is not updated, every channel source will show all channels, minimal manual editing as in (2) is required to fix that after saving
 4. We are still in pre-release and breaking changes are to be expected.

I will leave this PR unmerged for a while to see if anyone feels strongly about not breaking it.