### PR TITLE
Fix interpolation artifacts between render tiles [revised]

### DIFF
--- a/src/main/java/bdv/fx/viewer/ViewerPanelFX.java
+++ b/src/main/java/bdv/fx/viewer/ViewerPanelFX.java
@@ -48,6 +48,7 @@ import javafx.collections.ObservableList;
 import javafx.scene.Node;
 import javafx.scene.image.Image;
 import javafx.scene.layout.StackPane;
+import javafx.scene.paint.Color;
 import net.imglib2.Point;
 import net.imglib2.Positionable;
 import net.imglib2.RealLocalizable;
@@ -68,7 +69,6 @@ import net.imglib2.view.Views;
 import org.janelia.saalfeldlab.paintera.data.axisorder.AxisOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -585,7 +585,10 @@ public class ViewerPanelFX
 
 			final ReadOnlyObjectProperty<Image> image = grid.imagePropertyAt(i);
 			image.addListener((obs, oldv, newv) -> {
-				if (newv != null) {
+				if (newv == null) {
+					canvasPane.getCanvas().getGraphicsContext2D().setFill(Color.BLACK);
+					canvasPane.getCanvas().getGraphicsContext2D().fillRect(cellMin[0], cellMin[1], cellDims[0], cellDims[1]);
+				} else {
 					final int[] padding = imageDisplayGrid.get().getPadding();
 					canvasPane.getCanvas().getGraphicsContext2D().drawImage(
 						newv, // src

--- a/src/main/java/bdv/fx/viewer/ViewerPanelFX.java
+++ b/src/main/java/bdv/fx/viewer/ViewerPanelFX.java
@@ -585,11 +585,8 @@ public class ViewerPanelFX
 
 			final ReadOnlyObjectProperty<Image> image = grid.imagePropertyAt(i);
 			image.addListener((obs, oldv, newv) -> {
-				if (newv == null) {
-					canvasPane.getCanvas().getGraphicsContext2D().setFill(Color.BLACK);
-					canvasPane.getCanvas().getGraphicsContext2D().fillRect(cellMin[0], cellMin[1], cellDims[0], cellDims[1]);
-				} else {
-					final int[] padding = imageDisplayGrid.get().getPadding();
+				if (newv != null) {
+					final int[] padding = grid.getPadding();
 					canvasPane.getCanvas().getGraphicsContext2D().drawImage(
 						newv, // src
 						padding[0], padding[1], // src X, Y

--- a/src/main/java/bdv/fx/viewer/ViewerPanelFX.java
+++ b/src/main/java/bdv/fx/viewer/ViewerPanelFX.java
@@ -47,7 +47,6 @@ import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.scene.Node;
 import javafx.scene.image.Image;
-import javafx.scene.layout.GridPane;
 import javafx.scene.layout.StackPane;
 import net.imglib2.Point;
 import net.imglib2.Positionable;
@@ -65,6 +64,7 @@ import net.imglib2.type.numeric.integer.IntType;
 import net.imglib2.ui.TransformListener;
 import net.imglib2.util.Intervals;
 import net.imglib2.view.Views;
+
 import org.janelia.saalfeldlab.paintera.data.axisorder.AxisOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,7 +102,6 @@ public class ViewerPanelFX
 	private final OverlayPane overlayPane = new OverlayPane();
 
 	private final ViewerState state;
-
 	private final AffineTransform3D viewerTransform;
 
 	private ThreadGroup threadGroup;
@@ -228,7 +227,7 @@ public class ViewerPanelFX
 		{
 			this.imageDisplayGrid.set(renderUnit.getImagePropertyGrid());
 		});
-		this.imageDisplayGrid.addListener((obs, oldv, newv) -> {synchronized(renderUnit){this.display.setChild(makeGrid(newv));}});
+		this.imageDisplayGrid.addListener((obs, oldv, newv) -> {synchronized(renderUnit) {this.display.setChild(makeCanvas(newv));}});
 		this.widthProperty().addListener((obs, oldv, newv) -> this.renderUnit.setDimensions((long)getWidth(), (long)getHeight()));
 		this.heightProperty().addListener((obs, oldv, newv) -> this.renderUnit.setDimensions((long)getWidth(), (long)getHeight()));
 		setWidth(options.getWidth());
@@ -570,32 +569,35 @@ public class ViewerPanelFX
 		return range;
 	}
 
-	private static GridPane makeGrid(final RenderUnit.ImagePropertyGrid grid)
+	private CanvasPane makeCanvas(final RenderUnit.ImagePropertyGrid grid)
 	{
-		final GridPane pane = new GridPane();
-
+		final CanvasPane canvasPane = new CanvasPane(1, 1);
 		if (grid == null)
-			return pane;
+			return canvasPane;
 
 		final CellGrid cellGrid = grid.getGrid();
-		pane.setMinWidth(1);
-		pane.setMinHeight(1);
-		pane.setPrefWidth(cellGrid.getImgDimensions()[0]);
-		pane.setPrefHeight(cellGrid.getImgDimensions()[0]);
 		final long[] gridPos = new long[2];
-		final long[] cellMin = new long[2];
-		final int[] cellDims = new int[2];
-		final int numTiles = grid.numTiles();
-		for (int i = 0; i < numTiles; ++i) {
+		for (int i = 0; i < grid.numTiles(); ++i) {
+			final long[] cellMin = new long[2];
+			final int[] cellDims = new int[2];
 			cellGrid.getCellGridPositionFlat(i, gridPos);
 			cellGrid.getCellDimensions(gridPos, cellMin, cellDims);
+
 			final ReadOnlyObjectProperty<Image> image = grid.imagePropertyAt(i);
-			final ImagePane imagePane = new ImagePane(cellDims[0], cellDims[1]);
-			imagePane.imageProperty().bind(image);
-			LOG.debug("Putting render block {} into cell at position {}", i, gridPos);
-			pane.add(imagePane, (int) gridPos[0], (int) gridPos[1]);
+			image.addListener((obs, oldv, newv) -> {
+				if (newv != null) {
+					final int[] padding = imageDisplayGrid.get().getPadding();
+					canvasPane.getCanvas().getGraphicsContext2D().drawImage(
+						newv, // src
+						padding[0], padding[1], // src X, Y
+						newv.getWidth() - 2 * padding[0], newv.getHeight() - 2 * padding[1], // src width, height
+						cellMin[0], cellMin[1], // dst X, Y
+						cellDims[0], cellDims[1] // dst width, height
+					);
+				}
+			});
 		}
-		return pane;
+		return canvasPane;
 	}
 
 }

--- a/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererFX.java
+++ b/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererFX.java
@@ -112,7 +112,6 @@ public class MultiResolutionRendererFX extends MultiResolutionRendererGeneric<Bu
 
 	}
 
-	@SuppressWarnings("unchecked")
 	public MultiResolutionRendererFX(
 			final TransformAwareRenderTargetGeneric<BufferExposingWritableImage> display,
 			final PainterThread painterThread,
@@ -123,7 +122,8 @@ public class MultiResolutionRendererFX extends MultiResolutionRendererGeneric<Bu
 			final ExecutorService renderingExecutorService,
 			final boolean useVolatileIfAvailable,
 			final AccumulateProjectorFactory<ARGBType> accumulateProjectorFactory,
-			final CacheControl cacheControl)
+			final CacheControl cacheControl,
+			final int[] padding)
 	{
 		super(
 				display,
@@ -136,6 +136,7 @@ public class MultiResolutionRendererFX extends MultiResolutionRendererGeneric<Bu
 				useVolatileIfAvailable,
 				accumulateProjectorFactory,
 				cacheControl,
+				padding,
 				BufferExposingWritableImage::asArrayImg,
 				new MakeWritableImage(),
 				img -> (int) img.getWidth(),

--- a/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererGeneric.java
+++ b/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererGeneric.java
@@ -338,8 +338,8 @@ public class MultiResolutionRendererGeneric<T>
 		final int componentW = display.getWidth();
 		final int componentH = display.getHeight();
 		if (screenImages.get(0).get(0) == null
-				|| width .applyAsInt(screenImages.get(0).get(0)) != (int)(componentW * screenScales[0]) + 2 * padding[0]
-				|| height.applyAsInt(screenImages.get(0).get(0)) != (int)(componentH * screenScales[0]) + 2 * padding[1])
+				|| width .applyAsInt(screenImages.get(0).get(0)) != Math.max((int) (componentW * screenScales[0]), 1) + 2 * padding[0]
+				|| height.applyAsInt(screenImages.get(0).get(0)) != Math.max((int) (componentH * screenScales[0]), 1) + 2 * padding[1])
 		{
 			renderIdQueue.clear();
 			renderIdQueue.addAll(Arrays.asList(0, 1, 2));

--- a/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererGeneric.java
+++ b/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererGeneric.java
@@ -247,6 +247,8 @@ public class MultiResolutionRendererGeneric<T>
 
 	private final ImageGenerator<T> makeImage;
 
+	private final int[] padding;
+
 	/**
 	 * @param display
 	 * 		The canvas that will display the images we render.
@@ -273,8 +275,9 @@ public class MultiResolutionRendererGeneric<T>
 	 * 		can be used to customize how sources are combined.
 	 * @param cacheControl
 	 * 		the cache controls IO budgeting and fetcher queue.
+	 * @param padding
+	 * 		specifies by how many pixels the rendered images are extended on each side to enable seamless interpolation
 	 */
-	@SuppressWarnings("unchecked")
 	MultiResolutionRendererGeneric(
 			final TransformAwareRenderTargetGeneric<T> display,
 			final PainterThread painterThread,
@@ -286,6 +289,7 @@ public class MultiResolutionRendererGeneric<T>
 			final boolean useVolatileIfAvailable,
 			final AccumulateProjectorFactory<ARGBType> accumulateProjectorFactory,
 			final CacheControl cacheControl,
+			final int[] padding,
 			final Function<T, ArrayImg<ARGBType, ? extends IntAccess>> wrapAsArrayImg,
 			final ImageGenerator<T> makeImage,
 			final ToIntFunction<T> width,
@@ -319,6 +323,8 @@ public class MultiResolutionRendererGeneric<T>
 		this.cacheControl = cacheControl;
 		newFrameRequest = false;
 		previousTimepoint = -1;
+
+		this.padding = padding;
 	}
 
 	/**
@@ -343,21 +349,25 @@ public class MultiResolutionRendererGeneric<T>
 				final double screenToViewerScale = screenScales[i];
 				final int    w                   = Math.max((int) (screenToViewerScale * componentW), 1);
 				final int    h                   = Math.max((int) (screenToViewerScale * componentH), 1);
+				final int paddedW = w + 2 * padding[0];
+				final int paddedH = h + 2 * padding[1];
 				if (doubleBuffered)
+				{
 					for (int b = 0; b < 3; ++b)
 					{
 						// reuse storage arrays of level 0 (highest resolution)
 						screenImages.get(i).set(b, i == 0
-						                     ? makeImage.create(w, h)
-						                     : makeImage.create(w, h, screenImages.get(0).get(b)));
+						                     ? makeImage.create(paddedW, paddedH)
+						                     : makeImage.create(paddedW, paddedH, screenImages.get(0).get(b)));
 						final T bi = screenImages.get(i).get(b);
 						// getBufferedImage.apply( screenImages[ i ][ b ] );
 						bufferedImages.get(i).set(b, bi);
 						bufferedImageToRenderId.put(bi, b);
 					}
+				}
 				else
 				{
-					screenImages.get(i).set(0, makeImage.create(w, h));
+					screenImages.get(i).set(0, makeImage.create(paddedW, paddedH));
 					bufferedImages.get(i).set(0, screenImages.get(i).get(0));
 					// getBufferedImage.apply( screenImages[ i ][ 0 ] );
 				}
@@ -366,8 +376,8 @@ public class MultiResolutionRendererGeneric<T>
 				final double            yScale = (double) h / componentH;
 				scale.set(xScale, 0, 0);
 				scale.set(yScale, 1, 1);
-				scale.set(0.5 * xScale - 0.5, 0, 3);
-				scale.set(0.5 * yScale - 0.5, 1, 3);
+				scale.set(0.5 * xScale - 0.5 + padding[0], 0, 3);
+				scale.set(0.5 * yScale - 0.5 + padding[1], 1, 3);
 				screenScaleTransforms[i] = scale;
 			}
 

--- a/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererGeneric.java
+++ b/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererGeneric.java
@@ -338,8 +338,8 @@ public class MultiResolutionRendererGeneric<T>
 		final int componentW = display.getWidth();
 		final int componentH = display.getHeight();
 		if (screenImages.get(0).get(0) == null
-				|| width.applyAsInt(screenImages.get(0).get(0)) != (int)(componentW * screenScales[0])
-				|| height.applyAsInt(screenImages.get(0).get(0)) != (int)(componentH * screenScales[0]))
+				|| width .applyAsInt(screenImages.get(0).get(0)) != (int)(componentW * screenScales[0]) + 2 * padding[0]
+				|| height.applyAsInt(screenImages.get(0).get(0)) != (int)(componentH * screenScales[0]) + 2 * padding[1])
 		{
 			renderIdQueue.clear();
 			renderIdQueue.addAll(Arrays.asList(0, 1, 2));

--- a/src/main/java/bdv/fx/viewer/render/RenderUnit.java
+++ b/src/main/java/bdv/fx/viewer/render/RenderUnit.java
@@ -247,7 +247,7 @@ public class RenderUnit {
 
 		// Adjust the dimensions to be a greater or equal multiple of the block size
 		// to make sure that the border images have the same scaling coefficients
-		Arrays.setAll(dimensions, d -> (int) Math.ceil((double) dimensions[d] / blockSize[d]) * blockSize[d]);
+		Arrays.setAll(dimensions, d -> dimensions[d] > blockSize[d] ? (int) Math.ceil((double) dimensions[d] / blockSize[d]) * blockSize[d] : dimensions[d]);
 
 		this.grid = new CellGrid(dimensions, blockSize);
 

--- a/src/main/java/bdv/fx/viewer/render/RenderUnit.java
+++ b/src/main/java/bdv/fx/viewer/render/RenderUnit.java
@@ -245,6 +245,10 @@ public class RenderUnit {
 			p.interrupt();
 		}
 
+		// Adjust the dimensions to be a greater or equal multiple of the block size
+		// to make sure that the border images have the same scaling coefficients
+		Arrays.setAll(dimensions, d -> (int) Math.ceil((double) dimensions[d] / blockSize[d]) * blockSize[d]);
+
 		this.grid = new CellGrid(dimensions, blockSize);
 
 		int numBlocks = (int) LongStream.of(this.grid.getGridDimensions()).reduce(1, (l1, l2) -> l1 * l2);

--- a/src/main/java/bdv/fx/viewer/render/RenderUnit.java
+++ b/src/main/java/bdv/fx/viewer/render/RenderUnit.java
@@ -28,7 +28,7 @@ import java.util.function.Supplier;
 import java.util.stream.LongStream;
 
 /**
- * Render sreen as tiles instead of single image.
+ * Render screen as tiles instead of single image.
  */
 public class RenderUnit {
 
@@ -39,6 +39,8 @@ public class RenderUnit {
 	private final int[] blockSize = {250, 250};
 
 	private final long[] dimensions = {1, 1};
+
+	private final int[] padding = {1, 1};
 
 	private double[] screenScales = ScreenScalesConfig.defaultScreenScalesCopy();
 
@@ -258,8 +260,6 @@ public class RenderUnit {
 		final int[] cellDims = new int[2];
 		for (int index = 0; index < renderers.length; ++index) {
 			this.grid.getCellGridPositionFlat(index, cellPos);
-			min[0] = this.grid.getCellMin(0, cellPos[0]);
-			min[1] = this.grid.getCellMin(1, cellPos[1]);
 			this.grid.getCellDimensions(cellPos, min, cellDims);
 			Arrays.setAll(max, d -> min[d] + cellDims[d] - 1);
 			final TransformAwareBufferedImageOverlayRendererFX renderTarget = new TransformAwareBufferedImageOverlayRendererFX();
@@ -275,7 +275,8 @@ public class RenderUnit {
 					renderingExecutorService,
 					true,
 					accumulateProjectorFactory,
-					cacheControl
+					cacheControl,
+					padding
 			);
 			LOG.trace("Creating new renderer for block ({}) ({})", min, max);
 			renderTarget.setCanvasSize(cellDims[0], cellDims[1]);
@@ -292,7 +293,7 @@ public class RenderUnit {
 
 	public synchronized ImagePropertyGrid getImagePropertyGrid()
 	{
-		return new ImagePropertyGrid(images, grid);
+		return new ImagePropertyGrid(images, grid, padding);
 	}
 
 	private class Paintable implements PainterThread.Paintable
@@ -369,9 +370,12 @@ public class RenderUnit {
 
 		private final CellGrid grid;
 
-		private ImagePropertyGrid(final ObjectProperty<Image>[] images, final CellGrid grid) {
+		private final int[] padding;
+
+		private ImagePropertyGrid(final ObjectProperty<Image>[] images, final CellGrid grid, final int[] padding) {
 			this.images = images;
 			this.grid = grid;
+			this.padding = padding;
 		}
 
 		/**
@@ -400,6 +404,15 @@ public class RenderUnit {
 		public int numTiles()
 		{
 			return images.length;
+		}
+
+		/**
+		 *
+		 * @return padding value by which the rendered images are extended on each side
+		 */
+		public int[] getPadding()
+		{
+			return padding;
 		}
 	}
 

--- a/src/main/java/bdv/fx/viewer/render/RenderUnit.java
+++ b/src/main/java/bdv/fx/viewer/render/RenderUnit.java
@@ -247,9 +247,10 @@ public class RenderUnit {
 
 		// Adjust the dimensions to be a greater or equal multiple of the block size
 		// to make sure that the border images have the same scaling coefficients
-		Arrays.setAll(dimensions, d -> dimensions[d] > blockSize[d] ? (int) Math.ceil((double) dimensions[d] / blockSize[d]) * blockSize[d] : dimensions[d]);
+		final long[] adjustedDimensions = new long[dimensions.length];
+		Arrays.setAll(adjustedDimensions, d -> dimensions[d] > blockSize[d] ? (int) Math.ceil((double) dimensions[d] / blockSize[d]) * blockSize[d] : dimensions[d]);
 
-		this.grid = new CellGrid(dimensions, blockSize);
+		this.grid = new CellGrid(adjustedDimensions, blockSize);
 
 		int numBlocks = (int) LongStream.of(this.grid.getGridDimensions()).reduce(1, (l1, l2) -> l1 * l2);
 		renderers = new MultiResolutionRendererFX[numBlocks];
@@ -297,7 +298,7 @@ public class RenderUnit {
 
 	public synchronized ImagePropertyGrid getImagePropertyGrid()
 	{
-		return new ImagePropertyGrid(images, grid, padding);
+		return new ImagePropertyGrid(images, grid, dimensions, padding);
 	}
 
 	private class Paintable implements PainterThread.Paintable
@@ -374,11 +375,14 @@ public class RenderUnit {
 
 		private final CellGrid grid;
 
+		private long[] dimensions;
+
 		private final int[] padding;
 
-		private ImagePropertyGrid(final ObjectProperty<Image>[] images, final CellGrid grid, final int[] padding) {
+		private ImagePropertyGrid(final ObjectProperty<Image>[] images, final CellGrid grid, final long[] dimensions, final int[] padding) {
 			this.images = images;
 			this.grid = grid;
+			this.dimensions = dimensions;
 			this.padding = padding;
 		}
 
@@ -408,6 +412,15 @@ public class RenderUnit {
 		public int numTiles()
 		{
 			return images.length;
+		}
+
+		/**
+		 *
+		 * @return dimensions of the displayed image (may be smaller than the grid size)
+		 */
+		public long[] getDimensions()
+		{
+			return dimensions;
 		}
 
 		/**

--- a/src/main/java/bdv/fx/viewer/render/TransformAwareBufferedImageOverlayRendererFX.java
+++ b/src/main/java/bdv/fx/viewer/render/TransformAwareBufferedImageOverlayRendererFX.java
@@ -35,6 +35,7 @@ import java.util.function.Consumer;
 
 import javafx.scene.image.Image;
 import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.ui.TransformListener;
 import org.janelia.saalfeldlab.fx.util.InvokeOnJavaFXApplicationThread;
 import org.slf4j.Logger;
@@ -99,6 +100,23 @@ public class TransformAwareBufferedImageOverlayRendererFX
 
 				LOG.trace("Setting image to {}", sourceImage);
 				g.accept(null);
+
+				/*
+				 * NOTE: need to make the final image fully opaque to ensure that it is properly drawn on the screen later on.
+				 * It is only necessary because existing BlendMode options in JavaFX always perform some kind of blending with old contents of the displayed component.
+				 *
+				 * Ideally, we would use BlendMode.SRC if it was available (that would overwrite the destination with the source regardless of alpha).
+				 * See discussion about possibility of adding this mode in the future versions and more information here:
+				 *
+				 * https://bugs.openjdk.java.net/browse/JDK-8092156
+				 *
+				 * https://books.google.com/books?id=UxM2iXiFqbMC&pg=PA97&lpg=PA97&dq=Porter-Duff+%22source+over+destination%22&source=bl&ots=hYj5U2X5Lk&sig=ACfU3U095X67T4FghqCpgYrAhEWbNtd_xQ&hl=en&sa=X&ved=2ahUKEwjyg4rRufXfAhXvuFkKHfK8BysQ6AEwAnoECAcQAQ#v=snippet&q=%22overwrites%20the%20destination%20with%20the%20source%2C%20regardless%20of%20alpha%22&f=false
+				 *
+				 * https://docs.oracle.com/javase/8/javafx/api/javafx/scene/effect/BlendMode.html
+				 */
+				for (final ARGBType px : sourceImage.asArrayImg())
+					px.set(px.get() | (0xff << 24));
+
 				sourceImage.setPixelsDirty();
 				g.accept(sourceImage);
 				// TODO add countdown latch to wait for setImage to return

--- a/src/main/java/bdv/fx/viewer/render/TransformAwareBufferedImageOverlayRendererFX.java
+++ b/src/main/java/bdv/fx/viewer/render/TransformAwareBufferedImageOverlayRendererFX.java
@@ -48,6 +48,8 @@ public class TransformAwareBufferedImageOverlayRendererFX
 
 	private static Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
+	private static final int FULL_OPACITY = 0xff << 24;
+
 	protected AffineTransform3D pendingTransform;
 
 	protected AffineTransform3D paintedTransform;
@@ -115,7 +117,7 @@ public class TransformAwareBufferedImageOverlayRendererFX
 				 * https://docs.oracle.com/javase/8/javafx/api/javafx/scene/effect/BlendMode.html
 				 */
 				for (final ARGBType px : sourceImage.asArrayImg())
-					px.set(px.get() | (0xff << 24));
+					px.set(px.get() | FULL_OPACITY);
 
 				sourceImage.setPixelsDirty();
 				g.accept(sourceImage);

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceFX.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceFX.java
@@ -21,6 +21,7 @@ import net.imglib2.util.Intervals;
 import org.janelia.saalfeldlab.fx.util.InvokeOnJavaFXApplicationThread;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class OrthoSliceFX
@@ -78,6 +79,7 @@ public class OrthoSliceFX
 			if (newv == null)
 				return;
 			final CellGrid grid = newv.getGrid();
+			final int[] padding = newv.getPadding();
 			final int numMeshes = (int) Intervals.numElements(grid.getGridDimensions());
 			final long[] gridPos = new long[2];
 			final long[] min = new long[2];
@@ -87,11 +89,8 @@ public class OrthoSliceFX
 			for (int meshIndex = 0; meshIndex < numMeshes; ++meshIndex)
 			{
 				grid.getCellGridPositionFlat(meshIndex, gridPos);
-				min[0] = grid.getCellMin(0, gridPos[0]);
-				min[1] = grid.getCellMin(1, gridPos[1]);
 				grid.getCellDimensions(gridPos, min, dims);
-				max[0] = min[0] + dims[0] - 1;
-				max[1] = min[1] + dims[1] - 1;
+				Arrays.setAll(max, d -> min[d] + dims[d]);
 
 				final OrthoSliceMeshFX mesh = new OrthoSliceMeshFX(
 					new RealPoint(min[0], min[1]),
@@ -100,16 +99,23 @@ public class OrthoSliceFX
 					new RealPoint(min[0], max[1]),
 					new AffineTransform3D()
 				);
+
 				final MeshView mv = new MeshView(mesh);
 				final PhongMaterial material = new PhongMaterial();
 				mv.setCullFace(CullFace.NONE);
 				mv.setMaterial(material);
 				material.setDiffuseColor(Color.BLACK);
 				material.setSpecularColor(Color.BLACK);
+
+				final int[] paddedTextureSize = new int[2];
 				final ReadOnlyObjectProperty<Image> display = newv.imagePropertyAt(meshIndex);
 				display.addListener((obsIm, oldvIm, newvIm) -> {
-					if (newvIm != null)
-						InvokeOnJavaFXApplicationThread.invoke(() -> material.setSelfIlluminationMap(newvIm));
+					if (newvIm != null) {
+						paddedTextureSize[0] = (int) newvIm.getWidth();
+						paddedTextureSize[1] = (int) newvIm.getHeight();
+						mesh.updateTexCoords(paddedTextureSize, padding);
+						material.setSelfIlluminationMap(newvIm);
+					}
 				});
 				newMeshViews.add(mv);
 			}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceFX.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceFX.java
@@ -79,6 +79,7 @@ public class OrthoSliceFX
 			if (newv == null)
 				return;
 			final CellGrid grid = newv.getGrid();
+			final long[] dimensions = newv.getDimensions();
 			final int[] padding = newv.getPadding();
 			final int numMeshes = (int) Intervals.numElements(grid.getGridDimensions());
 			final long[] gridPos = new long[2];
@@ -90,7 +91,7 @@ public class OrthoSliceFX
 			{
 				grid.getCellGridPositionFlat(meshIndex, gridPos);
 				grid.getCellDimensions(gridPos, min, dims);
-				Arrays.setAll(max, d -> min[d] + dims[d]);
+				Arrays.setAll(max, d -> Math.min(min[d] + dims[d], dimensions[d]));
 
 				final OrthoSliceMeshFX mesh = new OrthoSliceMeshFX(
 					new RealPoint(min[0], min[1]),
@@ -107,13 +108,15 @@ public class OrthoSliceFX
 				material.setDiffuseColor(Color.BLACK);
 				material.setSpecularColor(Color.BLACK);
 
+				final double[] meshSizeToTextureSizeRatio = new double[2];
+				Arrays.setAll(meshSizeToTextureSizeRatio, d -> (double) (max[d] - min[d]) / dims[d]);
 				final int[] paddedTextureSize = new int[2];
 				final ReadOnlyObjectProperty<Image> display = newv.imagePropertyAt(meshIndex);
 				display.addListener((obsIm, oldvIm, newvIm) -> {
 					if (newvIm != null) {
 						paddedTextureSize[0] = (int) newvIm.getWidth();
 						paddedTextureSize[1] = (int) newvIm.getHeight();
-						mesh.updateTexCoords(paddedTextureSize, padding);
+						mesh.updateTexCoords(paddedTextureSize, padding, meshSizeToTextureSizeRatio);
 						material.setSelfIlluminationMap(newvIm);
 					}
 				});

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceMeshFX.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceMeshFX.java
@@ -45,12 +45,12 @@ public class OrthoSliceMeshFX extends TriangleMesh
 		setVertexFormat(VertexFormat.POINT_NORMAL_TEXCOORD);
 	}
 
-	public void updateTexCoords(final int[] paddedTextureSize, final int[] padding) {
+	public void updateTexCoords(final int[] paddedTextureSize, final int[] padding, final double[] meshSizeToTextureSizeRatio) {
 
 		for (int d = 0; d < 2; ++d) {
-			final float coord = (float) padding[d] / paddedTextureSize[d];
-			texCoordMin[d] = coord;
-			texCoordMax[d] = 1.f - coord;
+			final float unpaddedTextureCoord = (float) padding[d] / paddedTextureSize[d];
+			texCoordMin[d] = unpaddedTextureCoord;
+			texCoordMax[d] = unpaddedTextureCoord + (float) meshSizeToTextureSizeRatio[d] * (1.0f - 2 * unpaddedTextureCoord);
 		}
 
 		texCoords[0] = texCoordMin[0]; texCoords[1] = texCoordMin[1];

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceMeshFX.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceMeshFX.java
@@ -2,7 +2,6 @@ package org.janelia.saalfeldlab.paintera.viewer3d;
 
 import java.lang.invoke.MethodHandles;
 
-import javafx.collections.ObservableFloatArray;
 import javafx.scene.shape.ObservableFaceArray;
 import javafx.scene.shape.TriangleMesh;
 import javafx.scene.shape.VertexFormat;
@@ -23,27 +22,46 @@ public class OrthoSliceMeshFX extends TriangleMesh
 			0, 1, 2, 0, 2, 3
 	};
 
-	private static final float[] texcoords = {
-			0.0f, 0.0f,
-			1.0f, 0.0f,
-			1.0f, 1.0f,
-			0.0f, 1.0f
-	};
+	final float[] texCoordMin = new float[2], texCoordMax = new float[2];
+	final float[] texCoords = new float[2 * 4];
 
-	public OrthoSliceMeshFX(final RealLocalizable bottomLeft, final RealLocalizable bottomRight, final RealLocalizable
-			topRight, final RealLocalizable topLeft, final AffineTransform3D pointTransform)
+	public OrthoSliceMeshFX(
+		final RealLocalizable bottomLeft,
+		final RealLocalizable bottomRight,
+		final RealLocalizable topRight,
+		final RealLocalizable topLeft,
+		final AffineTransform3D pointTransform)
 	{
-		super();
-		getTexCoords().addAll(texcoords);
-		this.update(bottomLeft, bottomRight, topRight, topLeft, pointTransform);
+		setVertices(bottomLeft, bottomRight, topRight, topLeft, pointTransform);
+
+		setNormals(pointTransform);
+
+		getTexCoords().setAll(texCoords); // initialize tex coords
+
 		final ObservableFaceArray faceIndices = getFaces();
 		for (final int i : indices)
 			faceIndices.addAll(i, i, i);
-		setVertexFormat(VertexFormat.POINT_NORMAL_TEXCOORD);
 
+		setVertexFormat(VertexFormat.POINT_NORMAL_TEXCOORD);
 	}
 
-	public void update(
+	public void updateTexCoords(final int[] paddedTextureSize, final int[] padding) {
+
+		for (int d = 0; d < 2; ++d) {
+			final float coord = (float) padding[d] / paddedTextureSize[d];
+			texCoordMin[d] = coord;
+			texCoordMax[d] = 1.f - coord;
+		}
+
+		texCoords[0] = texCoordMin[0]; texCoords[1] = texCoordMin[1];
+		texCoords[2] = texCoordMax[0]; texCoords[3] = texCoordMin[1];
+		texCoords[4] = texCoordMax[0]; texCoords[5] = texCoordMax[1];
+		texCoords[6] = texCoordMin[0]; texCoords[7] = texCoordMax[1];
+
+		getTexCoords().setAll(texCoords);
+	}
+
+	private void setVertices(
 			final RealLocalizable bottomLeft,
 			final RealLocalizable bottomRight,
 			final RealLocalizable topRight,
@@ -51,14 +69,9 @@ public class OrthoSliceMeshFX extends TriangleMesh
 			final AffineTransform3D pointTransform)
 	{
 		final RealPoint p = new RealPoint(3);
-
 		final double offset = 0.0;
 
-		final ObservableFloatArray vertices = getPoints();
-		final ObservableFloatArray normals  = getNormals();
-
 		final float[] vertex = new float[3];
-
 		final float[] vertexBuffer = new float[3 * 4];
 
 		transformPoint(bottomLeft, p, pointTransform, offset);
@@ -77,6 +90,11 @@ public class OrthoSliceMeshFX extends TriangleMesh
 		p.localize(vertex);
 		System.arraycopy(vertex, 0, vertexBuffer, 9, 3);
 
+		getPoints().setAll(vertexBuffer);
+	}
+
+	private void setNormals(final AffineTransform3D pointTransform)
+	{
 		final float[] normal = new float[] {0.0f, 0.0f, 1.0f};
 		pointTransform.apply(normal, normal);
 		final float norm = normal[0] * normal[0] + normal[1] * normal[1] + normal[2] * normal[2];
@@ -88,10 +106,8 @@ public class OrthoSliceMeshFX extends TriangleMesh
 		System.arraycopy(normal, 0, normalBuffer, 3, 3);
 		System.arraycopy(normal, 0, normalBuffer, 6, 3);
 		System.arraycopy(normal, 0, normalBuffer, 9, 3);
-		vertices.clear();
-		normals.clear();
-		vertices.addAll(vertexBuffer);
-		normals.addAll(normalBuffer);
+
+		getNormals().setAll(normalBuffer);
 	}
 
 	private static <T extends RealPositionable & RealLocalizable> void transformPoint(


### PR DESCRIPTION
This is a revised version of #180. The difference is that the issue with scaling of border tiles here is solved differently: instead of rendering only the truncated part and keeping track of scaling coefficients, the border tiles are rendered in full, and then only the visible part is used.

Summary of changes:

- 1px padding is applied to each rendered tile on each side (the padding is always the same regardless of the screen scale used)
- Instead of using the grid layout to arrange tile images, they are now cropped (to remove the padding) and drawn onto a canvas at their corresponding grid position
- Texture coordinates for the meshes are recomputed each time the rendered tile image changes
- Border tiles are extended to be of the same size as regular tiles
- After a tile is rendered, its alpha channel is set to 1 to avoid blending problems