### PR TITLE
Add merge all selected action (Ctrl+Enter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Usage: Paintera [-h] [--default-to-temp-directory] [--print-error-codes]
 | `C` | Increment ARGB stream seed by one |
 | `Shift` + `C` | Decrement ARGB stream seed by one |
 | `Ctrl` + `Shift` + `C` | Show ARGB stream seed spinner |
-| `Ctrl` + `Shift` + `M` | Merge all selected ids |
+| `Ctrl` + `Enter` | Merge all selected ids |
 | `V` | Toggle visibility of current source |
 | `Shift` + `V` | Toggle visibility of not-selected ids in current source (if label source) |
 | `R` | Clear mesh caches and refresh meshes (if current source is label source) |

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Usage: Paintera [-h] [--default-to-temp-directory] [--print-error-codes]
 | `C` | Increment ARGB stream seed by one |
 | `Shift` + `C` | Decrement ARGB stream seed by one |
 | `Ctrl` + `Shift` + `C` | Show ARGB stream seed spinner |
+| `Ctrl` + `Shift` + `M` | Merge all selected ids |
 | `V` | Toggle visibility of current source |
 | `Shift` + `V` | Toggle visibility of not-selected ids in current source (if label source) |
 | `R` | Clear mesh caches and refresh meshes (if current source is label source) |

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceStateMergeDetachHandler.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceStateMergeDetachHandler.java
@@ -109,7 +109,7 @@ public class LabelSourceStateMergeDetachHandler {
 		handler.addOnKeyPressed(EventFX.KEY_PRESSED(
 				"merge all selected",
 				e -> mergeAllSelected(),
-				e -> paintera.allowedActionsProperty().get().isAllowed(LabelActionType.Merge) && keyTracker.areOnlyTheseKeysDown(KeyCode.SHIFT, KeyCode.CONTROL, KeyCode.M)));
+				e -> paintera.allowedActionsProperty().get().isAllowed(LabelActionType.Merge) && keyTracker.areOnlyTheseKeysDown(KeyCode.CONTROL, KeyCode.ENTER)));
 
 		return handler;
 	}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceStateMergeDetachHandler.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceStateMergeDetachHandler.java
@@ -1,8 +1,10 @@
 package org.janelia.saalfeldlab.paintera.state;
 
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -103,7 +105,62 @@ public class LabelSourceStateMergeDetachHandler {
 				"detach fragment",
 				new ConfirmSelection(vp),
 				e -> paintera.allowedActionsProperty().get().isAllowed(LabelActionType.Split) && e.isSecondaryButtonDown() && keyTracker.areOnlyTheseKeysDown(KeyCode.SHIFT, KeyCode.CONTROL)));
+
+		handler.addOnKeyPressed(EventFX.KEY_PRESSED(
+				"merge all selected",
+				e -> mergeAllSelected(),
+				e -> paintera.allowedActionsProperty().get().isAllowed(LabelActionType.Merge) && keyTracker.areOnlyTheseKeysDown(KeyCode.SHIFT, KeyCode.CONTROL, KeyCode.M)));
+
 		return handler;
+	}
+
+	private void mergeAllSelected()
+	{
+		final long[] ids = selectedIds.getActiveIds();
+		final long lastSelection = selectedIds.getLastSelection();
+		if (ids.length <= 1)
+			return;
+
+		final long into;
+		if (selectedIds.isLastSelectionValid() && assignment.getSegment(lastSelection) != lastSelection)
+		{
+			// last selected fragment belongs to a segment, merge into it to re-use its segment id
+			into = lastSelection;
+		}
+		else
+		{
+			// last selection does not belong to an assignment or is empty, go over all selected fragments to see if there is one that belongs to an assignment
+			// (it uses the first such found fragment, so if there are several, one of them will be picked arbitrarily because the order of the ids is not defined)
+			long idWithAssignment = Label.INVALID;
+			for (final long id : ids)
+			{
+				final long segmentId = assignment.getSegment(id);
+				if (segmentId != id)
+				{
+					idWithAssignment = id;
+					break;
+				}
+			}
+			if (idWithAssignment != Label.INVALID)
+			{
+				// there is a selected fragment that belongs to an assignment, merge into it to re-use its segment id
+				into = idWithAssignment;
+			}
+			else
+			{
+				// all selected fragments do not belong to any assignment, a new segment id will be created for merging
+				into = ids[0];
+			}
+		}
+
+		final List<Merge> merges = new ArrayList<>();
+		for (final long id : ids)
+		{
+			final Optional<Merge> action = assignment.getMergeAction(id, into, idService::next);
+			if (action.isPresent())
+				merges.add(action.get());
+		}
+		assignment.apply(merges);
 	}
 
 	private class MergeFragments implements Consumer<MouseEvent> {


### PR DESCRIPTION
Adds a new shortcut `Ctrl`+`Shift`+`M` that will merge all selected fragments as described in #137.
(let me know if there are any better ideas for the key combination)

* If the last selected fragment belongs to a segment, its ID will be used for merging
* Otherwise, if the last selection doesn't belong to any assignment or is empty, the segment ID is chosen arbitrarily based on the assignment of the selected fragments (the order is not specified)
* If all selected fragments are trivial and are not part of any assignment, a new segment ID is created