### PR TITLE
Mesh openers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,13 @@
 			<version>2.0</version>
 		</dependency>
 
+<!--		Load meshes-->
+<!--		https://github.com/javagl/Obj -->
+		<dependency>
+			<groupId>de.javagl</groupId>
+			<artifactId>obj</artifactId>
+			<version>0.3.0</version>
+		</dependency>
 
 
 		<!--		Tests-->

--- a/src/main/java/org/janelia/saalfeldlab/fx/TitledPanes.java
+++ b/src/main/java/org/janelia/saalfeldlab/fx/TitledPanes.java
@@ -1,16 +1,118 @@
 package org.janelia.saalfeldlab.fx;
 
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
 import javafx.scene.Node;
+import javafx.scene.control.Label;
 import javafx.scene.control.TitledPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+
+import java.util.Optional;
 
 public class TitledPanes
 {
+
+	public static Builder builder() {
+		return new Builder();
+	}
 
 	public static TitledPane createCollapsed(String title, Node contents)
 	{
 		final TitledPane tp = new TitledPane(title, contents);
 		tp.setExpanded(false);
 		return tp;
+	}
+
+	public static class Builder {
+
+		private String title = null;
+		private Boolean isExpanded = null;
+		private Node graphic = null;
+		private Insets padding = null;
+		private Node content = null;
+		private Pos alignment = null;
+
+		private Builder() {}
+
+		public Builder withTitle(final String title) {
+			this.title = title;
+			return this;
+		}
+
+		public Builder setIsExpanded(final Boolean isExpanded) {
+			this.isExpanded = isExpanded;
+			return this;
+		}
+
+		public Builder collapsed() {
+			return setIsExpanded(false);
+		}
+
+		public Builder withGraphic(final Node graphic) {
+			this.graphic = graphic;
+			return this;
+		}
+
+		public Builder withPadding(final Insets padding) {
+			this.padding = padding;
+			return this;
+		}
+
+		public Builder zeroPadding() {
+			return withPadding(Insets.EMPTY);
+		}
+
+		public Builder withContent(final Node content) {
+			this.content = content;
+			return this;
+		}
+
+		public Builder withAlignment(final Pos alignment) {
+			this.alignment = alignment;
+			return this;
+		}
+
+		public TitledPane build() {
+			final TitledPane pane = new TitledPane(title, content);
+			Optional.ofNullable(isExpanded).ifPresent(pane::setExpanded);
+			Optional.ofNullable(graphic).ifPresent(pane::setGraphic);
+			Optional.ofNullable(padding).ifPresent(pane::setPadding);
+			Optional.ofNullable(alignment).ifPresent(pane::setAlignment);
+			return pane;
+		}
+
+	}
+
+	public static TitledPane graphicsOnly(
+			final TitledPane pane,
+			final String title,
+			final Node right) {
+		return graphicsOnly(pane, new Label(title), right);
+	}
+
+	public static TitledPane graphicsOnly(
+			final TitledPane pane,
+			final Node left,
+			final Node right) {
+		final Region spacer = new Region();
+		spacer.setMaxWidth(Double.POSITIVE_INFINITY);
+		HBox.setHgrow(spacer, Priority.ALWAYS);
+		final HBox graphicsContents = new HBox(left, spacer, right);
+		graphicsContents.setAlignment(Pos.CENTER);
+		graphicsContents.setPadding(new Insets(0, 35, 0, 0));
+		return graphicsOnly(pane, graphicsContents);
+	}
+
+	public static TitledPane graphicsOnly(
+			final TitledPane pane,
+			final Pane graphicsContentPane) {
+		graphicsContentPane.minWidthProperty().bind(pane.widthProperty());
+		pane.setGraphic(graphicsContentPane);
+		pane.setText(null);
+		return pane;
 	}
 
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars.java
@@ -42,6 +42,8 @@ import org.janelia.saalfeldlab.fx.ui.ResizeOnLeftSide;
 import org.janelia.saalfeldlab.fx.ui.SingleChildStackPane;
 import org.janelia.saalfeldlab.fx.util.InvokeOnJavaFXApplicationThread;
 import org.janelia.saalfeldlab.paintera.cache.MemoryBoundedSoftRefLoaderCache;
+import org.janelia.saalfeldlab.paintera.config.ArbitraryMeshConfig;
+import org.janelia.saalfeldlab.paintera.config.ArbitraryMeshConfigNode;
 import org.janelia.saalfeldlab.paintera.config.BookmarkConfigNode;
 import org.janelia.saalfeldlab.paintera.config.CrosshairConfigNode;
 import org.janelia.saalfeldlab.paintera.config.NavigationConfigNode;
@@ -106,6 +108,8 @@ public class BorderPaneWithStatusBars
 	private final ScaleBarOverlayConfigNode scaleBarConfigNode = new ScaleBarOverlayConfigNode();
 
 	private final BookmarkConfigNode bookmarkConfigNode;
+
+	private final ArbitraryMeshConfigNode arbitraryMeshConfigNode = new ArbitraryMeshConfigNode();
 
 	private final Map<ViewerAndTransforms, Crosshair> crossHairs;
 
@@ -299,11 +303,14 @@ public class BorderPaneWithStatusBars
 				this.viewer3DConfigNode.getContents(),
 				this.scaleBarConfigNode,
 				this.bookmarkConfigNode,
+				this.arbitraryMeshConfigNode,
 				this.screenScaleConfigNode.getContents(),
 				memoryUsage
 		);
 		final TitledPane settings = new TitledPane("settings", settingsContents);
 		settings.setExpanded(false);
+
+		center.viewer3D().meshesGroup().getChildren().add(this.arbitraryMeshConfigNode.getMeshGroup());
 
 		saveProjectButton = new Button("Save");
 
@@ -426,6 +433,10 @@ public class BorderPaneWithStatusBars
 
 	public BookmarkConfigNode bookmarkConfigNode() {
 		return this.bookmarkConfigNode;
+	}
+
+	public ArbitraryMeshConfigNode arbitraryMeshConfigNode() {
+		return this.arbitraryMeshConfigNode;
 	}
 
 	public Map<ViewerAndTransforms, Crosshair> crosshairs()

--- a/src/main/java/org/janelia/saalfeldlab/paintera/Paintera.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/Paintera.java
@@ -233,6 +233,10 @@ public class Paintera extends Application
 
 		defaultHandlers.scaleBarConfig().bindBidirectionalTo(properties.scaleBarOverlayConfig);
 
+		paneWithStatus.arbitraryMeshConfigNode().getConfig().setTo(properties.arbitraryMeshConfig);
+		properties.arbitraryMeshConfig.bindTo(paneWithStatus.arbitraryMeshConfigNode().getConfig());
+
+
 
 
 		//		gridConstraintsManager.set( properties.gridConstraints );

--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/ArbitraryMeshConfig.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/ArbitraryMeshConfig.java
@@ -18,6 +18,7 @@ import javafx.scene.shape.CullFace;
 import javafx.scene.shape.DrawMode;
 import javafx.scene.shape.MeshView;
 import javafx.scene.shape.TriangleMesh;
+import org.janelia.saalfeldlab.paintera.meshes.Meshes;
 import org.janelia.saalfeldlab.paintera.meshes.io.TriangleMeshFormat;
 
 import java.io.IOException;
@@ -47,7 +48,7 @@ public class ArbitraryMeshConfig {
 
 		private final StringProperty name = new SimpleStringProperty();
 
-		private final ObjectProperty<Color> color = new SimpleObjectProperty<>(Color.WHITE);
+		private final ObjectProperty<Color> color = new SimpleObjectProperty<>(Meshes.DEFAULT_MESH_COLOR);
 
 		private final ObjectProperty<CullFace> cullFace = new SimpleObjectProperty<>(CullFace.BACK);
 
@@ -67,7 +68,7 @@ public class ArbitraryMeshConfig {
 			this.format = format;
 			this.mesh = mesh;
 			this.meshView = new MeshView(this.mesh);
-			final PhongMaterial material = new PhongMaterial(color.get());
+			final PhongMaterial material = Meshes.painteraPhongMaterial(color.get());
 			material.diffuseColorProperty().bindBidirectional(color);
 			this.meshView.setMaterial(material);
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/ArbitraryMeshConfig.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/ArbitraryMeshConfig.java
@@ -1,0 +1,180 @@
+package org.janelia.saalfeldlab.paintera.config;
+
+import javafx.beans.InvalidationListener;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleDoubleProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.Node;
+import javafx.scene.paint.Color;
+import javafx.scene.paint.PhongMaterial;
+import javafx.scene.shape.CullFace;
+import javafx.scene.shape.DrawMode;
+import javafx.scene.shape.MeshView;
+import javafx.scene.shape.TriangleMesh;
+import org.janelia.saalfeldlab.paintera.meshes.io.TriangleMeshFormat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class ArbitraryMeshConfig {
+
+	public static class MeshInfo {
+
+		private final Path path;
+
+		private final TriangleMeshFormat format;
+
+		private final TriangleMesh mesh;
+
+		private final MeshView meshView;
+
+		private final BooleanProperty isVisible = new SimpleBooleanProperty(true);
+
+		private final DoubleProperty scale = new SimpleDoubleProperty(1.0);
+
+		private final DoubleProperty translateX = new SimpleDoubleProperty(0.0);
+
+		private final DoubleProperty translateY = new SimpleDoubleProperty(0.0);
+
+		private final DoubleProperty translateZ = new SimpleDoubleProperty(0.0);
+
+		private final StringProperty name = new SimpleStringProperty();
+
+		private final ObjectProperty<Color> color = new SimpleObjectProperty<>(Color.WHITE);
+
+		private final ObjectProperty<CullFace> cullFace = new SimpleObjectProperty<>(CullFace.BACK);
+
+		private final ObjectProperty<DrawMode> drawMode = new SimpleObjectProperty<>(DrawMode.FILL);
+
+		public MeshInfo(
+				final Path path,
+				final TriangleMeshFormat format) throws IOException {
+			this(path, format, format.getLoader().loadMesh(path));
+		}
+
+		public MeshInfo(
+				final Path path,
+				final TriangleMeshFormat format,
+				final TriangleMesh mesh) {
+			this.path = path;
+			this.format = format;
+			this.mesh = mesh;
+			this.meshView = new MeshView(this.mesh);
+			final PhongMaterial material = new PhongMaterial(color.get());
+			material.diffuseColorProperty().bindBidirectional(color);
+			this.meshView.setMaterial(material);
+
+			this.meshView.visibleProperty().bindBidirectional(this.isVisible);
+
+			this.meshView.scaleXProperty().bindBidirectional(scale);
+			this.meshView.scaleYProperty().bindBidirectional(scale);
+			this.meshView.scaleZProperty().bindBidirectional(scale);
+
+			this.meshView.translateXProperty().bindBidirectional(translateX);
+			this.meshView.translateYProperty().bindBidirectional(translateY);
+			this.meshView.translateZProperty().bindBidirectional(translateZ);
+
+			this.meshView.cullFaceProperty().bindBidirectional(this.cullFace);
+			this.meshView.drawModeProperty().bindBidirectional(this.drawMode);
+
+			this.name.set(this.path.getFileName().toString());
+		}
+
+		public Path getPath() {
+			return this.path;
+		}
+
+		public TriangleMeshFormat getFormat() {
+			return this.format;
+		}
+
+		public BooleanProperty isVisibleProperty() {
+			return isVisible;
+		}
+
+		public Node getMeshView() {
+			return this.meshView;
+		}
+
+		public StringProperty nameProperty() {
+			return this.name;
+		}
+
+		public ObjectProperty<Color> colorProperty() {
+			return this.color;
+		}
+
+		public DoubleProperty scaleProperty() {
+			return this.scale;
+		}
+
+		public DoubleProperty translateXProperty() {
+			return translateX;
+		}
+
+		public DoubleProperty translateYProperty() {
+			return translateY;
+		}
+
+		public DoubleProperty translateZProperty() {
+			return translateZ;
+		}
+
+		public ObjectProperty<CullFace> cullFaceProperty() {
+			return cullFace;
+		}
+
+		public ObjectProperty<DrawMode> drawModeProperty() {
+			return drawMode;
+		}
+	}
+
+	private final ObservableList<MeshInfo> meshes = FXCollections.observableArrayList();
+
+	private final ObservableList<MeshInfo> unmodifiableMeshes = FXCollections.unmodifiableObservableList(meshes);
+
+	private final BooleanProperty isVisible = new SimpleBooleanProperty(true);
+
+	private final ObjectProperty<Path> lastPath = new SimpleObjectProperty<>();
+
+	public ObservableList<MeshInfo> getUnmodifiableMeshes() {
+		return this.unmodifiableMeshes;
+	}
+
+	public BooleanProperty isVisibleProperty() {
+		return this.isVisible;
+	}
+
+	public void addMesh(final MeshInfo mesh) {
+		this.meshes.add(mesh);
+	}
+
+	public void removeMesh(final MeshInfo mesh) {
+		this.meshes.remove(mesh);
+	}
+
+	public ObjectProperty<Path> lastPathProperty() {
+		return lastPath;
+	}
+
+	public void setTo(ArbitraryMeshConfig that) {
+		this.lastPath.set(that.lastPath.get());
+		this.meshes.setAll(that.meshes);
+		this.isVisible.set(that.isVisible.get());
+	}
+
+	public void bindTo(ArbitraryMeshConfig that) {
+		this.lastPath.bind(that.lastPath);
+		this.isVisible.bind(that.isVisible);
+		that.meshes.addListener((InvalidationListener) obs -> this.meshes.setAll(that.meshes));
+	}
+
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/ArbitraryMeshConfigNode.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/ArbitraryMeshConfigNode.java
@@ -1,0 +1,264 @@
+package org.janelia.saalfeldlab.paintera.config;
+
+import javafx.beans.InvalidationListener;
+import javafx.beans.binding.BooleanBinding;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Group;
+import javafx.scene.Node;
+import javafx.scene.control.Alert;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.ChoiceBox;
+import javafx.scene.control.ColorPicker;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.control.TextField;
+import javafx.scene.control.TitledPane;
+import javafx.scene.control.Tooltip;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+import javafx.scene.shape.CullFace;
+import javafx.scene.shape.DrawMode;
+import javafx.stage.FileChooser;
+import javafx.util.Callback;
+import org.janelia.saalfeldlab.fx.Labels;
+import org.janelia.saalfeldlab.fx.TitledPanes;
+import org.janelia.saalfeldlab.fx.ui.Exceptions;
+import org.janelia.saalfeldlab.fx.ui.NumberField;
+import org.janelia.saalfeldlab.fx.ui.ObjectField;
+import org.janelia.saalfeldlab.paintera.meshes.io.TriangleMeshFormat;
+import org.janelia.saalfeldlab.paintera.meshes.io.obj.ObjFormat;
+import org.janelia.saalfeldlab.paintera.ui.PainteraAlerts;
+
+import javax.tools.Tool;
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ArbitraryMeshConfigNode extends TitledPane {
+
+	private final ArbitraryMeshConfig config = new ArbitraryMeshConfig();
+
+	private final CheckBox isVisibleCheckbox = new CheckBox();
+
+	private final Group meshGroup = new Group();
+
+	private final Map<ArbitraryMeshConfig.MeshInfo, Node> nodeMap = new HashMap<>();
+
+	private final VBox meshConfigs = new VBox();
+
+	private final Button addButton = new Button("+");
+
+	public ArbitraryMeshConfigNode() {
+		super("Triangle Meshes",null);
+		isVisibleCheckbox.selectedProperty().bindBidirectional(config.isVisibleProperty());
+		meshGroup.visibleProperty().bindBidirectional(isVisibleCheckbox.selectedProperty());
+		this.config.getUnmodifiableMeshes().addListener((InvalidationListener) obs -> update());
+
+		addButton.setOnAction(e -> {
+			final Alert dialog = PainteraAlerts.alert(Alert.AlertType.CONFIRMATION, true);
+			((Button)dialog.getDialogPane().lookupButton(ButtonType.OK)).setText("_OK");
+			((Button)dialog.getDialogPane().lookupButton(ButtonType.CANCEL)).setText("_Cancel");
+			dialog.setHeaderText("Open mesh from file");
+			final ObservableList<TriangleMeshFormat> formats = FXCollections.observableArrayList(TriangleMeshFormat.availableFormats());
+			final Map<String, List<TriangleMeshFormat>> extensionFormatMapping = TriangleMeshFormat.extensionsToFormatMapping();
+			ComboBox<TriangleMeshFormat> formatChoiceBox = new ComboBox<>(formats);
+			formatChoiceBox.setPromptText("Format");
+
+			formatChoiceBox.setCellFactory(param -> new ListCell<TriangleMeshFormat>() {
+				@Override
+				protected void updateItem(TriangleMeshFormat item, boolean empty) {
+					super.updateItem(item, empty);
+					if (item == null || empty) {
+						setGraphic(null);
+					} else {
+						setText(String.format("%s %s", item.formatName(), item.knownExtensions()));
+					}
+				}
+			});
+			formatChoiceBox.setButtonCell(formatChoiceBox.getCellFactory().call(null));
+
+			final Path lastPath = config.lastPathProperty().get();
+			final TextField path = new TextField(null);
+			path.setTooltip(new Tooltip());
+			path.getTooltip().textProperty().bind(path.textProperty());
+			path.textProperty().addListener((obs, oldv, newv) -> {
+				if (newv == null)
+					formatChoiceBox.setValue(null);
+				else {
+					final String[] split = newv.split("\\.");
+					final String extension = split[split.length - 1];
+					formatChoiceBox.setValue(Optional.ofNullable(extensionFormatMapping.get(extension)).map(l -> l.get(0)).orElse(null));
+				}
+			});
+			path.setText(lastPath == null ? null : lastPath.toAbsolutePath().toString());
+			final BooleanBinding isNull = path.textProperty().isNull();
+			dialog.getDialogPane().lookupButton(ButtonType.OK).disableProperty().bind(isNull);
+			path.setEditable(false);
+			final Button browseButton = new Button("_Browse");
+			final FileChooser chooser = new FileChooser();
+			chooser.setInitialDirectory(lastPath == null ? null : lastPath.getParent().toFile());
+			final ObjectProperty<Path> newPath = new SimpleObjectProperty<>();
+			browseButton.setOnAction(ev -> {
+				final File newFile = chooser.showOpenDialog(dialog.getOwner());
+				if (newFile != null) {
+					newPath.set(newFile.toPath());
+					path.setText(newPath.get().toAbsolutePath().toString());
+				}
+			});
+			final GridPane contents = new GridPane();
+			contents.add(path, 0, 0);
+			contents.add(browseButton, 1, 0);
+			contents.add(formatChoiceBox, 1, 1);
+			GridPane.setHgrow(path, Priority.ALWAYS);
+			browseButton.setMaxWidth(120);
+			formatChoiceBox.setMaxWidth(120);
+			browseButton.setTooltip(new Tooltip("Browse for mesh file"));
+			dialog.getDialogPane().setContent(contents);
+			final Optional<ButtonType> button = dialog.showAndWait();
+			if (ButtonType.OK.equals(button.orElse(ButtonType.CANCEL)) && newPath.get() != null) {
+				try {
+					config.lastPathProperty().set(newPath.get());
+					config.addMesh(new ArbitraryMeshConfig.MeshInfo(newPath.get(), new ObjFormat()));
+				} catch (final Exception ex){
+					Exceptions.exceptionAlert(String.format("Unable to load mesh at path %s", newPath.getName()), ex);
+				}
+			}
+		});
+
+		setContent(meshConfigs);
+		setExpanded(false);
+		setPadding(Insets.EMPTY);
+		final HBox hbox = new HBox(isVisibleCheckbox, new Label("Triangle Meshes"));
+		hbox.setAlignment(Pos.CENTER);
+		TitledPanes.graphicsOnly(this, hbox, addButton);
+
+		meshConfigs.setPadding(Insets.EMPTY);
+
+		update();
+	}
+
+	private void update() {
+		final List<ArbitraryMeshConfig.MeshInfo> meshInfos = new ArrayList<>(this.config.getUnmodifiableMeshes());
+		final Set<ArbitraryMeshConfig.MeshInfo> toRemoveFromNodeMap = nodeMap
+				.keySet()
+				.stream()
+				.filter(meshInfos::contains)
+				.collect(Collectors.toSet());
+		toRemoveFromNodeMap.forEach(nodeMap::remove);
+
+		for (final ArbitraryMeshConfig.MeshInfo meshInfo : meshInfos) {
+			if (!nodeMap.containsKey(meshInfo)) {
+				final TitledPane tp = TitledPanes.createCollapsed(null, null);
+				final CheckBox visibleBox = new CheckBox();
+				visibleBox.selectedProperty().bindBidirectional(meshInfo.isVisibleProperty());
+				final TextField nameField = new TextField(meshInfo.nameProperty().get());
+				nameField.textProperty().bindBidirectional(meshInfo.nameProperty());
+				tp.setPadding(Insets.EMPTY);
+
+				final double prefCellWidth = 50.0;
+
+				final GridPane settingsGrid = new GridPane();
+				final ColorPicker colorPicker = new ColorPicker();
+				colorPicker.valueProperty().bindBidirectional(meshInfo.colorProperty());
+				settingsGrid.add(Labels.withTooltip("Color"), 0, 0);
+				settingsGrid.add(colorPicker, 3, 0);
+				colorPicker.setPrefWidth(prefCellWidth);
+
+				final NumberField<DoubleProperty> translationX = NumberField.doubleField(0.0, v -> true, ObjectField.SubmitOn.values());
+				final NumberField<DoubleProperty> translationY = NumberField.doubleField(0.0, v -> true, ObjectField.SubmitOn.values());
+				final NumberField<DoubleProperty> translationZ = NumberField.doubleField(0.0, v -> true, ObjectField.SubmitOn.values());
+				translationX.valueProperty().bindBidirectional(meshInfo.translateXProperty());
+				translationY.valueProperty().bindBidirectional(meshInfo.translateYProperty());
+				translationZ.valueProperty().bindBidirectional(meshInfo.translateZProperty());
+				settingsGrid.add(Labels.withTooltip("Translation"), 0, 1);
+				settingsGrid.add(translationX.textField(), 1, 1);
+				settingsGrid.add(translationY.textField(), 2, 1);
+				settingsGrid.add(translationZ.textField(), 3, 1);
+				translationX.textField().setTooltip(new Tooltip());
+				translationY.textField().setTooltip(new Tooltip());
+				translationZ.textField().setTooltip(new Tooltip());
+				translationX.textField().getTooltip().textProperty().bind(translationX.textField().textProperty());
+				translationY.textField().getTooltip().textProperty().bind(translationY.textField().textProperty());
+				translationZ.textField().getTooltip().textProperty().bind(translationZ.textField().textProperty());
+				translationX.textField().setPrefWidth(prefCellWidth);
+				translationY.textField().setPrefWidth(prefCellWidth);
+				translationZ.textField().setPrefWidth(prefCellWidth);
+
+
+				final NumberField<DoubleProperty> scale = NumberField.doubleField(1.0, v -> v > 0.0, ObjectField.SubmitOn.values());
+				scale.valueProperty().bindBidirectional(meshInfo.scaleProperty());
+				settingsGrid.add(Labels.withTooltip("Scale"), 0, 2);
+				settingsGrid.add(scale.textField(), 3, 2);
+				scale.textField().setPrefWidth(prefCellWidth);
+
+				final ChoiceBox<DrawMode> drawMode = new ChoiceBox<>(FXCollections.observableArrayList(DrawMode.values()));
+				drawMode.valueProperty().bindBidirectional(meshInfo.drawModeProperty());
+				settingsGrid.add(Labels.withTooltip("Draw Mode"), 0, 3);
+				settingsGrid.add(drawMode, 3, 3);
+				drawMode.setPrefWidth(prefCellWidth);
+				drawMode.setTooltip(new Tooltip("Select draw mode"));
+
+				final ChoiceBox<CullFace> cullFace = new ChoiceBox<>(FXCollections.observableArrayList(CullFace.values()));
+				cullFace.valueProperty().bindBidirectional(meshInfo.cullFaceProperty());
+				settingsGrid.add(Labels.withTooltip("Cull Face"), 0, 4);
+				settingsGrid.add(cullFace, 3, 4);
+				cullFace.setPrefWidth(prefCellWidth);
+				cullFace.setTooltip(new Tooltip("Select cull face"));
+
+				tp.setContent(settingsGrid);
+
+				final Button removeButton = new Button("x");
+				removeButton.setOnAction(e -> config.removeMesh(meshInfo));
+
+				final HBox hbox = new HBox(visibleBox, nameField);
+				hbox.setAlignment(Pos.CENTER);
+				HBox.setHgrow(nameField, Priority.ALWAYS);
+				TitledPanes.graphicsOnly(tp, hbox, removeButton);
+
+				nodeMap.put(meshInfo, tp);
+			}
+		}
+
+		final List<Node> meshes = meshInfos
+				.stream()
+				.map(ArbitraryMeshConfig.MeshInfo::getMeshView)
+				.collect(Collectors.toList());
+
+		final List<Node> configNodes = meshInfos
+				.stream()
+				.map(nodeMap::get)
+				.collect(Collectors.toList());
+
+		meshConfigs.getChildren().setAll(configNodes);
+		meshGroup.getChildren().setAll(meshes);
+	}
+
+	public Node getMeshGroup() {
+		return this.meshGroup;
+	}
+
+	public ArbitraryMeshConfig getConfig() {
+		return this.config;
+	}
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/meshes/MeshGeneratorJobManager.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/meshes/MeshGeneratorJobManager.java
@@ -1,20 +1,6 @@
 package org.janelia.saalfeldlab.paintera.meshes;
 
-import java.lang.invoke.MethodHandles;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.function.IntConsumer;
-import java.util.stream.Collectors;
-
 import javafx.collections.ObservableMap;
-import javafx.scene.paint.Color;
 import javafx.scene.paint.PhongMaterial;
 import javafx.scene.shape.CullFace;
 import javafx.scene.shape.DrawMode;
@@ -28,6 +14,19 @@ import net.imglib2.util.ValuePair;
 import org.janelia.saalfeldlab.util.HashWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.function.IntConsumer;
+import java.util.stream.Collectors;
 
 public class MeshGeneratorJobManager<T>
 {
@@ -359,9 +358,7 @@ public class MeshGeneratorJobManager<T>
 			faceIndices[i + 2] = 0;
 		}
 		mesh.getFaces().addAll(faceIndices);
-		final PhongMaterial material = new PhongMaterial();
-		material.setSpecularColor(new Color(1, 1, 1, 1.0));
-		material.setSpecularPower(50);
+		final PhongMaterial material = Meshes.painteraPhongMaterial();
 		//						material.diffuseColorProperty().bind( color );
 		final MeshView mv = new MeshView(mesh);
 		mv.setOpacity(1.0);

--- a/src/main/java/org/janelia/saalfeldlab/paintera/meshes/Meshes.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/meshes/Meshes.java
@@ -1,0 +1,21 @@
+package org.janelia.saalfeldlab.paintera.meshes;
+
+import javafx.scene.paint.Color;
+import javafx.scene.paint.PhongMaterial;
+
+public class Meshes {
+
+	public static final Color DEFAULT_MESH_COLOR = new Color(1, 1, 1, 1.0);
+
+	public static PhongMaterial painteraPhongMaterial() {
+		return painteraPhongMaterial(DEFAULT_MESH_COLOR);
+	}
+
+	public static PhongMaterial painteraPhongMaterial(final Color color) {
+		final PhongMaterial material = new PhongMaterial();
+		material.setSpecularColor(color);
+		material.setSpecularPower(50);
+		return material;
+	}
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/meshes/io/TriangleMeshFormat.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/meshes/io/TriangleMeshFormat.java
@@ -1,0 +1,65 @@
+package org.janelia.saalfeldlab.paintera.meshes.io;
+
+import javafx.scene.shape.TriangleMesh;
+import org.scijava.Context;
+import org.scijava.InstantiableException;
+import org.scijava.plugin.DefaultPluginService;
+import org.scijava.plugin.Plugin;
+import org.scijava.plugin.PluginInfo;
+import org.scijava.plugin.PluginService;
+import org.scijava.plugin.SciJavaPlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public interface TriangleMeshFormat extends SciJavaPlugin {
+
+	class FormatFinder {
+
+		private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+		private static List<TriangleMeshFormat> meshFormats = new ArrayList<>();
+
+		private static Map<String, List<TriangleMeshFormat>> extensionToFormatMapping = new HashMap<>();
+
+		static {
+			final Context context = new Context();
+			final PluginService pluginService = context.getService(PluginService.class);
+			final List<PluginInfo<TriangleMeshFormat>> pluginInfos = pluginService.getPluginsOfType(TriangleMeshFormat.class);
+			for (PluginInfo<TriangleMeshFormat> pluginInfo : pluginInfos) {
+				try {
+					final TriangleMeshFormat instance = pluginInfo.createInstance();
+					meshFormats.add(instance);
+					for (final String ext : instance.knownExtensions())
+						extensionToFormatMapping.computeIfAbsent(ext, k -> new ArrayList<>()).add(instance);
+				} catch (InstantiableException e) {
+					LOG.error("Unable to instantiate plugin {}", pluginInfo, e);
+				}
+			}
+		}
+
+	}
+
+	String formatName();
+
+	Set<String> knownExtensions();
+
+	TriangleMeshWriter getWriter();
+
+	TriangleMeshLoader getLoader();
+
+	static List<TriangleMeshFormat> availableFormats() {
+		return Collections.unmodifiableList(FormatFinder.meshFormats);
+	}
+
+	static Map<String, List<TriangleMeshFormat>> extensionsToFormatMapping() {
+		return Collections.unmodifiableMap(FormatFinder.extensionToFormatMapping);
+	}
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/meshes/io/TriangleMeshLoader.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/meshes/io/TriangleMeshLoader.java
@@ -1,0 +1,12 @@
+package org.janelia.saalfeldlab.paintera.meshes.io;
+
+import javafx.scene.shape.TriangleMesh;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public interface TriangleMeshLoader {
+
+	TriangleMesh loadMesh(Path path) throws IOException;
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/meshes/io/TriangleMeshWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/meshes/io/TriangleMeshWriter.java
@@ -1,0 +1,12 @@
+package org.janelia.saalfeldlab.paintera.meshes.io;
+
+import javafx.scene.shape.TriangleMesh;
+import org.scijava.plugin.SciJavaPlugin;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public interface TriangleMeshWriter extends SciJavaPlugin {
+
+	void writeMesh(TriangleMesh mesh, Path path) throws IOException;
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/meshes/io/obj/ObjFormat.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/meshes/io/obj/ObjFormat.java
@@ -1,0 +1,35 @@
+package org.janelia.saalfeldlab.paintera.meshes.io.obj;
+
+import org.janelia.saalfeldlab.paintera.meshes.io.TriangleMeshFormat;
+import org.janelia.saalfeldlab.paintera.meshes.io.TriangleMeshLoader;
+import org.janelia.saalfeldlab.paintera.meshes.io.TriangleMeshWriter;
+import org.scijava.plugin.Plugin;
+import org.scijava.plugin.SciJavaPlugin;
+
+import java.util.Collections;
+import java.util.Set;
+
+@Plugin(type = TriangleMeshFormat.class)
+public class ObjFormat implements TriangleMeshFormat, SciJavaPlugin {
+
+	@Override
+	public String formatName() {
+		return "OBJ";
+	}
+
+	@Override
+	public Set<String> knownExtensions() {
+		return Collections.singleton("obj");
+	}
+
+	@Override
+	public TriangleMeshWriter getWriter() {
+		return new ObjWriter();
+	}
+
+	@Override
+	public TriangleMeshLoader getLoader() {
+		return new ObjLoader();
+	}
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/meshes/io/obj/ObjLoader.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/meshes/io/obj/ObjLoader.java
@@ -8,8 +8,6 @@ import de.javagl.obj.ObjReader;
 import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.paint.Color;
-import javafx.scene.paint.PhongMaterial;
-import javafx.scene.shape.Box;
 import javafx.scene.shape.CullFace;
 import javafx.scene.shape.DrawMode;
 import javafx.scene.shape.MeshView;
@@ -19,6 +17,7 @@ import javafx.stage.Stage;
 import net.imglib2.FinalRealInterval;
 import net.imglib2.Interval;
 import net.imglib2.util.Intervals;
+import org.janelia.saalfeldlab.paintera.meshes.Meshes;
 import org.janelia.saalfeldlab.paintera.meshes.io.TriangleMeshLoader;
 import org.janelia.saalfeldlab.paintera.viewer3d.Viewer3DFX;
 
@@ -134,20 +133,25 @@ public class ObjLoader implements TriangleMeshLoader {
 		}
 		final Interval interval = Intervals.smallestContainingInterval(new FinalRealInterval(min, max));
 		final MeshView mv = new MeshView(mesh);
-		mv.setMaterial(new PhongMaterial(Color.WHITE));
+		mv.setMaterial(Meshes.painteraPhongMaterial(Color.WHITE));
 		mv.setDrawMode(DrawMode.FILL);
 		mv.setCullFace(CullFace.BACK);
 		final Viewer3DFX viewer = new Viewer3DFX(800, 600);
 		viewer.isMeshesEnabledProperty().set(true);
 		mv.setOpacity(1.0);
-		viewer.meshesGroup().getChildren().add(mv);
 		viewer.setInitialTransformToInterval(interval);
+		final MeshView mv2 = new MeshView(mesh);
+		mv.setMaterial(Meshes.painteraPhongMaterial());
+		mv.setDrawMode(DrawMode.FILL);
+		mv.setCullFace(CullFace.BACK);
+		mv2.setTranslateX(100);
+		viewer.meshesGroup().getChildren().addAll(mv, mv2);
 //		final double factor = 1;
 //		final double w = 1*factor, h = 2*factor, d = 3*factor;
 //		final Box box = new Box(w, h, d);
 //		box.setCullFace(CullFace.NONE);
 //		box.setOpacity(1.0);
-//		box.setMaterial(new PhongMaterial(Color.RED));
+//		box.setMaterial(Meshes.painteraPhongMaterial(Color.RED));
 //		viewer.meshesGroup().getChildren().add(box);
 		Platform.setImplicitExit(true);
 		Platform.runLater(() -> {

--- a/src/main/java/org/janelia/saalfeldlab/paintera/meshes/io/obj/ObjLoader.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/meshes/io/obj/ObjLoader.java
@@ -1,0 +1,163 @@
+package org.janelia.saalfeldlab.paintera.meshes.io.obj;
+
+import com.sun.javafx.application.PlatformImpl;
+import de.javagl.obj.FloatTuple;
+import de.javagl.obj.Obj;
+import de.javagl.obj.ObjFace;
+import de.javagl.obj.ObjReader;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.paint.Color;
+import javafx.scene.paint.PhongMaterial;
+import javafx.scene.shape.Box;
+import javafx.scene.shape.CullFace;
+import javafx.scene.shape.DrawMode;
+import javafx.scene.shape.MeshView;
+import javafx.scene.shape.TriangleMesh;
+import javafx.scene.shape.VertexFormat;
+import javafx.stage.Stage;
+import net.imglib2.FinalRealInterval;
+import net.imglib2.Interval;
+import net.imglib2.util.Intervals;
+import org.janelia.saalfeldlab.paintera.meshes.io.TriangleMeshLoader;
+import org.janelia.saalfeldlab.paintera.viewer3d.Viewer3DFX;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class ObjLoader implements TriangleMeshLoader {
+
+	@Override
+	public TriangleMesh loadMesh(Path path) throws IOException {
+		try (final InputStream fis = new FileInputStream(path.toFile())) {
+
+			final Obj obj = ObjReader.read(fis);
+
+			final VertexFormat vertexFormat;
+			if (obj.getNumFaces() > 0 && obj.getFace(0).containsNormalIndices())
+				vertexFormat = VertexFormat.POINT_NORMAL_TEXCOORD;
+			else
+				vertexFormat = VertexFormat.POINT_TEXCOORD;
+
+			final boolean hasTexCoordinates = obj.getNumTexCoords() > 0;
+			final float[] texCoords = new float[obj.getNumTexCoords() * 2];
+			final float[] vertices = new float[obj.getNumVertices() * 3];
+			final float[] normals = new float[obj.getNumNormals() * 3];
+			final int[] faces = new int[obj.getNumFaces() * vertexFormat.getVertexIndexSize() * 3];
+
+			// assume 3D (not 4D, or 2D)
+
+			for (int i = 0, k = -1; i < obj.getNumTexCoords(); ++i) {
+				final FloatTuple coord = obj.getTexCoord(i);
+				texCoords[++k] = coord.getX();
+				texCoords[++k] = coord.getY();
+			}
+
+			for (int i = 0, k = -1; i < obj.getNumVertices(); ++i) {
+				final FloatTuple vertex = obj.getVertex(i);
+				vertices[++k] = vertex.getX();
+				vertices[++k] = vertex.getY();
+				vertices[++k] = vertex.getZ();
+			}
+
+			for (int i = 0, k = -1; i < obj.getNumNormals(); ++i) {
+				final FloatTuple normal = obj.getNormal(i);
+				normals[++k] = normal.getX();
+				normals[++k] = normal.getY();
+				normals[++k] = normal.getZ();
+			}
+
+			// from TriangleMesh doc:
+			//
+			// VertexFormat.POINT_TEXCOORD
+			// p0, t0, p1, t1, p3, t3
+			//
+			// VertexFormat.POINT_NORMAL_TEXCOORD:
+			// p0, n0, t0, p1, n1, t1, p3, n3, t3, // First triangle of a textured rectangle
+			// p: vertex
+			// n: normal
+			// t: texture
+			// https://docs.oracle.com/javase/8/javafx/api/javafx/scene/shape/TriangleMesh.html
+			if (VertexFormat.POINT_NORMAL_TEXCOORD.equals(vertexFormat)) {
+				for (int i = 0, k = -1; i < obj.getNumFaces(); ++i) {
+					final ObjFace face = obj.getFace(i);
+					faces[++k] = face.getVertexIndex(0);
+					faces[++k] = face.getNormalIndex(0);
+					faces[++k] = hasTexCoordinates ? face.getTexCoordIndex(0) : 0;
+					faces[++k] = face.getVertexIndex(1);
+					faces[++k] = face.getNormalIndex(1);
+					faces[++k] = hasTexCoordinates ? face.getTexCoordIndex(1) : 0;
+					faces[++k] = face.getVertexIndex(2);
+					faces[++k] = face.getNormalIndex(2);
+					faces[++k] = hasTexCoordinates ? face.getTexCoordIndex(2) : 0;
+				}
+			} else {
+				for (int i = 0, k = -1; i < obj.getNumFaces(); ++i) {
+					final ObjFace face = obj.getFace(i);
+					faces[++k] = face.getVertexIndex(0);
+					faces[++k] = hasTexCoordinates ? face.getTexCoordIndex(0) : 0;
+					faces[++k] = face.getVertexIndex(1);
+					faces[++k] = hasTexCoordinates ? face.getTexCoordIndex(1) : 0;
+					faces[++k] = face.getVertexIndex(2);
+					faces[++k] = hasTexCoordinates ? face.getTexCoordIndex(2) : 0;
+				}
+			}
+
+			final TriangleMesh mesh = new TriangleMesh(vertexFormat);
+			mesh.getTexCoords().setAll(hasTexCoordinates ? texCoords : new float[] {0.0f, 0.0f});
+			mesh.getPoints().setAll(vertices);
+			mesh.getFaces().setAll(faces);
+			if (normals.length > 0)
+				mesh.getNormals().setAll(normals);
+			return mesh;
+		}
+	}
+
+	public static void main(String[] args) throws IOException {
+		PlatformImpl.startup(() -> {});
+		// https://people.sc.fsu.edu/~jburkardt/data/obj/obj.html
+//		final String objFile = "al.obj";
+//		final String objFile = "diamond.obj";
+		final String objFile = "alfa147.obj";
+		final Path path = Paths.get(System.getProperty("user.home"), "Downloads", objFile);
+		final TriangleMesh mesh = new ObjLoader().loadMesh(path);
+		final double[] min = {Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY};
+		final double[] max = {Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY};
+		for (int i = 0; i < mesh.getPoints().size(); i += 3) {
+			for (int d = 0; d < 3; ++d) {
+				min[d] = Math.min(min[d], mesh.getPoints().get(i + d));
+				max[d] = Math.max(max[d], mesh.getPoints().get(i + d));
+			}
+		}
+		final Interval interval = Intervals.smallestContainingInterval(new FinalRealInterval(min, max));
+		final MeshView mv = new MeshView(mesh);
+		mv.setMaterial(new PhongMaterial(Color.WHITE));
+		mv.setDrawMode(DrawMode.FILL);
+		mv.setCullFace(CullFace.BACK);
+		final Viewer3DFX viewer = new Viewer3DFX(800, 600);
+		viewer.isMeshesEnabledProperty().set(true);
+		mv.setOpacity(1.0);
+		viewer.meshesGroup().getChildren().add(mv);
+		viewer.setInitialTransformToInterval(interval);
+//		final double factor = 1;
+//		final double w = 1*factor, h = 2*factor, d = 3*factor;
+//		final Box box = new Box(w, h, d);
+//		box.setCullFace(CullFace.NONE);
+//		box.setOpacity(1.0);
+//		box.setMaterial(new PhongMaterial(Color.RED));
+//		viewer.meshesGroup().getChildren().add(box);
+		Platform.setImplicitExit(true);
+		Platform.runLater(() -> {
+			final Scene scene = new Scene(viewer);
+			final Stage stage = new Stage();
+			stage.setScene(scene);
+			stage.setWidth(800);
+			stage.setHeight(600);
+			stage.show();
+		});
+	}
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/meshes/io/obj/ObjWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/meshes/io/obj/ObjWriter.java
@@ -1,0 +1,43 @@
+package org.janelia.saalfeldlab.paintera.meshes.io.obj;
+
+import de.javagl.obj.Obj;
+import de.javagl.obj.Objs;
+import javafx.scene.shape.TriangleMesh;
+import org.janelia.saalfeldlab.paintera.meshes.io.TriangleMeshWriter;
+
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.nio.file.Path;
+
+public class ObjWriter implements TriangleMeshWriter {
+
+
+	@Override
+	public void writeMesh(
+			final TriangleMesh mesh,
+			final Path path) throws IOException {
+
+		final float[] texCoords = new float[mesh.getTexCoords().size()];
+		final float[] vertices = new float[mesh.getPoints().size()];
+		final float[] normals = new float[mesh.getNormals().size()];
+		final int[] faces = new int[mesh.getFaces().size()];
+		mesh.getTexCoords().toArray(texCoords);
+		mesh.getPoints().toArray(vertices);
+		mesh.getNormals().toArray(normals);
+		mesh.getFaces().toArray(faces);
+
+		final Obj obj = Objs.createFromIndexedTriangleData(
+				IntBuffer.wrap(faces),
+				FloatBuffer.wrap(vertices),
+				FloatBuffer.wrap(texCoords),
+				FloatBuffer.wrap(normals));
+		
+		try (final OutputStream fos = new FileOutputStream(path.toFile())) {
+			de.javagl.obj.ObjWriter.write(obj, fos);
+		}
+	}
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/serialization/ArbitraryMeshConfigSerializer.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/serialization/ArbitraryMeshConfigSerializer.java
@@ -1,0 +1,153 @@
+package org.janelia.saalfeldlab.paintera.serialization;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.CullFace;
+import javafx.scene.shape.DrawMode;
+import org.janelia.saalfeldlab.paintera.config.ArbitraryMeshConfig;
+import org.janelia.saalfeldlab.paintera.meshes.io.TriangleMeshFormat;
+import org.janelia.saalfeldlab.util.Colors;
+import org.scijava.plugin.Plugin;
+
+import java.lang.reflect.Type;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+
+@Plugin(type = PainteraSerialization.PainteraAdapter.class)
+public class ArbitraryMeshConfigSerializer implements PainteraSerialization.PainteraAdapter<ArbitraryMeshConfig> {
+
+	private static final String IS_VISIBLE_KEY = "isVisible";
+
+	private static final String LAST_PATH_KEY = "lastPath";
+
+	private static final String MESH_INFO_LIST_KEY = "meshes";
+
+	@Plugin(type = PainteraSerialization.PainteraAdapter.class)
+	public static class MeshInfoSerializer implements PainteraSerialization.PainteraAdapter<ArbitraryMeshConfig.MeshInfo> {
+
+		private static final String PATH_KEY = "path";
+
+		private static final String FORMAT_KEY = "format";
+
+		private static final String NAME_KEY = "name";
+
+		private static final String IS_VISIBLE_KEY = "isVisible";
+
+		private static final String COLOR_KEY = "color";
+
+		private static final String SCALE_KEY = "scale";
+
+		private static final String TRANSLATE_X_KEY = "translateX";
+
+		private static final String TRANSLATE_Y_KEY = "translateY";
+
+		private static final String TRANSLATE_Z_KEY = "translateZ";
+
+		private static final String CULL_FACE_KEY = "cullFace";
+
+		private static final String DRAW_MODE_KEY = "drawMode";
+
+		@Override
+		public ArbitraryMeshConfig.MeshInfo deserialize(
+				final JsonElement json,
+				final Type typeOfT,
+				final JsonDeserializationContext context) throws JsonParseException {
+			final JsonObject map = json.getAsJsonObject();
+			final String path = map.get(PATH_KEY).getAsString();
+			final String className = map.get(FORMAT_KEY).getAsString();
+			try {
+				final ArbitraryMeshConfig.MeshInfo meshInfo = new ArbitraryMeshConfig.MeshInfo(
+						Paths.get(path),
+						((Class<TriangleMeshFormat>)Class.forName(className)).getConstructor().newInstance());
+				if (map.has(NAME_KEY)) meshInfo.nameProperty().set(map.get(NAME_KEY).getAsString());
+				if (map.has(IS_VISIBLE_KEY)) meshInfo.isVisibleProperty().set(map.get(IS_VISIBLE_KEY).getAsBoolean());
+				if (map.has(COLOR_KEY)) meshInfo.colorProperty().set(Color.web(map.get(COLOR_KEY).getAsString()));
+				if (map.has(SCALE_KEY)) meshInfo.scaleProperty().set(map.get(SCALE_KEY).getAsDouble());
+				if (map.has(TRANSLATE_X_KEY)) meshInfo.translateXProperty().set(map.get(TRANSLATE_X_KEY).getAsDouble());
+				if (map.has(TRANSLATE_Y_KEY)) meshInfo.translateYProperty().set(map.get(TRANSLATE_Y_KEY).getAsDouble());
+				if (map.has(TRANSLATE_Z_KEY)) meshInfo.translateZProperty().set(map.get(TRANSLATE_Z_KEY).getAsDouble());
+				if (map.has(CULL_FACE_KEY)) meshInfo.cullFaceProperty().set(context.deserialize(map.get(CULL_FACE_KEY), CullFace.class));
+				if (map.has(DRAW_MODE_KEY)) meshInfo.drawModeProperty().set(context.deserialize(map.get(DRAW_MODE_KEY), DrawMode.class));
+				return meshInfo;
+			} catch (Exception e) {
+				throw new JsonParseException(e);
+			}
+		}
+
+		@Override
+		public JsonElement serialize(
+				final ArbitraryMeshConfig.MeshInfo meshInfo,
+				final Type typeOfSrc,
+				final JsonSerializationContext context) {
+			final JsonObject map = new JsonObject();
+			map.addProperty(PATH_KEY, meshInfo.getPath().toAbsolutePath().toString());
+			map.addProperty(FORMAT_KEY, meshInfo.getFormat().getClass().getName());
+			map.addProperty(NAME_KEY, meshInfo.nameProperty().get());
+			map.addProperty(IS_VISIBLE_KEY, meshInfo.isVisibleProperty().get());
+			map.addProperty(COLOR_KEY, Colors.toHTML(meshInfo.colorProperty().get()));
+			map.addProperty(SCALE_KEY, meshInfo.scaleProperty().get());
+			map.addProperty(TRANSLATE_X_KEY, meshInfo.translateXProperty().get());
+			map.addProperty(TRANSLATE_Y_KEY, meshInfo.translateYProperty().get());
+			map.addProperty(TRANSLATE_Z_KEY, meshInfo.translateZProperty().get());
+			map.add(CULL_FACE_KEY, context.serialize(meshInfo.cullFaceProperty().get()));
+			map.add(DRAW_MODE_KEY, context.serialize(meshInfo.drawModeProperty().get()));
+			return map;
+		}
+
+		@Override
+		public Class<ArbitraryMeshConfig.MeshInfo> getTargetClass() {
+			return ArbitraryMeshConfig.MeshInfo.class;
+		}
+
+		@Override
+		public boolean isHierarchyAdapter() {
+			return false;
+		}
+	}
+
+	@Override
+	public ArbitraryMeshConfig deserialize(
+			final JsonElement json,
+			final Type typeOfT,
+			final JsonDeserializationContext context) throws JsonParseException {
+		final ArbitraryMeshConfig config = new ArbitraryMeshConfig();
+		if (json.isJsonObject()) {
+			final JsonObject map = json.getAsJsonObject();
+			if (map.has(IS_VISIBLE_KEY)) config.isVisibleProperty().set(map.get(IS_VISIBLE_KEY).getAsBoolean());
+			if (map.has(LAST_PATH_KEY)) config.lastPathProperty().set(Paths.get(map.get(LAST_PATH_KEY).getAsString()));
+			if (map.has(MESH_INFO_LIST_KEY)) {
+				final JsonArray jsonList = map.get(MESH_INFO_LIST_KEY).getAsJsonArray();
+				for (int i = 0; i < jsonList.size(); ++i)
+					config.addMesh(context.deserialize(jsonList.get(i), ArbitraryMeshConfig.MeshInfo.class));
+			}
+		}
+		return config;
+	}
+
+	@Override
+	public JsonElement serialize(
+			final ArbitraryMeshConfig config,
+			final Type typeOfSrc,
+			final JsonSerializationContext context) {
+		final JsonObject map = new JsonObject();
+		map.addProperty(IS_VISIBLE_KEY, config.isVisibleProperty().get());
+		if (config.lastPathProperty().get() != null) map.addProperty(LAST_PATH_KEY, config.lastPathProperty().get().toAbsolutePath().toString());
+		map.add(MESH_INFO_LIST_KEY, context.serialize(new ArrayList<>(config.getUnmodifiableMeshes())));
+		return map;
+	}
+
+	@Override
+	public Class<ArbitraryMeshConfig> getTargetClass() {
+		return ArbitraryMeshConfig.class;
+	}
+
+	@Override
+	public boolean isHierarchyAdapter() {
+		return false;
+	}
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/serialization/Properties.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/serialization/Properties.java
@@ -11,6 +11,7 @@ import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.ui.TransformListener;
 import org.janelia.saalfeldlab.fx.ortho.GridConstraintsManager;
 import org.janelia.saalfeldlab.paintera.PainteraBaseView;
+import org.janelia.saalfeldlab.paintera.config.ArbitraryMeshConfig;
 import org.janelia.saalfeldlab.paintera.config.BookmarkConfig;
 import org.janelia.saalfeldlab.paintera.config.CrosshairConfig;
 import org.janelia.saalfeldlab.paintera.config.NavigationConfig;
@@ -57,6 +58,8 @@ public class Properties implements TransformListener<AffineTransform3D>
 
 	private static final String BOOKMARK_CONFIG = "bookmarkConfig";
 
+	private static final String ARBITRARY_MESH_CONFIG = "arbitraryMeshConfig";
+
 	@Expose
 	public final SourceInfo sourceInfo;
 
@@ -89,6 +92,9 @@ public class Properties implements TransformListener<AffineTransform3D>
 
 	@Expose
 	public final BookmarkConfig bookmarkConfig = new BookmarkConfig();
+
+	@Expose
+	public final ArbitraryMeshConfig arbitraryMeshConfig = new ArbitraryMeshConfig();
 
 	private transient final BooleanProperty transformDirty = new SimpleBooleanProperty(false);
 
@@ -224,6 +230,11 @@ public class Properties implements TransformListener<AffineTransform3D>
 					properties.bookmarkConfig.setAll(bmc.getUnmodifiableBookmarks());
 					properties.bookmarkConfig.setTransitionTime(bmc.getTransitionTime());
 				});
+
+		Optional
+				.ofNullable(serializedProperties.get(ARBITRARY_MESH_CONFIG))
+				.map(json -> gson.fromJson(json, ArbitraryMeshConfig.class))
+				.ifPresent(properties.arbitraryMeshConfig::setTo);
 
 
 		gridConstraints.set(deserializedGridConstraints);


### PR DESCRIPTION
I added support for loading arbitrary meshes into the Paintera viewer. @cpatrickc this will allow you to import the fafb landmark mesh into Paintera.

Example image with examples `alfa147.obj` and `al.obj` from https://people.sc.fsu.edu/~jburkardt/data/obj/obj.html:

![Screenshot_20190724_174628](https://user-images.githubusercontent.com/1086317/61831246-44145f00-ae3b-11e9-9551-eb7524558213.png)

The UI in the side bar has a new entry `Triangle Meshes` and new meshes can be added with the `+` button.

![Screenshot_20190724_174918](https://user-images.githubusercontent.com/1086317/61831274-5e4e3d00-ae3b-11e9-889e-2a18a2a670cc.png)

Addresses the first item of #254