### PR TITLE
Log exception only in DEBUG mode

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/util/n5/N5FragmentSegmentAssignmentInitialLut.java
+++ b/src/main/java/org/janelia/saalfeldlab/util/n5/N5FragmentSegmentAssignmentInitialLut.java
@@ -57,7 +57,7 @@ public class N5FragmentSegmentAssignmentInitialLut implements Supplier<TLongLong
 			return new TLongLongHashMap(keys, values);
 		} catch (IOException e) {
 			LOG.debug("Exception while trying to return initial lut from N5", e);
-			LOG.error("Unable to read initial lut from {} -- returning empty map", meta, e);
+			LOG.info("Unable to read initial lut from {} -- returning empty map", meta);
 			return new TLongLongHashMap();
 		}
 	}


### PR DESCRIPTION
Spamming users with exceptions that do not have any effect is just confusing.

Also, info seems to be a better log level here