### PR TITLE
Allow to toggle ids with Ctrl+left click

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Usage: Paintera [-h] [--default-to-temp-directory] [--print-error-codes]
 | `Shift` + `M` | Maximize split view of one slicing viewer and 3D scene |
 | `Shift` + `Z` | Un-rotate but keep scale and translation |
 | left click | toggle id under cursor if current source is label source (de-select all others) |
-| right click | toggle id under cursor if current source is label source (append to current selection) |
+| right click / `Ctrl` left click | toggle id under cursor if current source is label source (append to current selection) |
 | `Shift` left click | Merge id under cursor with id that was last toggled active (if any) |
 | `Shift` right click | Split id under cursor from id that was last toggled active (if any) |
 | `Space` left click/drag | Paint with id that was last toggled active (if any) |

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceStateIdSelectorHandler.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceStateIdSelectorHandler.java
@@ -75,7 +75,10 @@ public class LabelSourceStateIdSelectorHandler {
 				event -> event.isPrimaryButtonDown() && keyTracker.noKeysActive()).handler());
 		handler.addEventHandler(MouseEvent.ANY, selector.appendFragmentWithMaximumCount(
 				"append id",
-				event -> event.isSecondaryButtonDown() && keyTracker.noKeysActive()).handler());
+				event ->
+					(event.isSecondaryButtonDown() && keyTracker.noKeysActive()) ||
+					(event.isPrimaryButtonDown() && keyTracker.areOnlyTheseKeysDown(KeyCode.CONTROL)))
+			.handler());
 		handler.addOnKeyPressed(EventFX.KEY_PRESSED(
 				"lock segment",
 				e -> selector.toggleLock(selectedIds, assignment, lockedSegments),


### PR DESCRIPTION
I sometimes find myself trying to toggle label ids with `Ctrl`+left click similar to how one would select multiple files, for example, in a file browser application. This PR adds this shortcut in addition to the right click for toggling.