### PR TITLE
Expose thresholding config through GUI and add shortcut to create threshold from RAW

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Usage: Paintera [-h] [--default-to-temp-directory] [--print-error-codes]
 | `L` | Lock last selected segment (if label source) |
 | `Ctrl` + `S` | Save current project state |
 | `Ctrl` + `Shift` + `N` | Create new label dataset |
+| `Ctrl` + `T` | Threshold raw source (only available if current source is raw source) |
 
 ## Data
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/serialization/sourcestate/ThresholdingSourceStateDeserializer.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/serialization/sourcestate/ThresholdingSourceStateDeserializer.java
@@ -13,6 +13,7 @@ import com.google.gson.JsonParseException;
 import net.imglib2.type.numeric.ARGBType;
 import org.ejml.factory.DecompositionFactory;
 import org.janelia.saalfeldlab.paintera.serialization.PainteraSerialization;
+import org.janelia.saalfeldlab.paintera.serialization.SerializationHelpers;
 import org.janelia.saalfeldlab.paintera.serialization.StatefulSerializer;
 import org.janelia.saalfeldlab.paintera.serialization.StatefulSerializer.Arguments;
 import org.janelia.saalfeldlab.paintera.state.RawSourceState;
@@ -92,8 +93,21 @@ public class ThresholdingSourceStateDeserializer implements JsonDeserializer<Thr
 		final ARGBType   background   = Colors.toARGBType(converterMap.get(ThresholdingSourceStateSerializer
 				.BACKGROUND_COLOR_KEY).getAsString());
 		LOG.debug("Got foreground={} and background={}", foreground, background);
-		state.converter().setMasked(foreground);
-		state.converter().setNotMasked(background);
+		state.colorProperty().set(Colors.toColor(foreground));
+		state.backgroundColorProperty().set(Colors.toColor(background));
+
+		if (map.has(ThresholdingSourceStateSerializer.COMPOSITE_KEY)) {
+			try {
+				state
+						.compositeProperty()
+						.set(SerializationHelpers.deserializeFromClassInfo(
+								map.getAsJsonObject(ThresholdingSourceStateSerializer.COMPOSITE_KEY),
+								context));
+			} catch (final ClassNotFoundException e) {
+				throw new JsonParseException(e);
+			}
+		}
+
 		return state;
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/serialization/sourcestate/ThresholdingSourceStateDeserializer.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/serialization/sourcestate/ThresholdingSourceStateDeserializer.java
@@ -108,6 +108,15 @@ public class ThresholdingSourceStateDeserializer implements JsonDeserializer<Thr
 			}
 		}
 
+		if (map.has(ThresholdingSourceStateSerializer.MIN_KEY))
+			state.minProperty().set(map.get(ThresholdingSourceStateSerializer.MIN_KEY).getAsDouble());
+
+		if (map.has(ThresholdingSourceStateSerializer.MAX_KEY))
+			state.maxProperty().set(map.get(ThresholdingSourceStateSerializer.MAX_KEY).getAsDouble());
+
+		if (map.has(ThresholdingSourceStateSerializer.CONTROL_SEPARATELY_KEY))
+			state.controlSeparatelyProperty().set(map.get(ThresholdingSourceStateSerializer.CONTROL_SEPARATELY_KEY).getAsBoolean());
+
 		return state;
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/serialization/sourcestate/ThresholdingSourceStateSerializer.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/serialization/sourcestate/ThresholdingSourceStateSerializer.java
@@ -9,6 +9,7 @@ import java.util.function.ToIntFunction;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
+import org.janelia.saalfeldlab.paintera.serialization.SerializationHelpers;
 import org.janelia.saalfeldlab.paintera.serialization.StatefulSerializer;
 import org.janelia.saalfeldlab.paintera.state.SourceState;
 import org.janelia.saalfeldlab.paintera.state.ThresholdingSourceState;
@@ -31,6 +32,8 @@ public class ThresholdingSourceStateSerializer implements JsonSerializer<Thresho
 	public static final String FOREGROUND_COLOR_KEY = "foreground";
 
 	public static final String BACKGROUND_COLOR_KEY = "background";
+
+	public static final String COMPOSITE_KEY = "composite";
 
 	private final ToIntFunction<SourceState<?, ?>> stateToIndex;
 
@@ -70,6 +73,7 @@ public class ThresholdingSourceStateSerializer implements JsonSerializer<Thresho
 		converterMap.addProperty(FOREGROUND_COLOR_KEY, Colors.toHTML(state.converter().getMasked()));
 		converterMap.addProperty(BACKGROUND_COLOR_KEY, Colors.toHTML(state.converter().getNotMasked()));
 		map.add(CONVERTER_KEY, converterMap);
+		map.add(COMPOSITE_KEY, SerializationHelpers.serializeWithClassInfo(state.compositeProperty().get(), context));
 		return map;
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/serialization/sourcestate/ThresholdingSourceStateSerializer.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/serialization/sourcestate/ThresholdingSourceStateSerializer.java
@@ -35,6 +35,12 @@ public class ThresholdingSourceStateSerializer implements JsonSerializer<Thresho
 
 	public static final String COMPOSITE_KEY = "composite";
 
+	public static final String MIN_KEY = "min";
+
+	public static final String MAX_KEY = "max";
+
+	public static final String CONTROL_SEPARATELY_KEY = "controlSeparately";
+
 	private final ToIntFunction<SourceState<?, ?>> stateToIndex;
 
 	public ThresholdingSourceStateSerializer(final ToIntFunction<SourceState<?, ?>> stateToIndex)
@@ -74,6 +80,9 @@ public class ThresholdingSourceStateSerializer implements JsonSerializer<Thresho
 		converterMap.addProperty(BACKGROUND_COLOR_KEY, Colors.toHTML(state.converter().getNotMasked()));
 		map.add(CONVERTER_KEY, converterMap);
 		map.add(COMPOSITE_KEY, SerializationHelpers.serializeWithClassInfo(state.compositeProperty().get(), context));
+		map.addProperty(MIN_KEY, state.minProperty().get());
+		map.addProperty(MAX_KEY, state.maxProperty().get());
+		map.addProperty(CONTROL_SEPARATELY_KEY, state.controlSeparatelyProperty().get());
 		return map;
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/RawSourceState.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/RawSourceState.java
@@ -1,6 +1,10 @@
 package org.janelia.saalfeldlab.paintera.state;
 
 import bdv.util.volatiles.VolatileTypeMatcher;
+import javafx.event.Event;
+import javafx.event.EventHandler;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.ARGBColorConverter;
 import net.imglib2.converter.Converters;
@@ -12,6 +16,9 @@ import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.volatiles.AbstractVolatileNativeRealType;
 import net.imglib2.util.Util;
 import net.imglib2.view.Views;
+import org.janelia.saalfeldlab.fx.event.DelegateEventHandlers;
+import org.janelia.saalfeldlab.fx.event.EventFX;
+import org.janelia.saalfeldlab.fx.event.KeyTracker;
 import org.janelia.saalfeldlab.paintera.PainteraBaseView;
 import org.janelia.saalfeldlab.paintera.cache.InvalidateAll;
 import org.janelia.saalfeldlab.paintera.composition.Composite;
@@ -20,10 +27,16 @@ import org.janelia.saalfeldlab.paintera.data.DataSource;
 import org.janelia.saalfeldlab.paintera.data.RandomAccessibleIntervalDataSource;
 import org.janelia.saalfeldlab.paintera.data.axisorder.AxisOrder;
 import org.janelia.saalfeldlab.paintera.data.axisorder.AxisOrderNotSupported;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
 
 public class RawSourceState<D, T extends RealType<T>>
 		extends MinimalSourceState<D, T, DataSource<D, T>, ARGBColorConverter<T>>
 {
+
+	private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
 	public RawSourceState(
 			final DataSource<D, T> dataSource,
@@ -123,6 +136,15 @@ public class RawSourceState<D, T extends RealType<T>>
 				name
 		);
 
+	}
+
+	@Override
+	public EventHandler<Event> stateSpecificGlobalEventHandler(PainteraBaseView paintera, KeyTracker keyTracker) {
+		LOG.debug("Returning {}-specific global handler", getClass().getSimpleName());
+		final DelegateEventHandlers.AnyHandler handler = DelegateEventHandlers.handleAny();
+		final EventHandler<KeyEvent> threshold = new RawSourceStateThreshold(this).keyPressedHandler(paintera, keyTracker, KeyCode.CONTROL, KeyCode.T);
+		handler.addEventHandler(KeyEvent.KEY_PRESSED, threshold);
+		return handler;
 	}
 
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/RawSourceStateThreshold.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/RawSourceStateThreshold.java
@@ -1,0 +1,141 @@
+package org.janelia.saalfeldlab.paintera.state;
+
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.event.Event;
+import javafx.event.EventHandler;
+import javafx.scene.Node;
+import javafx.scene.control.Alert;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.ColorPicker;
+import javafx.scene.control.DialogPane;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.Priority;
+import javafx.scene.paint.Color;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.volatiles.AbstractVolatileRealType;
+import org.janelia.saalfeldlab.fx.Labels;
+import org.janelia.saalfeldlab.fx.event.KeyTracker;
+import org.janelia.saalfeldlab.paintera.PainteraBaseView;
+import org.janelia.saalfeldlab.paintera.ui.PainteraAlerts;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+public class RawSourceStateThreshold<D extends RealType<D>, T extends AbstractVolatileRealType<D, T>> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+	private final RawSourceState<D, T> toBeThresholded;
+
+	public RawSourceStateThreshold(final RawSourceState<D, T> toBeThresholded) {
+		this.toBeThresholded = toBeThresholded;
+	}
+
+	public EventHandler<KeyEvent> keyPressedHandler(
+			final PainteraBaseView pbv,
+			final KeyTracker keyTracker,
+			final KeyCode... keys) {
+		return new Handler<>(
+				pbv,
+				e -> KeyEvent.KEY_PRESSED.equals(e.getEventType()) && keyTracker.areOnlyTheseKeysDown(keys));
+	}
+
+	private final class Handler<E extends Event> implements EventHandler<E> {
+
+		private final PainteraBaseView pbv;
+
+		private final Predicate<E> test;
+
+		private Handler(
+				final PainteraBaseView pbv,
+				final Predicate<E> test) {
+			this.pbv = pbv;
+			this.test = test;
+		}
+
+		@Override
+		public void handle(E event) {
+			if (test.test(event)) {
+				event.consume();
+
+				final Label sourceIndexLabel = Labels.withTooltip("Source Index", "Index of the raw source to be thresholded.");
+				final Label sourceNameLabel = Labels.withTooltip("Source Name", "Name of the raw source to be thresholded.");
+				final Label targetNameLabel = Labels.withTooltip("Target Name", "Name of the new, thresholded source");
+				final Label foregroundColorLabel = Labels.withTooltip("Foreground Color", "Color of foreground in thresholded source.");
+				final Label backgroundColorLabel = Labels.withTooltip("Background Color", "Color of background in thresholded source.");
+
+				final TextField sourceIndex = new TextField(Integer.toString(pbv.sourceInfo().indexOf(toBeThresholded.dataSource())));
+				final TextField sourceName = new TextField(toBeThresholded.nameProperty().get());
+				final TextField targetName = new TextField(sourceName.getText() + "-thresholded");
+				final ColorPicker foregroundColorPicker = new ColorPicker(Color.WHITE);
+				final ColorPicker backgroundColorPicker = new ColorPicker(Color.BLACK);
+				foregroundColorPicker.getStyleClass().add("button");
+				backgroundColorPicker.getStyleClass().add("button");
+				foregroundColorPicker.setMaxWidth(Double.MAX_VALUE);
+				backgroundColorPicker.setMaxWidth(Double.MAX_VALUE);
+
+				sourceIndex.setEditable(false);
+				sourceIndex.setDisable(true);
+				sourceName.setEditable(false);
+				sourceName.setDisable(true);
+
+				final GridPane contents = new GridPane();
+				contents.add(sourceIndexLabel, 0, 0);
+				contents.add(sourceNameLabel, 0, 1);
+				contents.add(targetNameLabel, 0, 2);
+				contents.add(foregroundColorLabel, 0, 3);
+				contents.add(backgroundColorLabel, 0, 4);
+
+				contents.add(sourceIndex, 1, 0);
+				contents.add(sourceName, 1, 1);
+				contents.add(targetName, 1, 2);
+				contents.add(foregroundColorPicker, 1, 3);
+				contents.add(backgroundColorPicker, 1, 4);
+
+				GridPane.setHgrow(sourceIndex, Priority.ALWAYS);
+				GridPane.setHgrow(sourceName, Priority.ALWAYS);
+				GridPane.setHgrow(targetName, Priority.ALWAYS);
+				GridPane.setHgrow(foregroundColorPicker, Priority.ALWAYS);
+				GridPane.setHgrow(backgroundColorPicker, Priority.ALWAYS);
+
+				final Alert dialog = PainteraAlerts.alert(Alert.AlertType.CONFIRMATION);
+				dialog.getDialogPane().setContent(contents);
+				dialog.setHeaderText(String.format("Threshold raw source `%s'", sourceName.getText()));
+				((Button)dialog.getDialogPane().lookupButton(ButtonType.OK)).setText("Threshold");
+				makeMnemonic(dialog.getDialogPane());
+
+				final Optional<ButtonType> buttonType = dialog.showAndWait();
+				if (buttonType.filter(ButtonType.OK::equals).isPresent()) {
+					final ThresholdingSourceState<D, T> thresholdedState = new ThresholdingSourceState<>(targetName.getText(), toBeThresholded);
+					LOG.debug("Foreground color is {}", foregroundColorPicker.getValue());
+					thresholdedState.colorProperty().set(foregroundColorPicker.getValue());
+					LOG.debug("Background color is {}", backgroundColorPicker.getValue());
+					thresholdedState.backgroundColorProperty().set(backgroundColorPicker.getValue());
+					pbv.addState(thresholdedState);
+				}
+			}
+		}
+	}
+
+	private static void makeMnemonic(final DialogPane dialog) {
+		dialog
+				.getButtonTypes()
+				.stream()
+				.map(dialog::lookupButton)
+				.forEach(RawSourceStateThreshold::makeMnemonic);
+	}
+
+	private static void makeMnemonic(final Node button) {
+		if (button instanceof Button)
+			((Button) button).setText("_" + ((Button) button).getText());
+	}
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/ThresholdingSourceState.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/ThresholdingSourceState.java
@@ -33,6 +33,8 @@ public class ThresholdingSourceState<D extends RealType<D>, T extends AbstractVo
 
 	private final ObjectProperty<Color> color = new SimpleObjectProperty<>(Color.WHITE);
 
+	private final ObjectProperty<Color> backgroundColor = new SimpleObjectProperty<>(Color.BLACK);
+
 	private final DoubleProperty alpha = new SimpleDoubleProperty(1.0);
 
 	private final Threshold<D> threshold;
@@ -55,6 +57,8 @@ public class ThresholdingSourceState<D extends RealType<D>, T extends AbstractVo
 		     );
 		this.threshold = getDataSource().getPredicate();
 		this.axisOrderProperty().bindBidirectional(toBeThresholded.axisOrderProperty());
+		this.color.addListener((obs, oldv, newv) -> converter().setMasked(Colors.toARGBType(newv)));
+		this.backgroundColor.addListener((obs, oldv, newv) -> converter().setNotMasked(Colors.toARGBType(newv)));
 	}
 
 	public Threshold<D> getThreshold()
@@ -75,6 +79,9 @@ public class ThresholdingSourceState<D extends RealType<D>, T extends AbstractVo
 	public ObjectProperty<Color> colorProperty()
 	{
 		return this.color;
+	}
+	public ObjectProperty<Color> backgroundColorProperty() {
+		return this.backgroundColor;
 	}
 
 	public DoubleProperty alphaProperty()

--- a/src/main/java/org/janelia/saalfeldlab/paintera/ui/source/state/SourceStateUIElementsDefaultFactory.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/ui/source/state/SourceStateUIElementsDefaultFactory.java
@@ -2,21 +2,26 @@ package org.janelia.saalfeldlab.paintera.ui.source.state;
 
 import gnu.trove.set.hash.TLongHashSet;
 import javafx.beans.InvalidationListener;
+import javafx.beans.property.DoubleProperty;
 import javafx.scene.Node;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
+import javafx.scene.control.CheckBox;
 import javafx.scene.control.Dialog;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TitledPane;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import net.imglib2.converter.Converter;
 import org.janelia.saalfeldlab.fx.Labels;
 import org.janelia.saalfeldlab.fx.TitledPanes;
+import org.janelia.saalfeldlab.fx.ui.NumberField;
+import org.janelia.saalfeldlab.fx.ui.ObjectField;
 import org.janelia.saalfeldlab.fx.undo.UndoFromEvents;
 import org.janelia.saalfeldlab.paintera.control.assignment.FragmentSegmentAssignmentState;
 import org.janelia.saalfeldlab.paintera.control.assignment.FragmentSegmentAssignmentStateWithActionTracker;
@@ -31,6 +36,7 @@ import org.janelia.saalfeldlab.paintera.meshes.MeshInfos;
 import org.janelia.saalfeldlab.paintera.meshes.MeshManager;
 import org.janelia.saalfeldlab.paintera.state.LabelSourceState;
 import org.janelia.saalfeldlab.paintera.state.SourceState;
+import org.janelia.saalfeldlab.paintera.state.ThresholdingSourceState;
 import org.janelia.saalfeldlab.paintera.ui.BindUnbindAndNodeSupplier;
 import org.janelia.saalfeldlab.paintera.ui.source.MaskedSourcePane;
 import org.janelia.saalfeldlab.paintera.ui.source.axisorder.AxisOrderPane;
@@ -121,6 +127,43 @@ public class SourceStateUIElementsDefaultFactory implements SourceStateUIElement
 		@Override
 		public Class<LabelSourceState> getTargetClass() {
 			return LabelSourceState.class;
+		}
+	}
+
+	@Plugin(type = AdditionalBindUnbindSuppliersFactory.class)
+	public static class ThreshodlingSourceStateBindAndUNbindSupplierFactory implements AdditionalBindUnbindSuppliersFactory<ThresholdingSourceState<?, ?>> {
+
+		@Override
+		public BindUnbindAndNodeSupplier[] create(ThresholdingSourceState<?, ?> state) {
+
+			final Supplier<Node> converter = () -> {
+				final CheckBox checkBox = new CheckBox("From Raw Source");
+				checkBox.setTooltip(new Tooltip(
+						"When selected, use min and max from underlying raw source for threshold, " +
+						"use min and max below otherwise."));
+				checkBox.setSelected(!state.controlSeparatelyProperty().get());
+				checkBox.selectedProperty().addListener((obs, oldv, newv) -> state.controlSeparatelyProperty().set(!newv));
+				// TODO should we also listen on state.controLSeparatelyProperty?
+				// TODO currently, no other way to change it, so maybe not (for now)
+				final NumberField<DoubleProperty> min = NumberField.doubleField(state.minProperty().get(), d -> true, ObjectField.SubmitOn.ENTER_PRESSED, ObjectField.SubmitOn.FOCUS_LOST);
+				final NumberField<DoubleProperty> max = NumberField.doubleField(state.maxProperty().get(), d -> true, ObjectField.SubmitOn.ENTER_PRESSED, ObjectField.SubmitOn.FOCUS_LOST);
+				min.valueProperty().addListener((obs, oldv, newv) -> state.minProperty().set(newv.doubleValue()));
+				max.valueProperty().addListener((obs, oldv, newv) -> state.maxProperty().set(newv.doubleValue()));
+				final GridPane minMax = new GridPane();
+				minMax.add(new Label("min"), 0, 0);
+				minMax.add(new Label("max"), 0, 1);
+				minMax.add(min.textField(), 1, 0);
+				minMax.add(max.textField(), 1, 1);
+				GridPane.setHgrow(min.textField(), Priority.ALWAYS);
+				GridPane.setHgrow(max.textField(), Priority.ALWAYS);
+				return TitledPanes.createCollapsed("Threshold", new VBox(checkBox, minMax));
+			};
+			return new BindUnbindAndNodeSupplier[] {BindUnbindAndNodeSupplier.noBind(converter)};
+		}
+
+		@Override
+		public Class<ThresholdingSourceState<?, ?>> getTargetClass() {
+			return (Class<ThresholdingSourceState<?, ?>>) (Class) ThresholdingSourceState.class;
 		}
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/ui/source/state/SourceStateUIElementsDefaultFactory.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/ui/source/state/SourceStateUIElementsDefaultFactory.java
@@ -8,6 +8,7 @@ import javafx.scene.control.Alert;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.CheckBox;
+import javafx.scene.control.ColorPicker;
 import javafx.scene.control.Dialog;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
@@ -149,13 +150,27 @@ public class SourceStateUIElementsDefaultFactory implements SourceStateUIElement
 				final NumberField<DoubleProperty> max = NumberField.doubleField(state.maxProperty().get(), d -> true, ObjectField.SubmitOn.ENTER_PRESSED, ObjectField.SubmitOn.FOCUS_LOST);
 				min.valueProperty().addListener((obs, oldv, newv) -> state.minProperty().set(newv.doubleValue()));
 				max.valueProperty().addListener((obs, oldv, newv) -> state.maxProperty().set(newv.doubleValue()));
+
+				final ColorPicker foreground = new ColorPicker(state.colorProperty().get());
+				final ColorPicker background = new ColorPicker(state.backgroundColorProperty().get());
+				foreground.valueProperty().addListener((obs, oldv, newv) -> state.colorProperty().set(newv));
+				background.valueProperty().addListener((obs, oldv, newv) -> state.backgroundColorProperty().set(newv));
+
 				final GridPane minMax = new GridPane();
 				minMax.add(new Label("min"), 0, 0);
 				minMax.add(new Label("max"), 0, 1);
+				minMax.add(new Label("foreground"), 0, 2);
+				minMax.add(new Label("background"), 0, 3);
+
 				minMax.add(min.textField(), 1, 0);
 				minMax.add(max.textField(), 1, 1);
+				minMax.add(foreground, 1, 2);
+				minMax.add(background, 1, 3);
+
 				GridPane.setHgrow(min.textField(), Priority.ALWAYS);
 				GridPane.setHgrow(max.textField(), Priority.ALWAYS);
+				GridPane.setHgrow(foreground, Priority.ALWAYS);
+				GridPane.setHgrow(background, Priority.ALWAYS);
 				return TitledPanes.createCollapsed("Threshold", new VBox(checkBox, minMax));
 			};
 			return new BindUnbindAndNodeSupplier[] {BindUnbindAndNodeSupplier.noBind(converter)};


### PR DESCRIPTION
Closes #212 
When raw source is active, press `ctrl-T` to open dialog for adding appropriate source.

This also gave me the idea for a more general predicate source with an arbitrary number of filters (greater, smaller, greater equal, smaller equal, equal).