### PR TITLE
Repaint crosshair overlays when layout changes

### DIFF
--- a/src/main/java/bdv/fx/viewer/OverlayPane.java
+++ b/src/main/java/bdv/fx/viewer/OverlayPane.java
@@ -92,6 +92,8 @@ public class OverlayPane<A> extends StackPane
 			if (w <= 0 || h <= 0)
 				return;
 			overlayRenderers.forEach(or -> or.setCanvasSize(w, h));
+			layout();
+			drawOverlays();
 		};
 
 		widthProperty().addListener(sizeChangeListener);
@@ -156,12 +158,6 @@ public class OverlayPane<A> extends StackPane
 	public void removeHandler(final Collection<InstallAndRemove<Node>> h)
 	{
 		h.forEach(i -> i.removeFrom(this));
-	}
-
-	public void repaint()
-	{
-		drawOverlays();
-		layout();
 	}
 
 	@Override


### PR DESCRIPTION
Before this fix the crosshair overlays wouldn't get repainted when the layout changes, causing them to look inconsistent with the new layout.