### PR TITLE
Different rendering modes for navigation/painting

### DIFF
--- a/src/main/java/bdv/fx/viewer/ViewerPanelFX.java
+++ b/src/main/java/bdv/fx/viewer/ViewerPanelFX.java
@@ -394,7 +394,7 @@ public class ViewerPanelFX
 		state.setViewerTransform(transform);
 		for (final TransformListener<AffineTransform3D> l : transformListeners)
 			l.transformChanged(viewerTransform);
-		renderingModeController.transformChanged(transform);
+		renderingModeController.transformChanged();
 		requestRepaint();
 	}
 
@@ -556,6 +556,11 @@ public class ViewerPanelFX
 	public OverlayPane<?> getDisplay()
 	{
 		return this.overlayPane;
+	}
+
+	public RenderingModeController getRenderingModeController()
+	{
+		return renderingModeController;
 	}
 
 	/**

--- a/src/main/java/bdv/fx/viewer/ViewerPanelFX.java
+++ b/src/main/java/bdv/fx/viewer/ViewerPanelFX.java
@@ -608,7 +608,7 @@ public class ViewerPanelFX
 							cellDims[0], cellDims[1] // dst width, height
 						);
 					}
-					renderingModeController.receivedRenderedImage(newv.getTag());
+					renderingModeController.receivedRenderedImage(newv.getTag(), newv.getScreenScaleIndex());
 				}
 			});
 		}

--- a/src/main/java/bdv/fx/viewer/ViewerPanelFX.java
+++ b/src/main/java/bdv/fx/viewer/ViewerPanelFX.java
@@ -227,6 +227,7 @@ public class ViewerPanelFX
 				options.getAccumulateProjectorFactory(),
 				cacheControl,
 				options.getTargetRenderNanos(),
+				options.getNumRenderingThreads(),
 				renderingExecutorService);
 
 		this.renderingModeController = new RenderingModeController(renderUnit);

--- a/src/main/java/bdv/fx/viewer/ViewerPanelFX.java
+++ b/src/main/java/bdv/fx/viewer/ViewerPanelFX.java
@@ -390,21 +390,24 @@ public class ViewerPanelFX
 	public synchronized void transformChanged(final AffineTransform3D transform)
 	{
 		viewerTransform.set(transform);
-		state.setViewerTransform(transform);
+		synchronized (state)
+		{
+		    state.setViewerTransform(transform);
+		    renderingModeController.transformChanged();
+		}
 		for (final TransformListener<AffineTransform3D> l : transformListeners)
 			l.transformChanged(viewerTransform);
-		renderingModeController.transformChanged();
 		requestRepaint();
 	}
 
 	/**
-	 * Get a copy of the current {@link ViewerState}.
+	 * Get the current {@link ViewerState}.
 	 *
-	 * @return a copy of the current {@link ViewerState}.
+	 * @return the current {@link ViewerState}.
 	 */
 	public ViewerState getState()
 	{
-		return state.copy();
+		return state;
 	}
 
 	/**

--- a/src/main/java/bdv/fx/viewer/ViewerPanelFX.java
+++ b/src/main/java/bdv/fx/viewer/ViewerPanelFX.java
@@ -598,7 +598,6 @@ public class ViewerPanelFX
 			final ReadOnlyObjectProperty<RenderUnit.RenderedImage> renderedImage = grid.renderedImagePropertyAt(i);
 			renderedImage.addListener((obs, oldv, newv) -> {
 				if (newv != null && newv.getImage() != null) {
-				    System.out.println("tag: " + newv.getTag());
 					if (renderingModeController.validateTag(newv.getTag())) {
 						final int[] padding = grid.getPadding();
 						canvas.getGraphicsContext2D().drawImage(

--- a/src/main/java/bdv/fx/viewer/ViewerPanelFX.java
+++ b/src/main/java/bdv/fx/viewer/ViewerPanelFX.java
@@ -31,6 +31,8 @@ package bdv.fx.viewer;
 
 import bdv.cache.CacheControl;
 import bdv.fx.viewer.render.RenderUnit;
+import bdv.fx.viewer.render.RenderingModeController;
+import bdv.fx.viewer.render.RenderingModeController.RenderingMode;
 import bdv.viewer.Interpolation;
 import bdv.viewer.RequestRepaint;
 import bdv.viewer.Source;
@@ -115,6 +117,8 @@ public class ViewerPanelFX
 	private final MouseCoordinateTracker mouseTracker = new MouseCoordinateTracker();
 
 	private final ObjectProperty<RenderUnit.ImagePropertyGrid> imageDisplayGrid = new SimpleObjectProperty<>(null);
+
+	private final RenderingModeController renderingModeController;
 
 	public ViewerPanelFX(
 			final List<SourceAndConverter<?>> sources,
@@ -233,6 +237,8 @@ public class ViewerPanelFX
 		setWidth(options.getWidth());
 		setHeight(options.getHeight());
 		setAllSources(sources);
+
+		this.renderingModeController = new RenderingModeController(renderUnit);
 	}
 
 	/**
@@ -389,6 +395,7 @@ public class ViewerPanelFX
 		state.setViewerTransform(transform);
 		for (final TransformListener<AffineTransform3D> l : transformListeners)
 			l.transformChanged(viewerTransform);
+		renderingModeController.transformChanged(transform);
 		requestRepaint();
 	}
 

--- a/src/main/java/bdv/fx/viewer/ViewerState.java
+++ b/src/main/java/bdv/fx/viewer/ViewerState.java
@@ -38,12 +38,12 @@ public class ViewerState
 			SourceAndConverter::getSpimSource
 	                                                                               );
 
-	protected void setViewerTransform(final AffineTransform3D to)
+	protected synchronized void setViewerTransform(final AffineTransform3D to)
 	{
 		this.viewerTransform.set(to);
 	}
 
-	public void getViewerTransform(final AffineTransform3D to)
+	public synchronized void getViewerTransform(final AffineTransform3D to)
 	{
 		to.set(this.viewerTransform);
 	}
@@ -83,7 +83,7 @@ public class ViewerState
 		this.axisOrder = axisOrder;
 	}
 
-	public ViewerState copy()
+	public synchronized ViewerState copy()
 	{
 		final ViewerState state = new ViewerState(this.axisOrder);
 		state.viewerTransform.set(viewerTransform);

--- a/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererGeneric.java
+++ b/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererGeneric.java
@@ -428,8 +428,10 @@ public class MultiResolutionRendererGeneric<T>
 
 	/**
 	 * Render image at the {@link #requestedScreenScaleIndex requested screen scale}.
+	 *
+	 * @return index of the screen scale used for rendering this image, or -1 if the rendering was not completed
 	 */
-	public boolean paint(
+	public int paint(
 			final List<SourceAndConverter<?>> sources,
 			final Function<Source<?>, AxisOrder> axisOrders,
 			final int timepoint,
@@ -438,7 +440,7 @@ public class MultiResolutionRendererGeneric<T>
 			final Object synchronizationLock)
 	{
 		if (display.getWidth() <= 0 || display.getHeight() <= 0)
-			return false;
+			return -1;
 
 		final boolean resized = checkResize();
 
@@ -546,9 +548,9 @@ public class MultiResolutionRendererGeneric<T>
 					requestRepaint(currentScreenScaleIndex);
 				}
 			}
-		}
 
-		return success;
+			return success ? currentScreenScaleIndex : -1;
+		}
 	}
 
 	/**

--- a/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererGeneric.java
+++ b/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererGeneric.java
@@ -535,7 +535,6 @@ public class MultiResolutionRendererGeneric<T>
 					requestRepaint(currentScreenScaleIndex - 1);
 				else if (!p.isValid())
 				{
-				    System.out.println("NOT VALID");
 					try
 					{
 						Thread.sleep(1);

--- a/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererGeneric.java
+++ b/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererGeneric.java
@@ -428,8 +428,10 @@ public class MultiResolutionRendererGeneric<T>
 
 	/**
 	 * Render image at the {@link #requestedScreenScaleIndex requested screen scale}.
+	 *
+	 * @return index of the rendered screen scale, or -1 if the rendering was not successful
 	 */
-	public boolean paint(
+	public int paint(
 			final List<SourceAndConverter<?>> sources,
 			final Function<Source<?>, AxisOrder> axisOrders,
 			final int timepoint,
@@ -438,7 +440,7 @@ public class MultiResolutionRendererGeneric<T>
 			final Object synchronizationLock)
 	{
 		if (display.getWidth() <= 0 || display.getHeight() <= 0)
-			return false;
+			return -1;
 
 		final boolean resized = checkResize();
 
@@ -546,9 +548,9 @@ public class MultiResolutionRendererGeneric<T>
 					requestRepaint(currentScreenScaleIndex);
 				}
 			}
-		}
 
-		return success;
+			return success ? currentScreenScaleIndex : -1;
+		}
 	}
 
 	/**

--- a/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererGeneric.java
+++ b/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererGeneric.java
@@ -428,10 +428,8 @@ public class MultiResolutionRendererGeneric<T>
 
 	/**
 	 * Render image at the {@link #requestedScreenScaleIndex requested screen scale}.
-	 *
-	 * @return index of the screen scale used for rendering this image, or -1 if the rendering was not completed
 	 */
-	public int paint(
+	public boolean paint(
 			final List<SourceAndConverter<?>> sources,
 			final Function<Source<?>, AxisOrder> axisOrders,
 			final int timepoint,
@@ -440,7 +438,7 @@ public class MultiResolutionRendererGeneric<T>
 			final Object synchronizationLock)
 	{
 		if (display.getWidth() <= 0 || display.getHeight() <= 0)
-			return -1;
+			return false;
 
 		final boolean resized = checkResize();
 
@@ -537,6 +535,7 @@ public class MultiResolutionRendererGeneric<T>
 					requestRepaint(currentScreenScaleIndex - 1);
 				else if (!p.isValid())
 				{
+				    System.out.println("NOT VALID");
 					try
 					{
 						Thread.sleep(1);
@@ -548,9 +547,9 @@ public class MultiResolutionRendererGeneric<T>
 					requestRepaint(currentScreenScaleIndex);
 				}
 			}
-
-			return success ? currentScreenScaleIndex : -1;
 		}
+
+		return success;
 	}
 
 	/**

--- a/src/main/java/bdv/fx/viewer/render/RenderUnit.java
+++ b/src/main/java/bdv/fx/viewer/render/RenderUnit.java
@@ -36,7 +36,7 @@ public class RenderUnit {
 
 	private static final int NUM_RENDERING_THREADS = 1;
 
-	private final int[] blockSize = {250, 250};
+	private final int[] blockSize = {Integer.MAX_VALUE, Integer.MAX_VALUE};
 
 	private final long[] dimensions = {1, 1};
 
@@ -112,7 +112,7 @@ public class RenderUnit {
 	 * Set size of total screen to be rendered
 	 *
 	 * @param dimX width of screen
-	 * @param dimY heighto f screen
+	 * @param dimY height of screen
 	 */
 	public void setDimensions(final long dimX, final long dimY)
 	{

--- a/src/main/java/bdv/fx/viewer/render/RenderUnit.java
+++ b/src/main/java/bdv/fx/viewer/render/RenderUnit.java
@@ -362,7 +362,7 @@ public class RenderUnit {
 				null
 			);
 
-			renderTarget.drawOverlays(img -> renderedImage.set(new RenderedImage(img, 0, renderedImageTag)));
+			renderTarget.drawOverlays(img -> renderedImage.set(new RenderedImage(img, renderedImageTag)));
 		}
 	}
 
@@ -384,26 +384,20 @@ public class RenderUnit {
 	}
 
 	/**
-	 * Utility class to represent rendering results that contains a rendered image and an index of the screen scale used for rendering.
+	 * Utility class to represent rendering results that contains a rendered image and an assigned tag.
 	 */
 	public static class RenderedImage
 	{
 		private final Image image;
-		private final int screenScaleIndex;
 		private final int tag;
 
-		public RenderedImage(final Image image, final int screenScaleIndex, final int tag) {
+		public RenderedImage(final Image image, final int tag) {
 			this.image = image;
-			this.screenScaleIndex = screenScaleIndex;
 			this.tag = tag;
 		}
 
 		public Image getImage() {
 			return image;
-		}
-
-		public int getScreenScaleIndex() {
-			return screenScaleIndex;
 		}
 
 		public int getTag() {

--- a/src/main/java/bdv/fx/viewer/render/RenderUnit.java
+++ b/src/main/java/bdv/fx/viewer/render/RenderUnit.java
@@ -353,7 +353,7 @@ public class RenderUnit {
 
 			viewerTransform.translate(-offset[0], -offset[1], 0);
 
-			renderer.paint(
+			final int renderedScreenScaleIndex = renderer.paint(
 				sacs,
 				axisOrder,
 				timepoint,
@@ -362,7 +362,7 @@ public class RenderUnit {
 				null
 			);
 
-			renderTarget.drawOverlays(img -> renderedImage.set(new RenderedImage(img, renderedImageTag)));
+			renderTarget.drawOverlays(img -> renderedImage.set(new RenderedImage(img, renderedImageTag, renderedScreenScaleIndex)));
 		}
 	}
 
@@ -384,16 +384,18 @@ public class RenderUnit {
 	}
 
 	/**
-	 * Utility class to represent rendering results that contains a rendered image and an assigned tag.
+	 * Utility class to represent rendering results that contains a rendered image, an assigned tag, and an index of the screen scale used for rendering.
 	 */
 	public static class RenderedImage
 	{
 		private final Image image;
 		private final int tag;
+		private final int screenScaleIndex;
 
-		public RenderedImage(final Image image, final int tag) {
+		public RenderedImage(final Image image, final int tag, final int screenScaleIndex) {
 			this.image = image;
 			this.tag = tag;
+			this.screenScaleIndex = screenScaleIndex;
 		}
 
 		public Image getImage() {
@@ -402,6 +404,10 @@ public class RenderUnit {
 
 		public int getTag() {
 			return tag;
+		}
+
+		public int getScreenScaleIndex() {
+			return screenScaleIndex;
 		}
 	}
 

--- a/src/main/java/bdv/fx/viewer/render/RenderingModeController.java
+++ b/src/main/java/bdv/fx/viewer/render/RenderingModeController.java
@@ -101,7 +101,7 @@ public class RenderingModeController {
 		LOG.debug("Painting has been stopped");
 		currentTag.getAndIncrement();
 		if (needRepaintAfterPainting) {
-		    renderUnit.requestRepaint();
+		    renderUnit.requestRepaint(0);
 		    needRepaintAfterPainting = false;
 		}
 	}

--- a/src/main/java/bdv/fx/viewer/render/RenderingModeController.java
+++ b/src/main/java/bdv/fx/viewer/render/RenderingModeController.java
@@ -47,7 +47,7 @@ public class RenderingModeController {
 
 		modeProperty.set(mode);
 		lastModeSwitchTag = currentTag.get();
-		System.out.println("Switching rendering mode to " + mode);
+		LOG.debug("Switching rendering mode to " + mode);
 
 		switch (mode) {
 		case MULTI_TILE:
@@ -75,7 +75,7 @@ public class RenderingModeController {
 	{
 		currentTag.getAndIncrement();
 		if (modeProperty.get() != RenderingMode.SINGLE_TILE) {
-			System.out.println("Navigation has been initiated");
+			LOG.debug("Navigation has been initiated");
 			InvokeOnJavaFXApplicationThread.invoke(() -> setMode(RenderingMode.SINGLE_TILE));
 		}
 	}
@@ -85,9 +85,7 @@ public class RenderingModeController {
 		final int tag = currentTag.getAndIncrement();
 		if (modeProperty.get() != RenderingMode.MULTI_TILE) {
 			final boolean needRepaint = lastReceivedTag != tag;
-			if (needRepaint)
-				System.out.println("=========== Have not received rendered image yet after last transform ===========");
-			System.out.println("Painting has been initiated");
+			LOG.debug("Painting has been initiated, needRepaint={}", needRepaint);
 			InvokeOnJavaFXApplicationThread.invoke(() -> {
 				setMode(RenderingMode.MULTI_TILE);
 				if (needRepaint)
@@ -98,8 +96,8 @@ public class RenderingModeController {
 
 	public void paintingFinished()
 	{
-		System.out.println("Painting has been stopped");
-		currentTag.incrementAndGet();
+		LOG.debug("Painting has been stopped");
+		currentTag.getAndIncrement();
 	}
 
 	public void receivedRenderedImage(final int tag)

--- a/src/main/java/bdv/fx/viewer/render/RenderingModeController.java
+++ b/src/main/java/bdv/fx/viewer/render/RenderingModeController.java
@@ -9,10 +9,7 @@ import org.janelia.saalfeldlab.fx.util.InvokeOnJavaFXApplicationThread;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import net.imglib2.realtransform.AffineTransform3D;
-import net.imglib2.ui.TransformListener;
-
-public class RenderingModeController implements TransformListener<AffineTransform3D> {
+public class RenderingModeController {
 
 	private static Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
@@ -58,14 +55,26 @@ public class RenderingModeController implements TransformListener<AffineTransfor
 		}
 	}
 
-	@Override
-	public void transformChanged(final AffineTransform3D transform)
+	public void transformChanged()
 	{
 		if (modeSwitchTimerTask != null)
 			modeSwitchTimerTask.cancel();
 
 		lastTransformChangedTime = System.currentTimeMillis();
 		InvokeOnJavaFXApplicationThread.invoke(() -> setMode(RenderingMode.SINGLE_TILE));
+	}
+
+	public void paintingStarted()
+	{
+		if (mode == RenderingMode.SINGLE_TILE) {
+			if (modeSwitchTimerTask != null)
+				modeSwitchTimerTask.cancel();
+
+			InvokeOnJavaFXApplicationThread.invoke(() -> {
+				setMode(RenderingMode.MULTI_TILE);
+				renderUnit.requestRepaint();
+			});
+		}
 	}
 
 	public void receivedRenderedImage(final int screenScaleIndex)

--- a/src/main/java/bdv/fx/viewer/render/RenderingModeController.java
+++ b/src/main/java/bdv/fx/viewer/render/RenderingModeController.java
@@ -1,0 +1,76 @@
+package bdv.fx.viewer.render;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Timer;
+import java.util.TimerTask;
+
+import org.apache.commons.lang.NotImplementedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.ui.TransformListener;
+
+public class RenderingModeController implements TransformListener<AffineTransform3D> {
+
+	private static Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+	public static enum RenderingMode {
+		MULTI_TILE,
+		SINGLE_TILE
+	}
+
+	private static final int[] DEFAULT_TILE_SIZE = {250, 250};
+
+	private final RenderUnit renderUnit;
+	private RenderingMode mode;
+
+	private final int modeSwitchDelay = 250;
+	private final Timer modeSwitchTimer;
+	private TimerTask modeSwitchTimerTask;
+
+	public RenderingModeController(final RenderUnit renderUnit)
+	{
+		this.renderUnit = renderUnit;
+		this.modeSwitchTimer = new Timer(true);
+		setMode(RenderingMode.MULTI_TILE);
+	}
+
+	public void setMode(final RenderingMode mode)
+	{
+		if (mode == this.mode)
+			return;
+
+		this.mode = mode;
+		LOG.debug("Switching rendering mode to " + mode);
+		switch (mode) {
+		case MULTI_TILE:
+			this.renderUnit.setBlockSize(DEFAULT_TILE_SIZE[0], DEFAULT_TILE_SIZE[1]);
+			break;
+		case SINGLE_TILE:
+			this.renderUnit.setBlockSize(Integer.MAX_VALUE, Integer.MAX_VALUE);
+			break;
+		default:
+			throw new NotImplementedException("Rendering mode " + mode + " is not implemented yet");
+		}
+	}
+
+	@Override
+	public void transformChanged(AffineTransform3D transform)
+	{
+		setMode(RenderingMode.SINGLE_TILE);
+
+		if (modeSwitchTimerTask != null)
+			modeSwitchTimerTask.cancel();
+
+		modeSwitchTimerTask = new TimerTask() {
+
+			@Override
+			public void run() {
+				setMode(RenderingMode.MULTI_TILE);
+			}
+		};
+
+		modeSwitchTimer.schedule(modeSwitchTimerTask, modeSwitchDelay);
+	}
+}

--- a/src/main/java/bdv/fx/viewer/render/RenderingModeController.java
+++ b/src/main/java/bdv/fx/viewer/render/RenderingModeController.java
@@ -5,6 +5,7 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 import org.apache.commons.lang.NotImplementedException;
+import org.janelia.saalfeldlab.fx.util.InvokeOnJavaFXApplicationThread;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +37,7 @@ public class RenderingModeController implements TransformListener<AffineTransfor
 		setMode(RenderingMode.MULTI_TILE);
 	}
 
-	public void setMode(final RenderingMode mode)
+	private void setMode(final RenderingMode mode)
 	{
 		if (mode == this.mode)
 			return;
@@ -58,7 +59,7 @@ public class RenderingModeController implements TransformListener<AffineTransfor
 	@Override
 	public void transformChanged(AffineTransform3D transform)
 	{
-		setMode(RenderingMode.SINGLE_TILE);
+		InvokeOnJavaFXApplicationThread.invoke(() -> setMode(RenderingMode.SINGLE_TILE));
 
 		if (modeSwitchTimerTask != null)
 			modeSwitchTimerTask.cancel();
@@ -67,7 +68,7 @@ public class RenderingModeController implements TransformListener<AffineTransfor
 
 			@Override
 			public void run() {
-				setMode(RenderingMode.MULTI_TILE);
+				InvokeOnJavaFXApplicationThread.invoke(() -> setMode(RenderingMode.MULTI_TILE));
 			}
 		};
 

--- a/src/main/java/bdv/fx/viewer/render/RenderingModeController.java
+++ b/src/main/java/bdv/fx/viewer/render/RenderingModeController.java
@@ -8,11 +8,14 @@ import org.janelia.saalfeldlab.fx.util.InvokeOnJavaFXApplicationThread;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+
 public class RenderingModeController {
 
 	private static Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-	private static enum RenderingMode {
+	public static enum RenderingMode {
 		MULTI_TILE,
 		SINGLE_TILE
 	}
@@ -20,7 +23,7 @@ public class RenderingModeController {
 	private static final int[] DEFAULT_TILE_SIZE = {200, 200};
 
 	private final RenderUnit renderUnit;
-	private RenderingMode mode;
+	private final ObjectProperty<RenderingMode> modeProperty = new SimpleObjectProperty<>();
 
 	private final AtomicInteger currentTag = new AtomicInteger();
 	private int lastReceivedTag;
@@ -32,12 +35,17 @@ public class RenderingModeController {
 		setMode(RenderingMode.MULTI_TILE);
 	}
 
+	public ObjectProperty<RenderingMode> getModeProperty()
+	{
+		return modeProperty;
+	}
+
 	private void setMode(final RenderingMode mode)
 	{
-		if (mode == this.mode)
+		if (mode == modeProperty.get())
 			return;
 
-		this.mode = mode;
+		modeProperty.set(mode);
 		lastModeSwitchTag = currentTag.get();
 		System.out.println("Switching rendering mode to " + mode);
 
@@ -66,7 +74,7 @@ public class RenderingModeController {
 	public void transformChanged()
 	{
 		currentTag.getAndIncrement();
-		if (mode != RenderingMode.SINGLE_TILE) {
+		if (modeProperty.get() != RenderingMode.SINGLE_TILE) {
 			System.out.println("Navigation has been initiated");
 			InvokeOnJavaFXApplicationThread.invoke(() -> setMode(RenderingMode.SINGLE_TILE));
 		}
@@ -75,7 +83,7 @@ public class RenderingModeController {
 	public void paintingStarted()
 	{
 		final int tag = currentTag.getAndIncrement();
-		if (mode != RenderingMode.MULTI_TILE) {
+		if (modeProperty.get() != RenderingMode.MULTI_TILE) {
 			final boolean needRepaint = lastReceivedTag != tag;
 			if (needRepaint)
 				System.out.println("=========== Have not received rendered image yet after last transform ===========");

--- a/src/main/java/bdv/fx/viewer/render/RenderingModeController.java
+++ b/src/main/java/bdv/fx/viewer/render/RenderingModeController.java
@@ -37,6 +37,7 @@ public class RenderingModeController {
 
 	private void setMode(final RenderingMode mode)
 	{
+		resetTimerTask();
 		if (mode == this.mode)
 			return;
 
@@ -57,19 +58,15 @@ public class RenderingModeController {
 
 	public void transformChanged()
 	{
-		if (modeSwitchTimerTask != null)
-			modeSwitchTimerTask.cancel();
-
+		resetTimerTask();
 		lastTransformChangedTime = System.currentTimeMillis();
 		InvokeOnJavaFXApplicationThread.invoke(() -> setMode(RenderingMode.SINGLE_TILE));
 	}
 
 	public void paintingStarted()
 	{
+		resetTimerTask();
 		if (mode == RenderingMode.SINGLE_TILE) {
-			if (modeSwitchTimerTask != null)
-				modeSwitchTimerTask.cancel();
-
 			InvokeOnJavaFXApplicationThread.invoke(() -> {
 				setMode(RenderingMode.MULTI_TILE);
 				renderUnit.requestRepaint();
@@ -92,6 +89,14 @@ public class RenderingModeController {
 				};
 				modeSwitchTimer.schedule(modeSwitchTimerTask, MODE_SWITCH_DELAY - Math.max(currentTime - lastTransformChangedTime, 0));
 			}
+		}
+	}
+
+	private void resetTimerTask()
+	{
+		if (modeSwitchTimerTask != null) {
+			modeSwitchTimerTask.cancel();
+			modeSwitchTimerTask = null;
 		}
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/IdSelector.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/IdSelector.java
@@ -145,13 +145,15 @@ public class IdSelector
 					synchronized (viewer)
 					{
 						final AffineTransform3D affine      = new AffineTransform3D();
+						final int level;
 						final ViewerState       viewerState = viewer.getState();
-						viewerState.getViewerTransform(affine);
-						final AffineTransform3D screenScaleTransforms = new AffineTransform3D();
-						final int               level                 = viewerState.getBestMipMapLevel(
-								screenScaleTransforms,
-								getIndexOf(dataSource, viewerState)
-						                                                                              );
+						synchronized (viewerState)
+						{
+							viewerState.getViewerTransform(affine);
+							final AffineTransform3D screenScaleTransforms = new AffineTransform3D();
+							level = viewerState.getBestMipMapLevel(screenScaleTransforms, getIndexOf(dataSource, viewerState));
+						}
+
 						dataSource.getSourceTransform(0, level, affine);
 						final RealTransformRealRandomAccessible<I, InverseRealTransform>.RealTransformRealRandomAccess
 								access = RealViews.transformReal(
@@ -242,12 +244,14 @@ public class IdSelector
 						if (lastSelection == Label.INVALID) { return; }
 
 						final AffineTransform3D viewerTransform = new AffineTransform3D();
+						final int level;
 						final ViewerState       viewerState     = viewer.getState();
-						viewerState.getViewerTransform(viewerTransform);
-						final int               level  = viewerState.getBestMipMapLevel(
-								viewerTransform,
-								getIndexOf(source, viewerState)
-						                                                               );
+						synchronized (viewerState)
+						{
+							viewerState.getViewerTransform(viewerTransform);
+							level = viewerState.getBestMipMapLevel(viewerTransform, getIndexOf(source, viewerState));
+						}
+
 						final AffineTransform3D affine = new AffineTransform3D();
 						dataSource.getSourceTransform(0, level, affine);
 						final RealRandomAccess<I> access = RealViews.transformReal(
@@ -308,12 +312,14 @@ public class IdSelector
 						if (lastSelection == Label.INVALID) { return; }
 
 						final AffineTransform3D viewerTransform = new AffineTransform3D();
+						final int level;
 						final ViewerState       viewerState     = viewer.getState();
-						viewerState.getViewerTransform(viewerTransform);
-						final int               level  = viewerState.getBestMipMapLevel(
-								viewerTransform,
-								getIndexOf(source, viewerState)
-						                                                               );
+						synchronized (viewerState)
+						{
+							viewerState.getViewerTransform(viewerTransform);
+							level = viewerState.getBestMipMapLevel(viewerTransform, getIndexOf(source, viewerState));
+						}
+
 						final AffineTransform3D affine = new AffineTransform3D();
 						dataSource.getSourceTransform(0, level, affine);
 						final RealTransformRealRandomAccessible<I, InverseRealTransform> transformedSource = RealViews
@@ -383,12 +389,14 @@ public class IdSelector
 						}
 
 						final AffineTransform3D viewerTransform = new AffineTransform3D();
+						final int level;
 						final ViewerState       viewerState     = viewer.getState();
-						viewerState.getViewerTransform(viewerTransform);
-						final int               level  = viewerState.getBestMipMapLevel(
-								viewerTransform,
-								getIndexOf(source, viewerState)
-						                                                               );
+						synchronized (viewerState)
+						{
+							viewerState.getViewerTransform(viewerTransform);
+							level = viewerState.getBestMipMapLevel(viewerTransform, getIndexOf(source, viewerState));
+						}
+
 						final AffineTransform3D affine = new AffineTransform3D();
 						dataSource.getSourceTransform(0, level, affine);
 						final RealTransformRealRandomAccessible<I, InverseRealTransform> transformedSource = RealViews
@@ -476,8 +484,13 @@ public class IdSelector
 		final AffineTransform3D viewerTransform = new AffineTransform3D();
 		final AffineTransform3D sourceTransform = new AffineTransform3D();
 		final ViewerState       state           = viewer.getState();
-		state.getViewerTransform(viewerTransform);
-		final int level = state.getBestMipMapLevel(viewerTransform, getIndexOf(dataSource, state));
+		final int level;
+		synchronized (state)
+		{
+			state.getViewerTransform(viewerTransform);
+			level = state.getBestMipMapLevel(viewerTransform, getIndexOf(dataSource, state));
+		}
+
 		dataSource.getSourceTransform(0, level, sourceTransform);
 
 		final RealRandomAccessible<I>                                    interpolatedSource = dataSource.getInterpolatedDataSource(

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/PaintActions2D.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/PaintActions2D.java
@@ -100,12 +100,13 @@ public class PaintActions2D
 			final MaskedSource<?, ?> maskedSource = (MaskedSource<?, ?>) source;
 
 			final AffineTransform3D viewerTransform = new AffineTransform3D();
-			state.getViewerTransform(viewerTransform);
 			final AffineTransform3D screenScaleTransform = new AffineTransform3D();
-			final int               level                = state.getBestMipMapLevel(
-					screenScaleTransform,
-					currentSource
-			                                                                       );
+			final int level;
+			synchronized (state)
+			{
+				state.getViewerTransform(viewerTransform);
+				level = state.getBestMipMapLevel(screenScaleTransform, currentSource);
+			}
 			maskedSource.getSourceTransform(0, level, labelToGlobalTransform);
 			this.labelToViewerTransform.set(viewerTransform.copy().concatenate(labelToGlobalTransform));
 			this.globalToViewerTransform.set(viewerTransform);

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/PaintClickOrDrag.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/PaintClickOrDrag.java
@@ -157,9 +157,13 @@ public class PaintClickOrDrag implements InstallAndRemove<Node> {
 					final MaskedSource<?, ?> source = (MaskedSource<?, ?>) currentSource;
 					final ViewerState state = viewer.getState();
 					final AffineTransform3D viewerTransform = new AffineTransform3D();
-					state.getViewerTransform(viewerTransform);
 					final AffineTransform3D screenScaleTransform = new AffineTransform3D();
-					final int               level                = state.getBestMipMapLevel(screenScaleTransform, currentSource);
+					final int level;
+					synchronized (state)
+					{
+						state.getViewerTransform(viewerTransform);
+						level = state.getBestMipMapLevel(screenScaleTransform, currentSource);
+					}
 					source.getSourceTransform(0, level, labelToGlobalTransform);
 					this.labelToViewerTransform.set(viewerTransform.copy().concatenate(labelToGlobalTransform));
 					this.globalToViewerTransform.set(viewerTransform);

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/PaintClickOrDrag.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/PaintClickOrDrag.java
@@ -171,6 +171,7 @@ public class PaintClickOrDrag implements InstallAndRemove<Node> {
 					this.fillLabel = 1;
 					this.interval = null;
 					this.paintIntoThis = source;
+					viewer.getRenderingModeController().paintingStarted();
 					position.update(event);
 					paint(position.x, position.y);
 				}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/PaintClickOrDrag.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/PaintClickOrDrag.java
@@ -242,13 +242,14 @@ public class PaintClickOrDrag implements InstallAndRemove<Node> {
 						LOG.debug("Not currently painting -- will not do anything");
 						return;
 					}
-					
+
 					if (this.paintIntoThis == null )
 					{
 						LOG.debug("No current source available -- will not do anything");
 						return;
 					}
 
+					viewer.getRenderingModeController().paintingFinished();
 					try {
 						this.paintIntoThis.applyMask(this.mask, this.interval, FOREGROUND_CHECK);
 					} catch (final Exception e) {

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/RestrictPainting.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/RestrictPainting.java
@@ -131,12 +131,13 @@ public class RestrictPainting
 			return;
 		}
 
-		final int               level          = viewerState.getBestMipMapLevel(
-				new AffineTransform3D(),
-				sourceInfo.currentSourceIndexInVisibleSources().get()
-		                                                                       );
+		final int level, time;
+		synchronized (viewerState)
+		{
+			level = viewerState.getBestMipMapLevel(new AffineTransform3D(), sourceInfo.currentSourceIndexInVisibleSources().get());
+			time = viewerState.timepointProperty().get();
+		}
 		final AffineTransform3D labelTransform = new AffineTransform3D();
-		final int               time           = viewerState.timepointProperty().get();
 		source.getSourceTransform(time, level, labelTransform);
 
 		final RealPoint rp = setCoordinates(x, y, viewer, labelTransform);

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceFX.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceFX.java
@@ -1,6 +1,7 @@
 package org.janelia.saalfeldlab.paintera.viewer3d;
 
 import bdv.fx.viewer.ViewerPanelFX;
+import bdv.fx.viewer.render.RenderUnit;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -111,13 +112,13 @@ public class OrthoSliceFX
 				final double[] meshSizeToTextureSizeRatio = new double[2];
 				Arrays.setAll(meshSizeToTextureSizeRatio, d -> (double) (max[d] - min[d]) / dims[d]);
 				final int[] paddedTextureSize = new int[2];
-				final ReadOnlyObjectProperty<Image> display = newv.imagePropertyAt(meshIndex);
-				display.addListener((obsIm, oldvIm, newvIm) -> {
-					if (newvIm != null) {
-						paddedTextureSize[0] = (int) newvIm.getWidth();
-						paddedTextureSize[1] = (int) newvIm.getHeight();
+				final ReadOnlyObjectProperty<RenderUnit.RenderedImage> renderedImage = newv.renderedImagePropertyAt(meshIndex);
+				renderedImage.addListener((obsIm, oldvIm, newvIm) -> {
+					if (newvIm != null && newvIm.getImage() != null) {
+						paddedTextureSize[0] = (int) newvIm.getImage().getWidth();
+						paddedTextureSize[1] = (int) newvIm.getImage().getHeight();
 						mesh.updateTexCoords(paddedTextureSize, padding, meshSizeToTextureSizeRatio);
-						material.setSelfIlluminationMap(newvIm);
+						material.setSelfIlluminationMap(newvIm.getImage());
 					}
 				});
 				newMeshViews.add(mv);

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceFX.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceFX.java
@@ -174,7 +174,7 @@ public class OrthoSliceFX
 			final int[] paddedTextureSize = new int[2];
 			final ReadOnlyObjectProperty<RenderUnit.RenderedImage> renderedImage = this.imagePropertyGrid.renderedImagePropertyAt(meshIndex);
 			renderedImage.addListener((obsIm, oldvIm, newvIm) -> {
-				if (newvIm != null && newvIm.getImage() != null) {
+				if (newvIm != null && newvIm.getImage() != null && this.viewer.getRenderingModeController().validateTag(newvIm.getTag())) {
 					paddedTextureSize[0] = (int) newvIm.getImage().getWidth();
 					paddedTextureSize[1] = (int) newvIm.getImage().getHeight();
 					mesh.updateTexCoords(paddedTextureSize, padding, meshSizeToTextureSizeRatio);

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceMeshFX.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceMeshFX.java
@@ -36,7 +36,7 @@ public class OrthoSliceMeshFX extends TriangleMesh
 
 		setNormals(pointTransform);
 
-		getTexCoords().setAll(texCoords); // initialize tex coords
+		updateTexCoords(); // initialize tex coords
 
 		final ObservableFaceArray faceIndices = getFaces();
 		for (final int i : indices)
@@ -52,6 +52,17 @@ public class OrthoSliceMeshFX extends TriangleMesh
 			texCoordMin[d] = unpaddedTextureCoord;
 			texCoordMax[d] = unpaddedTextureCoord + (float) meshSizeToTextureSizeRatio[d] * (1.0f - 2 * unpaddedTextureCoord);
 		}
+		updateTexCoords();
+	}
+
+	public void updateTexCoords(final float[] min, final float[] max) {
+
+		texCoordMin[0] = min[0]; texCoordMin[1] = min[1];
+		texCoordMax[0] = max[0]; texCoordMax[1] = max[1];
+		updateTexCoords();
+	}
+
+	private void updateTexCoords() {
 
 		texCoords[0] = texCoordMin[0]; texCoords[1] = texCoordMin[1];
 		texCoords[2] = texCoordMax[0]; texCoords[3] = texCoordMin[1];


### PR DESCRIPTION
**Motivation**: multi-tile rendering (currently used rendering scheme) enables very responsive painting which is great. But, when browsing through a dataset, the tiles are rendered and updated at different times, and the picture may look inconsistent, especially during rapid zooming/translation/rotation.

This PR allows the renderer to work in two different modes: rendering the entire screen as a single image (for navigation), and rendering it as multiple tile images (for painting). This way, the picture looks consistent when browsing the data while painting is kept responsive.

------------------------------

**Changes:** The new class `RenderingModeController` switches between the modes when needed by using `renderUnit.setBlockSize()` and keeps track of some extra information.
When switching between the modes, repaint is generally not required because the canvas already displays the most recent state. However, when painting is initiated before the most recent viewer transformation has been rendered, the repaint is needed (otherwise, only the user-painted tile will have up-to-date transformation while the rest of the canvas will be left with an older frame).

To ensure this consistency, I added a tag to each rendered image that is incremented whenever the viewer transformation changes, or painting is started/finished. `RenderingModeController` also keeps track of the last received tag, so that it knows whether the most recent transformation has been displayed or not.

To avoid race conditions, the renderer code synchronizes on `viewerState` when fetching the current viewer transform and generating a tag for the new frame.

3D orthoslice views also need to be updated carefully when the mode switch occurs so that they always have a valid texture:
* *Single-tile -> multi-tile*: the current texture of the mesh is used to initialize the new smaller meshes.
* *Multi-tile -> single-tile*: the update is postponed until the next rendered frame is received (this way the texture will be available immediately)

------------------------------

**Demo**

Current master:

![master-optimized](https://user-images.githubusercontent.com/6253116/52306679-9a154900-2966-11e9-9590-f35d8f5ca94e.gif)

This PR:

![pr-optimized](https://user-images.githubusercontent.com/6253116/52306687-9ed9fd00-2966-11e9-9c3c-033fe7aed2a4.gif)
