### PR TITLE
Interactive progress indicator for flood filling

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFill.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFill.java
@@ -13,8 +13,6 @@ import java.util.function.Supplier;
 import bdv.fx.viewer.ViewerPanelFX;
 import bdv.fx.viewer.ViewerState;
 import bdv.viewer.Source;
-import javafx.scene.Cursor;
-import javafx.scene.Scene;
 import net.imglib2.Interval;
 import net.imglib2.Localizable;
 import net.imglib2.Point;
@@ -160,8 +158,6 @@ public class FloodFill
 		}
 
 		LOG.debug("Filling source {} with label {} at {}", source, fill, p);
-		final Scene  scene          = viewer.getScene();
-		final Cursor previousCursor = scene.getCursor();
 		try
 		{
 			if (t instanceof LabelMultisetType)
@@ -171,9 +167,7 @@ public class FloodFill
 						time,
 						level,
 						fill,
-						p,
-						new RunAll(requestRepaint, () -> scene.setCursor(Cursor.WAIT)),
-						new RunAll(requestRepaint, () -> scene.setCursor(previousCursor))
+						p
 				            );
 			}
 			else
@@ -183,9 +177,7 @@ public class FloodFill
 						time,
 						level,
 						fill,
-						p,
-						new RunAll(requestRepaint, () -> scene.setCursor(Cursor.WAIT)),
-						new RunAll(requestRepaint, () -> scene.setCursor(previousCursor))
+						p
 				    );
 			}
 		} catch (final MaskInUse e)
@@ -227,9 +219,7 @@ public class FloodFill
 			final int time,
 			final int level,
 			final long fill,
-			final Localizable seed,
-			final Runnable doWhileFilling,
-			final Runnable doWhenDone) throws MaskInUse
+			final Localizable seed) throws MaskInUse
 	{
 		final MaskInfo<UnsignedLongType>                  maskInfo      = new MaskInfo<>(
 				time,
@@ -273,9 +263,9 @@ public class FloodFill
 					e.printStackTrace();
 				}
 				LOG.debug("Updating current view!");
-				doWhileFilling.run();
+				requestRepaint.run();
 			}
-			doWhenDone.run();
+			requestRepaint.run();
 			resetFloodFillState(source);
 			if (!Thread.interrupted())
 			{
@@ -289,9 +279,7 @@ public class FloodFill
 			final int time,
 			final int level,
 			final long fill,
-			final Localizable seed,
-			final Runnable doWhileFilling,
-			final Runnable doWhenDone) throws MaskInUse
+			final Localizable seed) throws MaskInUse
 	{
 
 		final RandomAccessibleInterval<LabelMultisetType> data       = source.getDataSource(time, level);
@@ -343,9 +331,9 @@ public class FloodFill
 					e.printStackTrace();
 				}
 				LOG.debug("Updating current view!");
-				doWhileFilling.run();
+				requestRepaint.run();
 			}
-			doWhenDone.run();
+			requestRepaint.run();
 			resetFloodFillState(source);
 			if (!Thread.interrupted())
 			{

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFill.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFill.java
@@ -232,10 +232,16 @@ public class FloodFill
 
 		@SuppressWarnings("unchecked")
 		final Thread floodFillThread = new Thread(() -> {
-			if (seedValue instanceof LabelMultisetType) {
-				fillMultisetType((RandomAccessibleInterval<LabelMultisetType>) data, accessTracker, seed, seedLabel);
-			} else {
-				fillPrimitiveType(data, accessTracker, seed, seedLabel);
+			try {
+				if (seedValue instanceof LabelMultisetType) {
+					fillMultisetType((RandomAccessibleInterval<LabelMultisetType>) data, accessTracker, seed, seedLabel);
+				} else {
+					fillPrimitiveType(data, accessTracker, seed, seedLabel);
+				}
+			} catch (final Exception e) {
+				// got an exception, ignore it if the operation has been canceled, or re-throw otherwise
+				if (!Thread.currentThread().isInterrupted())
+					throw e;
 			}
 			LOG.debug(Thread.currentThread().isInterrupted() ? "FloodFill has been interrupted" : "FloodFill has been completed");
 		});

--- a/src/main/java/org/janelia/saalfeldlab/paintera/data/mask/MaskedSource.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/data/mask/MaskedSource.java
@@ -455,6 +455,12 @@ public class MaskedSource<D extends Type<D>, T extends Type<T>> implements DataS
 
 	}
 
+	public synchronized void resetMasks()
+	{
+		forgetMasks();
+		setMasksConstant();
+	}
+
 	public void forgetMasks()
 	{
 		synchronized (this)

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/HasFloodFillState.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/HasFloodFillState.java
@@ -4,5 +4,17 @@ import javafx.beans.property.ObjectProperty;
 
 public interface HasFloodFillState {
 
-	ObjectProperty<Long> floodFillState();
+	public static class FloodFillState {
+
+		public final long labelId;
+		public final Runnable interrupt;
+
+		public FloodFillState(final long labelId, final Runnable interrupt)
+		{
+			this.labelId = labelId;
+			this.interrupt = interrupt;
+		}
+	}
+
+	ObjectProperty<FloodFillState> floodFillState();
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/HasFloodFillState.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/HasFloodFillState.java
@@ -1,0 +1,8 @@
+package org.janelia.saalfeldlab.paintera.state;
+
+import javafx.beans.property.ObjectProperty;
+
+public interface HasFloodFillState {
+
+	ObjectProperty<Long> floodFillState();
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceState.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceState.java
@@ -2,6 +2,7 @@ package org.janelia.saalfeldlab.paintera.state;
 
 import bdv.util.volatiles.VolatileTypeMatcher;
 import gnu.trove.set.hash.TLongHashSet;
+import javafx.beans.InvalidationListener;
 import javafx.event.Event;
 import javafx.event.EventHandler;
 import javafx.geometry.Insets;
@@ -486,7 +487,7 @@ public class LabelSourceState<D extends IntegerType<D>, T>
 		final Tooltip lastSelectedLabelColorRectTooltip = new Tooltip();
 		Tooltip.install(lastSelectedLabelColorRect, lastSelectedLabelColorRectTooltip);
 
-		selectedIds.addListener(obs -> {
+		final InvalidationListener lastSelectedIdUpdater = obs -> {
 			if (selectedIds.isLastSelectionValid()) {
 				final long lastSelectedLabelId = selectedIds.getLastSelection();
 				final AbstractHighlightingARGBStream colorStream = highlightingStreamConverter().getStream();
@@ -499,7 +500,13 @@ public class LabelSourceState<D extends IntegerType<D>, T>
 			} else {
 				lastSelectedLabelColorRect.setVisible(false);
 			}
-		});
+		};
+		selectedIds.addListener(lastSelectedIdUpdater);
+
+		// add the same listener to the color stream (for example, the color should change when a new random seed value is set)
+		final AbstractHighlightingARGBStream colorStream = highlightingStreamConverter().getStream();
+		if (colorStream != null)
+			highlightingStreamConverter().getStream().addListener(lastSelectedIdUpdater);
 
 		final ProgressIndicator applyingMaskIndicator = new ProgressIndicator(ProgressIndicator.INDETERMINATE_PROGRESS);
 		applyingMaskIndicator.setPrefWidth(15);

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceState.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceState.java
@@ -9,6 +9,7 @@ import javafx.event.Event;
 import javafx.event.EventHandler;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.scene.Cursor;
 import javafx.scene.Group;
 import javafx.scene.Node;
 import javafx.scene.control.ContextMenu;
@@ -537,11 +538,19 @@ public class LabelSourceState<D extends IntegerType<D>, T>
 		paintingProgressIndicator.setTooltip(paintingProgressIndicatorTooltip);
 
 		final Runnable resetProgressIndicatorContextMenu = () -> {
+			final ContextMenu contextMenu = paintingProgressIndicator.contextMenuProperty().get();
+			if (contextMenu != null)
+				contextMenu.hide();
 			paintingProgressIndicator.setContextMenu(null);
+			paintingProgressIndicator.setOnMouseClicked(null);
+			paintingProgressIndicator.setCursor(Cursor.DEFAULT);
 		};
 
 		final Consumer<ContextMenu> setProgressIndicatorContextMenu = contextMenu -> {
+			resetProgressIndicatorContextMenu.run();
 			paintingProgressIndicator.setContextMenu(contextMenu);
+			paintingProgressIndicator.setOnMouseClicked(event -> contextMenu.show(paintingProgressIndicator, event.getScreenX(), event.getScreenY()));
+			paintingProgressIndicator.setCursor(Cursor.HAND);
 		};
 
 		if (this.getDataSource() instanceof MaskedSource<?, ?>)

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceState.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceState.java
@@ -11,6 +11,7 @@ import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Group;
 import javafx.scene.Node;
+import javafx.scene.control.Control;
 import javafx.scene.control.ProgressIndicator;
 import javafx.scene.control.Tooltip;
 import javafx.scene.input.KeyCode;
@@ -526,6 +527,8 @@ public class LabelSourceState<D extends IntegerType<D>, T>
 		final ProgressIndicator paintingProgressIndicator = new ProgressIndicator(ProgressIndicator.INDETERMINATE_PROGRESS);
 		paintingProgressIndicator.setPrefWidth(15);
 		paintingProgressIndicator.setPrefHeight(15);
+		paintingProgressIndicator.setMinWidth(Control.USE_PREF_SIZE);
+		paintingProgressIndicator.setMinHeight(Control.USE_PREF_SIZE);
 		paintingProgressIndicator.setVisible(false);
 
 		final Tooltip paintingProgressIndicatorTooltip = new Tooltip();


### PR DESCRIPTION
* Display progress indicator during flood filling in the status bar
* Allow to cancel flood fill via context menu of the progress indicator
* Other minor fixes (ensure correct threading, react to random seed updates in the color stream)

Cancellation of a running flood-fill operation is "fake": it only resets the mask and the state, but the operation itself will continue to run in a background thread until it's completed. There is currently no way to interrupt active flood-fill operation, and this would need to be implemented in `net.imglib2.algorithm.fill.FloodFill`. For now I've put a TODO there because it would be nice to add, but it doesn't hurt (the result of the operation will be simply ignored, and the temporary mask will be garbage-collected after that).

![flood-fill-progress](https://user-images.githubusercontent.com/6253116/57722312-21ecac80-7654-11e9-8bb2-29482ff4edde.gif)

