### PR TITLE
Fix windows test bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,12 @@
 			<artifactId>throwing-function</artifactId>
 			<version>1.3</version>
 		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>1.7.25</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<developers>

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,11 @@
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>pl.touk</groupId>
+			<artifactId>throwing-function</artifactId>
+			<version>1.3</version>
+		</dependency>
 	</dependencies>
 
 	<developers>

--- a/src/main/java/org/janelia/saalfeldlab/paintera/PainteraShowContainer.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/PainteraShowContainer.java
@@ -488,7 +488,7 @@ public class PainteraShowContainer extends Application {
 		DatasetAttributes datasetAttributes = N5Helpers.isPainteraDataset(meta.writer(), meta.dataset())
 				? meta.writer().getDatasetAttributes(Paths.get(meta.dataset(), "data", "s0").toString())
 				: N5Helpers.isMultiScale(meta.writer(), meta.dataset())
-					? meta.writer().getDatasetAttributes(N5Helpers.getFinestLevel(meta.writer(), meta.dataset()))
+					? meta.writer().getDatasetAttributes(N5Helpers.getFinestLevelJoinWithGroup(meta.writer(), meta.dataset()))
 					: meta.datasetAttributes();
 		long channelDim = datasetAttributes.getDimensions()[channelDimension];
 		long channelMax = channelDim - 1;
@@ -646,7 +646,7 @@ public class PainteraShowContainer extends Application {
 		final int numProcessors = Runtime.getRuntime().availableProcessors();
 		final ExecutorService es = Executors.newFixedThreadPool(numProcessors, new NamedThreadFactory("max-id-discovery-%d", true));
 		dataset = N5Helpers.isPainteraDataset(reader, dataset) ? dataset + "/data" : dataset;
-		dataset = N5Helpers.isMultiScale(reader, dataset) ? N5Helpers.getFinestLevel(reader, dataset) : dataset;
+		dataset = N5Helpers.isMultiScale(reader, dataset) ? N5Helpers.getFinestLevelJoinWithGroup(reader, dataset) : dataset;
 		final boolean isLabelMultiset = N5Helpers.getBooleanAttribute(reader, dataset, N5Helpers.IS_LABEL_MULTISET_KEY, false);
 		final CachedCellImg<I, ?> img = isLabelMultiset ? (CachedCellImg<I, ?>) (CachedCellImg) LabelUtils.openVolatile(reader, dataset) : (CachedCellImg<I, ?>) N5Utils.open(reader, dataset);
 		final int[] blockSize = new  int[img.numDimensions()];

--- a/src/main/java/org/janelia/saalfeldlab/paintera/PainteraShowContainer.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/PainteraShowContainer.java
@@ -640,13 +640,16 @@ public class PainteraShowContainer extends Application {
 
 	private static <I extends IntegerType<I> & NativeType<I>> void findMaxId(
 			final N5Reader reader,
-			String dataset,
+			String group,
 			final LongConsumer maxIdTarget
 	) throws IOException {
 		final int numProcessors = Runtime.getRuntime().availableProcessors();
 		final ExecutorService es = Executors.newFixedThreadPool(numProcessors, new NamedThreadFactory("max-id-discovery-%d", true));
-		dataset = N5Helpers.isPainteraDataset(reader, dataset) ? dataset + "/data" : dataset;
-		dataset = N5Helpers.isMultiScale(reader, dataset) ? N5Helpers.getFinestLevelJoinWithGroup(reader, dataset) : dataset;
+		final String dataset = N5Helpers.isPainteraDataset(reader, group)
+				? group + "/data/s0"
+				: N5Helpers.isMultiScale(reader, group)
+					? N5Helpers.getFinestLevelJoinWithGroup(reader, group)
+					: group;
 		final boolean isLabelMultiset = N5Helpers.getBooleanAttribute(reader, dataset, N5Helpers.IS_LABEL_MULTISET_KEY, false);
 		final CachedCellImg<I, ?> img = isLabelMultiset ? (CachedCellImg<I, ?>) (CachedCellImg) LabelUtils.openVolatile(reader, dataset) : (CachedCellImg<I, ?>) N5Utils.open(reader, dataset);
 		final int[] blockSize = new  int[img.numDimensions()];

--- a/src/main/java/org/janelia/saalfeldlab/paintera/data/n5/CommitCanvasN5.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/data/n5/CommitCanvasN5.java
@@ -32,6 +32,7 @@ import net.imglib2.view.Views;
 import org.janelia.saalfeldlab.labels.blocks.LabelBlockLookup;
 import org.janelia.saalfeldlab.labels.downsample.WinnerTakesAll;
 import org.janelia.saalfeldlab.n5.ByteArrayDataBlock;
+import org.janelia.saalfeldlab.n5.DataBlock;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.LongArrayDataBlock;
 import org.janelia.saalfeldlab.n5.N5Reader;
@@ -542,6 +543,31 @@ public class CommitCanvasN5 implements PersistCanvas
 		return blockDiff;
 	}
 
+	private static BlockDiff createBlockDiffOldDoesNotExist(
+			final VolatileLabelMultisetArray access,
+			final int numElements
+	) {
+		return createBlockDiffOldDoesNotExist(access, numElements, new BlockDiff());
+	}
+
+	private static BlockDiff createBlockDiffOldDoesNotExist(
+			final VolatileLabelMultisetArray access,
+			final int numElements,
+			final BlockDiff blockDiff
+	) {
+		ArrayImg<LabelMultisetType, VolatileLabelMultisetArray> img = new ArrayImg<>(access, new long[]{numElements}, new LabelMultisetType().getEntitiesPerPixel());
+		img.setLinkedType(new LabelMultisetType(img));
+		return createBlockDiffOldDoesNotExist(img, blockDiff);
+	}
+
+	private static BlockDiff createBlockDiffOldDoesNotExist(
+			final Iterable<LabelMultisetType> labels,
+			final BlockDiff blockDiff
+	) {
+		labels.forEach(lmt -> lmt.entrySet().forEach(e -> blockDiff.addToNewUniqueLabels(e.getElement().id())));
+		return blockDiff;
+	}
+
 	private static <I extends IntegerType<I>> BlockDiff createBlockDiffInteger(
 			final RandomAccessibleInterval<I> oldAccess,
 			final RandomAccessibleInterval<I> newAccess)
@@ -655,9 +681,12 @@ public class CommitCanvasN5 implements PersistCanvas
 			ArrayMath.minOf3(blockMax, blockMin, blockMax);
 
 			LOG.trace("Reading old access at position {} and size {}. ({} {})", blockSpec.pos, size, blockSpec.min, blockSpec.max);
-			VolatileLabelMultisetArray oldAccess = LabelUtils.fromBytes(
-					(byte[]) n5.readBlock(targetDataset.dataset, targetDataset.attributes, blockSpec.pos).getData(),
-					(int) Intervals.numElements(size));
+			final DataBlock<?> block = n5.readBlock(targetDataset.dataset, targetDataset.attributes, blockSpec.pos);
+			VolatileLabelMultisetArray oldAccess = block != null && block.getData() instanceof byte[]
+					? LabelUtils.fromBytes(
+						(byte[]) block.getData(),
+						(int) Intervals.numElements(size))
+					: null;
 
 			VolatileLabelMultisetArray newAccess = downsampleVolatileLabelMultisetArrayAndSerialize(
 					n5,
@@ -668,7 +697,12 @@ public class CommitCanvasN5 implements PersistCanvas
 					targetMaxNumEntries,
 					size,
 					blockSpec.pos);
-			blockDiffsAt.put(targetBlock, createBlockDiff(oldAccess, newAccess, (int) Intervals.numElements(size)));
+			final int numElements = (int) Intervals.numElements(size);
+			blockDiffsAt.put(
+					targetBlock,
+					oldAccess == null
+							? createBlockDiffOldDoesNotExist(newAccess, numElements)
+							: createBlockDiff(oldAccess, newAccess, numElements));
 		}
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/data/n5/CommitCanvasN5.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/data/n5/CommitCanvasN5.java
@@ -80,7 +80,7 @@ public class CommitCanvasN5 implements PersistCanvas
 		this.isMultiscale = N5Helpers.isMultiScale(this.n5, volumetricDataGroup);
 		this.isLabelMultiset = N5Helpers.getBooleanAttribute(
 				this.n5,
-				N5Helpers.highestResolutionDataset(n5, volumetricDataGroup, this.isMultiscale),
+				this.isMultiscale ? N5Helpers.getFinestLevelJoinWithGroup(n5, volumetricDataGroup) : volumetricDataGroup,
 				N5Helpers.IS_LABEL_MULTISET_KEY,
 				false);
 	}
@@ -212,7 +212,7 @@ public class CommitCanvasN5 implements PersistCanvas
 
 			final CellGrid canvasGrid = canvas.getCellGrid();
 
-			final DatasetSpec highestResolutionDataset = DatasetSpec.of(n5, N5Helpers.highestResolutionDataset(n5, dataset));
+			final DatasetSpec highestResolutionDataset = DatasetSpec.of(n5, this.isMultiscale ? N5Helpers.getFinestLevelJoinWithGroup(n5, dataset) : dataset);
 
 			if (this.isLabelMultiset)
 				checkLabelMultisetTypeOrFail(n5, highestResolutionDataset.dataset);

--- a/src/main/java/org/janelia/saalfeldlab/paintera/ui/opendialog/menu/n5/GenericBackendDialogN5.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/ui/opendialog/menu/n5/GenericBackendDialogN5.java
@@ -406,7 +406,7 @@ public class GenericBackendDialogN5 implements Closeable
 		final int numProcessors = Runtime.getRuntime().availableProcessors();
 		final ExecutorService es = Executors.newFixedThreadPool(numProcessors, new NamedThreadFactory("max-id-discovery-%d", true));
 		dataset = N5Helpers.isPainteraDataset(reader, dataset) ? dataset + "/data" : dataset;
-		dataset = N5Helpers.isMultiScale(reader, dataset) ? N5Helpers.getFinestLevel(reader, dataset) : dataset;
+		dataset = N5Helpers.isMultiScale(reader, dataset) ? N5Helpers.getFinestLevelJoinWithGroup(reader, dataset) : dataset;
 		final boolean isLabelMultiset = N5Helpers.getBooleanAttribute(reader, dataset, N5Helpers.IS_LABEL_MULTISET_KEY, false);
 		final CachedCellImg<I, ?> img = isLabelMultiset ? (CachedCellImg<I, ?>) (CachedCellImg) LabelUtils.openVolatile(reader, dataset) : (CachedCellImg<I, ?>)N5Utils.open(reader, dataset);
 		final int[] blockSize = new  int[img.numDimensions()];

--- a/src/main/java/org/janelia/saalfeldlab/util/n5/N5Helpers.java
+++ b/src/main/java/org/janelia/saalfeldlab/util/n5/N5Helpers.java
@@ -104,7 +104,9 @@ public class N5Helpers
 	 */
 	public static boolean isPainteraDataset(final N5Reader n5, final String group) throws IOException
 	{
-		return n5.exists(group) && n5.listAttributes(group).containsKey(PAINTERA_DATA_KEY);
+		final boolean isPainteraDataset =  n5.exists(group) && n5.listAttributes(group).containsKey(PAINTERA_DATA_KEY);
+		LOG.debug("Is {}/{} Paintera dataset? {}", n5, group, isPainteraDataset);
+		return isPainteraDataset;
 	}
 
 	/**

--- a/src/main/java/org/janelia/saalfeldlab/util/n5/N5Types.java
+++ b/src/main/java/org/janelia/saalfeldlab/util/n5/N5Types.java
@@ -63,7 +63,7 @@ public class N5Types {
 	throws IOException
 	{
 		return isMultiscale
-		 	? isLabelMultisetType(n5, N5Helpers.getFinestLevel(n5, group))
+			? isLabelMultisetType(n5, N5Helpers.getFinestLevelJoinWithGroup(n5, group))
 			: Optional.ofNullable(n5.getAttribute(group, N5Helpers.IS_LABEL_MULTISET_KEY, Boolean.class)).orElse(false);
 	}
 
@@ -140,7 +140,7 @@ public class N5Types {
 	{
 		LOG.debug("Getting data type for group/dataset {}", group);
 		if (N5Helpers.isPainteraDataset(n5, group)) { return getDataType(n5, group + "/" + N5Helpers.PAINTERA_DATA_DATASET); }
-		if (N5Helpers.isMultiScale(n5, group)) { return getDataType(n5, N5Helpers.getFinestLevel(n5, group)); }
+		if (N5Helpers.isMultiScale(n5, group)) { return getDataType(n5, N5Helpers.getFinestLevelJoinWithGroup(n5, group)); }
 		return n5.getDatasetAttributes(group).getDataType();
 	}
 

--- a/src/test/java/org/janelia/saalfeldlab/paintera/data/n5/CommitCanvasN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/paintera/data/n5/CommitCanvasN5Test.java
@@ -1,0 +1,307 @@
+package org.janelia.saalfeldlab.paintera.data.n5;
+
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.cache.img.CachedCellImg;
+import net.imglib2.cache.img.CellLoader;
+import net.imglib2.cache.img.ReadOnlyCachedCellImgFactory;
+import net.imglib2.cache.img.ReadOnlyCachedCellImgOptions;
+import net.imglib2.img.cell.CellGrid;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.label.Label;
+import net.imglib2.type.label.LabelMultisetType;
+import net.imglib2.type.label.LabelUtils;
+import net.imglib2.type.label.VolatileLabelMultisetArray;
+import net.imglib2.type.numeric.integer.UnsignedLongType;
+import net.imglib2.util.Intervals;
+import net.imglib2.util.Pair;
+import net.imglib2.view.Views;
+import org.janelia.saalfeldlab.n5.DataType;
+import org.janelia.saalfeldlab.n5.DatasetAttributes;
+import org.janelia.saalfeldlab.n5.GzipCompression;
+import org.janelia.saalfeldlab.n5.N5Reader;
+import org.janelia.saalfeldlab.n5.N5Writer;
+import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
+import org.janelia.saalfeldlab.paintera.Paintera;
+import org.janelia.saalfeldlab.paintera.data.RandomAccessibleIntervalDataSource;
+import org.janelia.saalfeldlab.paintera.data.mask.persist.UnableToPersistCanvas;
+import org.janelia.saalfeldlab.util.MakeUnchecked;
+import org.janelia.saalfeldlab.util.n5.N5Helpers;
+import org.janelia.saalfeldlab.util.n5.N5TestUtil;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import pl.touk.throwing.ThrowingBiConsumer;
+import pl.touk.throwing.ThrowingBiFunction;
+import pl.touk.throwing.ThrowingFunction;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class CommitCanvasN5Test {
+
+	private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+	private static final UnsignedLongType INVALID = new UnsignedLongType(Label.INVALID);
+
+	private static final Map<String, Object> MULTISET_ATTRIBUTE = Collections.unmodifiableMap(Stream.of(1).collect(Collectors.toMap(o -> N5Helpers.LABEL_MULTISETTYPE_KEY, o -> true)));
+
+	private static final Map<String, Object> PAINTERA_DATA_ATTRIBUTE = Collections.unmodifiableMap(Stream.of(1).collect(Collectors.toMap(o -> "type", o -> "label")));
+
+	private static boolean isInvalid(final UnsignedLongType pixel) {
+		return INVALID.valueEquals(pixel);
+	}
+
+	@Test
+	public void testCommit() throws IOException, UnableToPersistCanvas {
+
+		final long[] dims = new long[] {2,3,4};
+		final int[] blockSize = new int[] {1, 2, 2};
+		final CellGrid grid = new CellGrid(dims, blockSize);
+		final CellLoader<UnsignedLongType> loader = img -> img.forEach(UnsignedLongType::setOne);
+		final ReadOnlyCachedCellImgFactory factory = new ReadOnlyCachedCellImgFactory(ReadOnlyCachedCellImgOptions.options().cellDimensions(blockSize));
+		final CachedCellImg<UnsignedLongType, ?> canvas = factory.create(dims, new UnsignedLongType(), loader);
+		final Random rng = new Random(100);
+		canvas.forEach(px -> px.setInteger(rng.nextDouble() > 0.5 ? rng.nextInt(50) : Label.INVALID));
+
+		final N5Writer container = N5TestUtil.fileSystemWriterAtTmpDir();
+		testLabelMultisetSingleScale(container, "single-scale-label-multisets", canvas);
+		testLabelMultisetMultiScale(container, "multi-scale-label-multisets", canvas);
+		testLabelMultisetPaintera(container, "paintera-label-multisets", canvas);
+		testUnsignedLongTypeSingleScale(container, "single-scale-uint64", canvas);
+		testUnsignedLongTypeMultiScale(container, "multi-scale-uint64", canvas);
+		testUnsignedLongTypePaintera(container, "paintera-uint64", canvas);
+	}
+
+	private static void testUnsignedLongTypeSingleScale(
+			final N5Writer container,
+			final String dataset,
+			final CachedCellImg<UnsignedLongType, ?> canvas) throws IOException, UnableToPersistCanvas {
+		CommitCanvasN5Test.<UnsignedLongType>testSingleScale(
+				container,
+				dataset,
+				DataType.UINT64,
+				canvas,
+				ThrowingBiFunction.unchecked(N5Utils::open),
+				(c, l) -> Assert.assertEquals(isInvalid(c) ? 0 : c.getIntegerLong(), l.getIntegerLong()));
+	}
+
+	private static void testLabelMultisetSingleScale(
+			final N5Writer container,
+			final String dataset,
+			final CachedCellImg<UnsignedLongType, ?> canvas) throws IOException, UnableToPersistCanvas {
+		CommitCanvasN5Test.<LabelMultisetType>testSingleScale(
+				container,
+				dataset,
+				DataType.UINT8,
+				canvas,
+				ThrowingBiFunction.unchecked(LabelUtils::openVolatile),
+				(c, l) -> Assert.assertEquals(isInvalid(c) ? 0 : c.getIntegerLong(), l.getIntegerLong()),
+				MULTISET_ATTRIBUTE);
+	}
+
+	private static void testUnsignedLongTypeMultiScale(
+			final N5Writer container,
+			final String dataset,
+			final CachedCellImg<UnsignedLongType, ?> canvas) throws IOException, UnableToPersistCanvas {
+		CommitCanvasN5Test.<UnsignedLongType>testMultiScale(
+				container,
+				dataset,
+				DataType.UINT64,
+				canvas,
+				ThrowingBiFunction.unchecked(N5Utils::open),
+				(c, l) -> Assert.assertEquals(isInvalid(c) ? 0 : c.getIntegerLong(), l.getIntegerLong()));
+	}
+
+	private static void testLabelMultisetMultiScale(
+			final N5Writer container,
+			final String dataset,
+			final CachedCellImg<UnsignedLongType, ?> canvas) throws IOException, UnableToPersistCanvas {
+		CommitCanvasN5Test.<LabelMultisetType>testMultiScale(
+				container,
+				dataset,
+				DataType.UINT8,
+				canvas,
+				ThrowingBiFunction.unchecked(LabelUtils::openVolatile),
+				(c, l) -> Assert.assertEquals(isInvalid(c) ? 0 : c.getIntegerLong(), l.getIntegerLong()),
+				MULTISET_ATTRIBUTE);
+	}
+
+	private static void testUnsignedLongTypePaintera(
+			final N5Writer container,
+			final String dataset,
+			final CachedCellImg<UnsignedLongType, ?> canvas) throws IOException, UnableToPersistCanvas {
+		CommitCanvasN5Test.<UnsignedLongType>testPainteraData(
+				container,
+				dataset,
+				DataType.UINT64,
+				canvas,
+				ThrowingBiFunction.unchecked(N5Utils::open),
+				(c, l) -> Assert.assertEquals(isInvalid(c) ? 0 : c.getIntegerLong(), l.getIntegerLong()));
+	}
+
+	private static void testLabelMultisetPaintera(
+			final N5Writer container,
+			final String dataset,
+			final CachedCellImg<UnsignedLongType, ?> canvas) throws IOException, UnableToPersistCanvas {
+		CommitCanvasN5Test.<LabelMultisetType>testPainteraData(
+				container,
+				dataset,
+				DataType.UINT8,
+				canvas,
+				ThrowingBiFunction.unchecked(LabelUtils::openVolatile),
+				(c, l) -> Assert.assertEquals(isInvalid(c) ? 0 : c.getIntegerLong(), l.getIntegerLong()),
+				MULTISET_ATTRIBUTE);
+	}
+
+	private static <T> void testPainteraData(
+			final N5Writer container,
+			final String dataset,
+			final DataType dataType,
+			final CachedCellImg<UnsignedLongType, ?> canvas,
+			final BiFunction<N5Reader, String, RandomAccessibleInterval<T>> openLabels,
+			final BiConsumer<UnsignedLongType, T> asserts,
+			final int[]... scaleFactors
+	) throws IOException, UnableToPersistCanvas {
+		testPainteraData(container, dataset, dataType, canvas, openLabels, asserts, new HashMap<>());
+	}
+
+	private static <T> void testPainteraData(
+			final N5Writer container,
+			final String dataset,
+			final DataType dataType,
+			final CachedCellImg<UnsignedLongType, ?> canvas,
+			final BiFunction<N5Reader, String, RandomAccessibleInterval<T>> openLabels,
+			final BiConsumer<UnsignedLongType, T> asserts,
+			final Map<String, Object> additionalAttributes,
+			final int[]... sclaeFactors
+	) throws IOException, UnableToPersistCanvas {
+		final DatasetAttributes attributes = new DatasetAttributes(canvas.getCellGrid().getImgDimensions(), blockSize(canvas.getCellGrid()), dataType, new GzipCompression());
+		container.createGroup(dataset);
+		final String dataGroup = String.join("/", dataset, "data");
+		container.createGroup(dataGroup);
+		final String s0 = String.join("/", dataGroup, "s0");
+		container.createDataset(s0, attributes);
+		additionalAttributes.forEach(ThrowingBiConsumer.unchecked((k, v) -> container.setAttribute(dataGroup, k, v)));
+		additionalAttributes.forEach(ThrowingBiConsumer.unchecked((k, v) -> container.setAttribute(s0, k, v)));
+		container.setAttribute(dataset, "painteraData", PAINTERA_DATA_ATTRIBUTE);
+		container.setAttribute(s0, N5Helpers.MULTI_SCALE_KEY, true);
+		testCanvasPersistance(container, dataset, s0, canvas, openLabels, asserts);
+	}
+
+	private static <T> void testMultiScale(
+			final N5Writer container,
+			final String dataset,
+			final DataType dataType,
+			final CachedCellImg<UnsignedLongType, ?> canvas,
+			final BiFunction<N5Reader, String, RandomAccessibleInterval<T>> openLabels,
+			final BiConsumer<UnsignedLongType, T> asserts,
+			final int[]... scaleFactors
+	) throws IOException, UnableToPersistCanvas {
+		testMultiScale(container, dataset, dataType, canvas, openLabels, asserts, new HashMap<>());
+	}
+
+	private static <T> void testMultiScale(
+			final N5Writer container,
+			final String dataset,
+			final DataType dataType,
+			final CachedCellImg<UnsignedLongType, ?> canvas,
+			final BiFunction<N5Reader, String, RandomAccessibleInterval<T>> openLabels,
+			final BiConsumer<UnsignedLongType, T> asserts,
+			final Map<String, Object> additionalAttributes,
+			final int[]... sclaeFactors
+	) throws IOException, UnableToPersistCanvas {
+		final DatasetAttributes attributes = new DatasetAttributes(canvas.getCellGrid().getImgDimensions(), blockSize(canvas.getCellGrid()), dataType, new GzipCompression());
+		container.createGroup(dataset);
+		final String s0 = String.join("/", dataset, "s0");
+		container.createDataset(s0, attributes);
+		additionalAttributes.forEach(ThrowingBiConsumer.unchecked((k, v) -> container.setAttribute(dataset, k, v)));
+		additionalAttributes.forEach(ThrowingBiConsumer.unchecked((k, v) -> container.setAttribute(s0, k, v)));
+		container.setAttribute(s0, N5Helpers.MULTI_SCALE_KEY, true);
+		testCanvasPersistance(container, dataset, s0, canvas, openLabels, asserts);
+	}
+
+	private static <T> void testSingleScale(
+			final N5Writer container,
+			final String dataset,
+			final DataType dataType,
+			final CachedCellImg<UnsignedLongType, ?> canvas,
+			final BiFunction<N5Reader, String, RandomAccessibleInterval<T>> openLabels,
+			final BiConsumer<UnsignedLongType, T> asserts
+	) throws IOException, UnableToPersistCanvas {
+		testSingleScale(container, dataset, dataType, canvas, openLabels, asserts, new HashMap<>());
+	}
+
+	private static <T> void testSingleScale(
+			final N5Writer container,
+			final String dataset,
+			final DataType dataType,
+			final CachedCellImg<UnsignedLongType, ?> canvas,
+			final BiFunction<N5Reader, String, RandomAccessibleInterval<T>> openLabels,
+			final BiConsumer<UnsignedLongType, T> asserts,
+			final Map<String, Object> additionalAttributes
+	) throws IOException, UnableToPersistCanvas {
+		final DatasetAttributes attributes = new DatasetAttributes(canvas.getCellGrid().getImgDimensions(), blockSize(canvas.getCellGrid()), dataType, new GzipCompression());
+		container.createDataset(dataset, attributes);
+		additionalAttributes.forEach(ThrowingBiConsumer.unchecked((k, v) -> container.setAttribute(dataset, k, v)));
+		testCanvasPersistance(container, dataset, canvas, openLabels, asserts);
+	}
+
+	private static <T> void testCanvasPersistance(
+			final N5Writer container,
+			final String group,
+			final CachedCellImg<UnsignedLongType, ?> canvas,
+			final BiFunction<N5Reader, String, RandomAccessibleInterval<T>> openLabels,
+			final BiConsumer<UnsignedLongType, T> asserts) throws IOException, UnableToPersistCanvas {
+
+		testCanvasPersistance(container, group, group, canvas, openLabels, asserts);
+	}
+
+	private static <T> void testCanvasPersistance(
+			final N5Writer container,
+			final String group,
+			final String labelsDataset,
+			final CachedCellImg<UnsignedLongType, ?> canvas,
+			final BiFunction<N5Reader, String, RandomAccessibleInterval<T>> openLabels,
+			final BiConsumer<UnsignedLongType, T> asserts) throws IOException, UnableToPersistCanvas {
+
+		writeAll(container, group, canvas);
+
+		final RandomAccessibleInterval<T> labels = openLabels.apply(container, labelsDataset);
+		Assert.assertArrayEquals(Intervals.dimensionsAsLongArray(canvas), Intervals.dimensionsAsLongArray(labels));
+
+		for (final Pair<UnsignedLongType, T> pair : Views.interval(Views.pair(canvas, labels), labels)) {
+			LOG.debug("Comparing canvas {} and background {}", pair.getA(), pair.getB());
+			asserts.accept(pair.getA(), pair.getB());
+		}
+	}
+
+
+	private static void writeAll(
+			final N5Writer container,
+			final String dataset,
+			final CachedCellImg<UnsignedLongType, ?> canvas) throws IOException, UnableToPersistCanvas {
+		final long numBlocks = Intervals.numElements(canvas.getCellGrid().getGridDimensions());
+		final long[] blocks = new long[(int) numBlocks];
+		Arrays.setAll(blocks, d -> d);
+
+		final CommitCanvasN5 cc = new CommitCanvasN5(container, dataset);
+		cc.persistCanvas(canvas, blocks);
+	}
+
+	private static int[] blockSize(final CellGrid grid) {
+		int[] blockSize = new int[grid.numDimensions()];
+		grid.cellDimensions(blockSize);
+		return blockSize;
+	}
+
+}

--- a/src/test/java/org/janelia/saalfeldlab/util/n5/N5HelpersTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/util/n5/N5HelpersTest.java
@@ -76,25 +76,8 @@ public class N5HelpersTest {
 
 		Assert.assertEquals(Arrays.asList("s0", "s1", "s2"), Arrays.asList(listAndSortScaleDatasets(writer, group)));
 
-		Assert.assertEquals("group/s0", N5Helpers.getFinestLevel(writer, group));
-		Assert.assertEquals("group/s2", N5Helpers.getCoarsestLevel(writer, group));
-	}
-
-	@Test
-	public void testHighestResolutionDataset() throws IOException {
-		final N5Writer writer = N5TestUtil.fileSystemWriterAtTmpDir();
-		final String group = "group";
-		writer.createGroup(group);
-		writer.setAttribute(group, N5Helpers.MULTI_SCALE_KEY, true);
-		final DatasetAttributes attrs = new DatasetAttributes(new long[]{1}, new int[]{1}, DataType.UINT8, new RawCompression());
-		writer.createDataset(group + "/s0", attrs);
-		writer.createDataset(group + "/s1", attrs);
-		writer.createDataset(group + "/s2", attrs);
-
-		Assert.assertEquals(group, N5Helpers.highestResolutionDataset(writer, group, false));
-		Assert.assertEquals(group + "/s0", N5Helpers.highestResolutionDataset(writer, group, true));
-		Assert.assertEquals(group + "/s0", N5Helpers.highestResolutionDataset(writer, group));
-
+		Assert.assertEquals("group/s0", String.join("/", N5Helpers.getFinestLevelJoinWithGroup(writer, group)));
+		Assert.assertEquals("group/s2", String.join("/", N5Helpers.getCoarsestLevelJoinWithGroup(writer, group)));
 	}
 
 	@Test

--- a/src/test/java/org/janelia/saalfeldlab/util/n5/N5HelpersTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/util/n5/N5HelpersTest.java
@@ -1,6 +1,10 @@
 package org.janelia.saalfeldlab.util.n5;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import net.imglib2.img.cell.CellGrid;
+import org.janelia.saalfeldlab.n5.Compression;
+import org.janelia.saalfeldlab.n5.CompressionAdapter;
 import org.janelia.saalfeldlab.n5.DataType;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.GzipCompression;
@@ -16,12 +20,16 @@ import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.janelia.saalfeldlab.util.n5.N5Helpers.listAndSortScaleDatasets;
 
 public class N5HelpersTest {
 
 	private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+	private static final Gson gsonWithCompression = new GsonBuilder().registerTypeHierarchyAdapter(Compression.class, CompressionAdapter.getJsonAdapter()).create();
 
 	@Test
 	public void testAsCellGrid()
@@ -41,7 +49,7 @@ public class N5HelpersTest {
 	}
 
 	@Test public void testIsMultiscale() throws IOException {
-		final N5Writer writer = N5TestUtil.fileSystemWriterAtTmpDir();
+		final N5Writer writer = N5TestUtil.fileSystemWriterAtTmpDir(!LOG.isDebugEnabled());
 		final String group = "group";
 		writer.createGroup(group);
 
@@ -65,7 +73,7 @@ public class N5HelpersTest {
 
 	@Test
 	public void testListAndSortScaleDatasets() throws IOException {
-		final N5Writer writer = N5TestUtil.fileSystemWriterAtTmpDir();
+		final N5Writer writer = N5TestUtil.fileSystemWriterAtTmpDir(!LOG.isDebugEnabled());
 		final String group = "group";
 		writer.createGroup(group);
 		writer.setAttribute(group, N5Helpers.MULTI_SCALE_KEY, true);
@@ -82,7 +90,7 @@ public class N5HelpersTest {
 
 	@Test
 	public void testDiscoverDatasets() throws IOException {
-		final N5Writer writer = N5TestUtil.fileSystemWriterAtTmpDir();
+		final N5Writer writer = N5TestUtil.fileSystemWriterAtTmpDir(!LOG.isDebugEnabled());
 		final String group = "group";
 		writer.createGroup(group);
 		writer.setAttribute(group, N5Helpers.MULTI_SCALE_KEY, true);
@@ -97,6 +105,51 @@ public class N5HelpersTest {
 		LOG.debug("Got groups {}", groups);
 		Assert.assertEquals(Arrays.asList("/group", "/some_group/two"), groups);
 
+	}
+
+	@Test
+	public void testGetDatasetAttributes() throws IOException {
+		final N5Writer writer = N5TestUtil.fileSystemWriterAtTmpDir(!LOG.isDebugEnabled());
+		final DatasetAttributes attributes = new DatasetAttributes(new long[] {1}, new int[] {1}, DataType.UINT8, new GzipCompression());
+
+		// single scale
+		final String dataset = "dataset";
+		writer.createDataset(dataset, attributes);
+		assertEquals(attributes, N5Helpers.getDatasetAttributes(writer, dataset));
+
+		// multi scale
+		final String group = "group";
+		writer.createGroup(group);
+		writer.createDataset("group/s0", attributes);
+		assertEquals(attributes, N5Helpers.getDatasetAttributes(writer, group));
+
+		writer.setAttribute(group, N5Helpers.MULTI_SCALE_KEY, true);
+		assertEquals(attributes, N5Helpers.getDatasetAttributes(writer, group));
+
+		// paintera data
+		final String painteraData = "paintera-data";
+		final String data = painteraData + "/data";
+		writer.createDataset(data + "/s0", attributes);
+		writer.createGroup(painteraData);
+		writer.createGroup(data);
+		writer.setAttribute(data, N5Helpers.MULTI_SCALE_KEY, true);
+
+		Assert.assertNull(N5Helpers.getDatasetAttributes(writer, painteraData));
+		assertEquals(attributes, N5Helpers.getDatasetAttributes(writer, data));
+
+		writer.setAttribute(painteraData, N5Helpers.PAINTERA_DATA_KEY, Stream.of(1).collect(Collectors.toMap(o -> "type", o -> "raw")));
+		assertEquals(attributes, N5Helpers.getDatasetAttributes(writer, painteraData));
+
+	}
+
+	private static void assertEquals(final DatasetAttributes expected, final DatasetAttributes actual) {
+		Assert.assertEquals(expected.getNumDimensions(), actual.getNumDimensions());
+		Assert.assertArrayEquals(expected.getDimensions(), actual.getDimensions());
+		Assert.assertArrayEquals(expected.getBlockSize(), actual.getBlockSize());
+		Assert.assertEquals(expected.getDataType(), actual.getDataType());
+		Assert.assertEquals(expected.getCompression().getClass(), actual.getCompression().getClass());
+		Assert.assertEquals(expected.getCompression().getType(), actual.getCompression().getType());
+		Assert.assertEquals(gsonWithCompression.toJson(expected.getCompression()), gsonWithCompression.toJson(actual.getCompression()));
 	}
 
 }

--- a/src/test/java/org/janelia/saalfeldlab/util/n5/N5TestUtil.java
+++ b/src/test/java/org/janelia/saalfeldlab/util/n5/N5TestUtil.java
@@ -20,11 +20,11 @@ public class N5TestUtil {
 
 	private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-	public static N5Writer fileSystemWriterAtTmpDir() throws IOException {
+	public static N5FSWriter fileSystemWriterAtTmpDir() throws IOException {
 		return fileSystemWriterAtTmpDir(true);
 	}
 
-	public static N5Writer fileSystemWriterAtTmpDir(final boolean deleteOnExit) throws IOException {
+	public static N5FSWriter fileSystemWriterAtTmpDir(final boolean deleteOnExit) throws IOException {
 		final Path tmp = Files.createTempDirectory(null);
 
 		LOG.debug("Creating temporary N5Writer at {} (delete on exit? {})", tmp, deleteOnExit);

--- a/src/test/java/org/janelia/saalfeldlab/util/n5/N5TestUtil.java
+++ b/src/test/java/org/janelia/saalfeldlab/util/n5/N5TestUtil.java
@@ -15,7 +15,7 @@ import java.nio.file.Path;
 
 public class N5TestUtil {
 
-	static N5Writer fileSystemWriterAtTmpDir() throws IOException {
+	public static N5Writer fileSystemWriterAtTmpDir() throws IOException {
 		final Path tmp = Files.createTempDirectory(null);
 		final File dir = tmp.toFile();
 		dir.deleteOnExit();

--- a/src/test/java/org/janelia/saalfeldlab/util/n5/N5TestUtil.java
+++ b/src/test/java/org/janelia/saalfeldlab/util/n5/N5TestUtil.java
@@ -7,21 +7,34 @@ import org.janelia.saalfeldlab.n5.N5FSWriter;
 import org.janelia.saalfeldlab.n5.N5Writer;
 import org.janelia.saalfeldlab.n5.RawCompression;
 import org.janelia.saalfeldlab.util.MakeUnchecked;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
 public class N5TestUtil {
 
+	private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
 	public static N5Writer fileSystemWriterAtTmpDir() throws IOException {
+		return fileSystemWriterAtTmpDir(true);
+	}
+
+	public static N5Writer fileSystemWriterAtTmpDir(final boolean deleteOnExit) throws IOException {
 		final Path tmp = Files.createTempDirectory(null);
+
+		LOG.debug("Creating temporary N5Writer at {} (delete on exit? {})", tmp, deleteOnExit);
+
 		final File dir = tmp.toFile();
-		dir.deleteOnExit();
-		Runtime.getRuntime().addShutdownHook(new Thread(MakeUnchecked.runnable(() -> FileUtils.deleteDirectory(dir))));
-		final N5FSWriter writer = new N5FSWriter(tmp.toAbsolutePath().toString());
-		return writer;
+		if (deleteOnExit) {
+			dir.deleteOnExit();
+			Runtime.getRuntime().addShutdownHook(new Thread(MakeUnchecked.runnable(() -> FileUtils.deleteDirectory(dir))));
+		}
+		return new N5FSWriter(tmp.toAbsolutePath().toString());
 	}
 
 	static DatasetAttributes defaultAttributes()


### PR DESCRIPTION
Fixes #183:
 - Add throwing-functions dependency
 - Do not use Paths.get for getting finest/coarsest datasets

Needs to 
 - [x] be tested on Windows machine, and 
 - [x] for general use, changed files:
   - [x] `PainteraShowContainer`
   - [x] `CommitCanvasN5` (added test)
   - [x] `GenericBackendDialogN5`
   - [x] `N5Helpers.getDatasetAttributes` (make test)
   - [x] `N5Types.isLabelMultisetType` (test exists)
   - [x] `N5Types.getDataType` (test exists)