### PR TITLE
Fix 241 NPE in pbv.add single scale label source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,14 @@
 			<version>1.7.25</version>
 			<scope>test</scope>
 		</dependency>
+<!--		Try this: -->
+<!--		https://uberconf.com/blog/andres_almiray/2016/02/running_testfx_tests_in_headless_mode -->
+		<dependency>
+			<groupId>org.testfx</groupId>
+			<artifactId>openjfx-monocle</artifactId>
+			<version>8u76-b04</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<developers>
@@ -234,5 +242,17 @@
 			<url>https://maven.scijava.org/content/groups/public</url>
 		</repository>
 	</repositories>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<argLine>-Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw -Dprism.text=t2k</argLine>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -159,14 +159,6 @@
 			<version>1.7.25</version>
 			<scope>test</scope>
 		</dependency>
-<!--		Try this: -->
-<!--		https://uberconf.com/blog/andres_almiray/2016/02/running_testfx_tests_in_headless_mode -->
-		<dependency>
-			<groupId>org.testfx</groupId>
-			<artifactId>openjfx-monocle</artifactId>
-			<version>8u76-b04</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<developers>
@@ -242,17 +234,5 @@
 			<url>https://maven.scijava.org/content/groups/public</url>
 		</repository>
 	</repositories>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<argLine>-Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw -Dprism.text=t2k</argLine>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceState.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceState.java
@@ -1,51 +1,5 @@
 package org.janelia.saalfeldlab.paintera.state;
 
-import java.lang.invoke.MethodHandles;
-import java.util.Arrays;
-import java.util.concurrent.ExecutorService;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.LongFunction;
-import java.util.function.ToLongFunction;
-
-import org.janelia.saalfeldlab.fx.event.DelegateEventHandlers;
-import org.janelia.saalfeldlab.fx.event.EventFX;
-import org.janelia.saalfeldlab.fx.event.KeyTracker;
-import org.janelia.saalfeldlab.fx.util.InvokeOnJavaFXApplicationThread;
-import org.janelia.saalfeldlab.labels.blocks.LabelBlockLookup;
-import org.janelia.saalfeldlab.paintera.PainteraBaseView;
-import org.janelia.saalfeldlab.paintera.cache.InvalidateAll;
-import org.janelia.saalfeldlab.paintera.cache.global.GlobalCache;
-import org.janelia.saalfeldlab.paintera.composition.ARGBCompositeAlphaYCbCr;
-import org.janelia.saalfeldlab.paintera.composition.Composite;
-import org.janelia.saalfeldlab.paintera.control.ShapeInterpolationMode;
-import org.janelia.saalfeldlab.paintera.control.ShapeInterpolationMode.ActiveSection;
-import org.janelia.saalfeldlab.paintera.control.ShapeInterpolationMode.ModeState;
-import org.janelia.saalfeldlab.paintera.control.assignment.FragmentSegmentAssignmentOnlyLocal;
-import org.janelia.saalfeldlab.paintera.control.assignment.FragmentSegmentAssignmentState;
-import org.janelia.saalfeldlab.paintera.control.lock.LockedSegmentsOnlyLocal;
-import org.janelia.saalfeldlab.paintera.control.lock.LockedSegmentsState;
-import org.janelia.saalfeldlab.paintera.control.selection.SelectedIds;
-import org.janelia.saalfeldlab.paintera.data.DataSource;
-import org.janelia.saalfeldlab.paintera.data.RandomAccessibleIntervalDataSource;
-import org.janelia.saalfeldlab.paintera.data.axisorder.AxisOrder;
-import org.janelia.saalfeldlab.paintera.data.mask.Mask;
-import org.janelia.saalfeldlab.paintera.data.mask.MaskedSource;
-import org.janelia.saalfeldlab.paintera.id.IdService;
-import org.janelia.saalfeldlab.paintera.id.LocalIdService;
-import org.janelia.saalfeldlab.paintera.meshes.InterruptibleFunction;
-import org.janelia.saalfeldlab.paintera.meshes.ManagedMeshSettings;
-import org.janelia.saalfeldlab.paintera.meshes.MeshManager;
-import org.janelia.saalfeldlab.paintera.meshes.MeshManagerWithAssignmentForSegments;
-import org.janelia.saalfeldlab.paintera.stream.AbstractHighlightingARGBStream;
-import org.janelia.saalfeldlab.paintera.stream.HighlightingStreamConverter;
-import org.janelia.saalfeldlab.paintera.stream.HighlightingStreamConverterIntegerType;
-import org.janelia.saalfeldlab.paintera.stream.ModalGoldenAngleSaturatedHighlightingARGBStream;
-import org.janelia.saalfeldlab.util.Colors;
-import org.janelia.saalfeldlab.util.grids.LabelBlockLookupNoBlocks;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import bdv.util.volatiles.VolatileTypeMatcher;
 import gnu.trove.set.hash.TLongHashSet;
 import javafx.beans.InvalidationListener;
@@ -88,7 +42,52 @@ import net.imglib2.type.numeric.integer.UnsignedLongType;
 import net.imglib2.util.Intervals;
 import net.imglib2.util.Util;
 import net.imglib2.view.Views;
+import org.janelia.saalfeldlab.fx.event.DelegateEventHandlers;
+import org.janelia.saalfeldlab.fx.event.EventFX;
+import org.janelia.saalfeldlab.fx.event.KeyTracker;
+import org.janelia.saalfeldlab.fx.util.InvokeOnJavaFXApplicationThread;
+import org.janelia.saalfeldlab.labels.blocks.LabelBlockLookup;
+import org.janelia.saalfeldlab.paintera.PainteraBaseView;
+import org.janelia.saalfeldlab.paintera.cache.InvalidateAll;
+import org.janelia.saalfeldlab.paintera.cache.global.GlobalCache;
+import org.janelia.saalfeldlab.paintera.composition.ARGBCompositeAlphaYCbCr;
+import org.janelia.saalfeldlab.paintera.composition.Composite;
+import org.janelia.saalfeldlab.paintera.control.ShapeInterpolationMode;
+import org.janelia.saalfeldlab.paintera.control.ShapeInterpolationMode.ActiveSection;
+import org.janelia.saalfeldlab.paintera.control.ShapeInterpolationMode.ModeState;
+import org.janelia.saalfeldlab.paintera.control.assignment.FragmentSegmentAssignmentOnlyLocal;
+import org.janelia.saalfeldlab.paintera.control.assignment.FragmentSegmentAssignmentState;
+import org.janelia.saalfeldlab.paintera.control.lock.LockedSegmentsOnlyLocal;
+import org.janelia.saalfeldlab.paintera.control.lock.LockedSegmentsState;
+import org.janelia.saalfeldlab.paintera.control.selection.SelectedIds;
+import org.janelia.saalfeldlab.paintera.data.DataSource;
+import org.janelia.saalfeldlab.paintera.data.RandomAccessibleIntervalDataSource;
+import org.janelia.saalfeldlab.paintera.data.axisorder.AxisOrder;
+import org.janelia.saalfeldlab.paintera.data.mask.Mask;
+import org.janelia.saalfeldlab.paintera.data.mask.MaskedSource;
+import org.janelia.saalfeldlab.paintera.id.IdService;
+import org.janelia.saalfeldlab.paintera.id.LocalIdService;
+import org.janelia.saalfeldlab.paintera.meshes.InterruptibleFunction;
+import org.janelia.saalfeldlab.paintera.meshes.ManagedMeshSettings;
+import org.janelia.saalfeldlab.paintera.meshes.MeshManager;
+import org.janelia.saalfeldlab.paintera.meshes.MeshManagerWithAssignmentForSegments;
+import org.janelia.saalfeldlab.paintera.stream.AbstractHighlightingARGBStream;
+import org.janelia.saalfeldlab.paintera.stream.HighlightingStreamConverter;
+import org.janelia.saalfeldlab.paintera.stream.HighlightingStreamConverterIntegerType;
+import org.janelia.saalfeldlab.paintera.stream.ModalGoldenAngleSaturatedHighlightingARGBStream;
+import org.janelia.saalfeldlab.util.Colors;
+import org.janelia.saalfeldlab.util.grids.LabelBlockLookupNoBlocks;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import pl.touk.throwing.ThrowingFunction;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.LongFunction;
+import java.util.function.ToLongFunction;
 
 public class LabelSourceState<D extends IntegerType<D>, T>
 		extends
@@ -636,36 +635,39 @@ public class LabelSourceState<D extends IntegerType<D>, T>
 			});
 		});
 
-		final InvalidationListener shapeInterpolationModeStatusUpdater = obs -> {
-			InvokeOnJavaFXApplicationThread.invoke(() -> {
-				final ModeState modeState = this.shapeInterpolationMode.modeStateProperty().get();
-				final ActiveSection activeSection = this.shapeInterpolationMode.activeSectionProperty().get();
-				if (modeState != null) {
-					switch (modeState) {
-					case Select:
-						statusTextProperty().set("Select #" + activeSection);
-						break;
-					case Interpolate:
-						statusTextProperty().set("Interpolating");
-						break;
-					case Preview:
-						statusTextProperty().set("Preview");
-						break;
-					default:
+		// only necessary if we actually have shape interpolation
+		if (this.shapeInterpolationMode != null ) {
+			final InvalidationListener shapeInterpolationModeStatusUpdater = obs -> {
+				InvokeOnJavaFXApplicationThread.invoke(() -> {
+					final ModeState modeState = this.shapeInterpolationMode.modeStateProperty().get();
+					final ActiveSection activeSection = this.shapeInterpolationMode.activeSectionProperty().get();
+					if (modeState != null) {
+						switch (modeState) {
+							case Select:
+								statusTextProperty().set("Select #" + activeSection);
+								break;
+							case Interpolate:
+								statusTextProperty().set("Interpolating");
+								break;
+							case Preview:
+								statusTextProperty().set("Preview");
+								break;
+							default:
+								statusTextProperty().set(null);
+								break;
+						}
+					} else {
 						statusTextProperty().set(null);
-						break;
 					}
-				} else {
-					statusTextProperty().set(null);
-				}
-				final boolean showProgressIndicator = modeState == ModeState.Interpolate;
-				paintingProgressIndicator.setVisible(showProgressIndicator);
-				paintingProgressIndicatorTooltip.setText(showProgressIndicator ? "Interpolating between sections..." : "");
-			});
-		};
+					final boolean showProgressIndicator = modeState == ModeState.Interpolate;
+					paintingProgressIndicator.setVisible(showProgressIndicator);
+					paintingProgressIndicatorTooltip.setText(showProgressIndicator ? "Interpolating between sections..." : "");
+				});
+			};
 
-		this.shapeInterpolationMode.modeStateProperty().addListener(shapeInterpolationModeStatusUpdater);
-		this.shapeInterpolationMode.activeSectionProperty().addListener(shapeInterpolationModeStatusUpdater);
+			this.shapeInterpolationMode.modeStateProperty().addListener(shapeInterpolationModeStatusUpdater);
+			this.shapeInterpolationMode.activeSectionProperty().addListener(shapeInterpolationModeStatusUpdater);
+		}
 
 		final HBox displayStatus = new HBox(5,
 				lastSelectedLabelColorRect,

--- a/src/test/java/org/janelia/saalfeldlab/paintera/PainteraBaseViewTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/paintera/PainteraBaseViewTest.java
@@ -14,6 +14,9 @@ public class PainteraBaseViewTest {
 
 	@Before
 	public void initialize() {
+		System.setProperty("glass.platform", "Monocle");
+		System.setProperty("monocle.platform", "Headless");
+		System.setProperty("prism.order", "sw");
 		PlatformImpl.startup(() -> {});
 	}
 

--- a/src/test/java/org/janelia/saalfeldlab/paintera/PainteraBaseViewTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/paintera/PainteraBaseViewTest.java
@@ -1,0 +1,32 @@
+package org.janelia.saalfeldlab.paintera;
+
+import com.sun.javafx.application.PlatformImpl;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.UnsignedLongType;
+import org.janelia.saalfeldlab.paintera.data.axisorder.AxisOrderNotSupported;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class PainteraBaseViewTest {
+
+	@Before
+	public void initialize() {
+		PlatformImpl.startup(() -> {});
+	}
+
+	@Test
+	public void testAddSingleScaleLabelSource() throws IOException, AxisOrderNotSupported {
+		final RandomAccessibleInterval<UnsignedLongType> labels = ArrayImgs.unsignedLongs(10, 20, 30);
+		final PainteraBaseView.DefaultPainteraBaseView viewer = PainteraBaseView.defaultView();
+		viewer.baseView.addSingleScaleLabelSource(
+				labels,
+				new double[] {1.0, 1.0, 1.0},
+				new double[] {0.0, 0.0, 0.0},
+				1,
+				"blub");
+	}
+
+}

--- a/src/test/java/org/janelia/saalfeldlab/paintera/PainteraBaseViewTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/paintera/PainteraBaseViewTest.java
@@ -1,35 +1,35 @@
 package org.janelia.saalfeldlab.paintera;
 
-import com.sun.javafx.application.PlatformImpl;
-import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.img.array.ArrayImgs;
-import net.imglib2.type.numeric.integer.UnsignedLongType;
-import org.janelia.saalfeldlab.paintera.data.axisorder.AxisOrderNotSupported;
-import org.junit.Before;
-import org.junit.Test;
+// TODO uncomment imports and tests once #243 is fixed
 
-import java.io.IOException;
+//import com.sun.javafx.application.PlatformImpl;
+//import net.imglib2.RandomAccessibleInterval;
+//import net.imglib2.img.array.ArrayImgs;
+//import net.imglib2.type.numeric.integer.UnsignedLongType;
+//import org.janelia.saalfeldlab.paintera.data.axisorder.AxisOrderNotSupported;
+//import org.junit.Before;
+//import org.junit.Test;
 
 public class PainteraBaseViewTest {
 
-	@Before
-	public void initialize() {
-		System.setProperty("glass.platform", "Monocle");
-		System.setProperty("monocle.platform", "Headless");
-		System.setProperty("prism.order", "sw");
-		PlatformImpl.startup(() -> {});
-	}
-
-	@Test
-	public void testAddSingleScaleLabelSource() throws IOException, AxisOrderNotSupported {
-		final RandomAccessibleInterval<UnsignedLongType> labels = ArrayImgs.unsignedLongs(10, 20, 30);
-		final PainteraBaseView.DefaultPainteraBaseView viewer = PainteraBaseView.defaultView();
-		viewer.baseView.addSingleScaleLabelSource(
-				labels,
-				new double[] {1.0, 1.0, 1.0},
-				new double[] {0.0, 0.0, 0.0},
-				1,
-				"blub");
-	}
+//	@Before
+//	public void initialize() {
+//		System.setProperty("glass.platform", "Monocle");
+//		System.setProperty("monocle.platform", "Headless");
+//		System.setProperty("prism.order", "sw");
+//		PlatformImpl.startup(() -> {});
+//	}
+//
+//	@Test
+//	public void testAddSingleScaleLabelSource() throws IOException, AxisOrderNotSupported {
+//		final RandomAccessibleInterval<UnsignedLongType> labels = ArrayImgs.unsignedLongs(10, 20, 30);
+//		final PainteraBaseView.DefaultPainteraBaseView viewer = PainteraBaseView.defaultView();
+//		viewer.baseView.addSingleScaleLabelSource(
+//				labels,
+//				new double[] {1.0, 1.0, 1.0},
+//				new double[] {0.0, 0.0, 0.0},
+//				1,
+//				"blub");
+//	}
 
 }


### PR DESCRIPTION
Fixes #241 

The culprit in `LabelSourceState`:
```java
this.shapeInterpolationMode.modeStateProperty().addListener(shapeInterpolationModeStatusUpdater);
this.shapeInterpolationMode.activeSectionProperty().addListener(shapeInterpolationModeStatusUpdater);
```

If no `MaskedSource` is provided, `this.shapeInterpolationMode` is `null`. Added check for `null` for all other cases.