### PR TITLE
Use MultiResolutionRenderer from bigdataviewer-core

### DIFF
--- a/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererFX.java
+++ b/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererFX.java
@@ -36,9 +36,12 @@ import bdv.viewer.render.AccumulateProjectorFactory;
 import net.imglib2.Interval;
 import net.imglib2.Volatile;
 import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.basictypeaccess.IntAccess;
+import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.ui.RenderTarget;
 import net.imglib2.ui.Renderer;
+import net.imglib2.ui.TransformListener;
 
 /**
  * A {@link Renderer} that uses a coarse-to-fine rendering scheme. First, a small {@link ArrayImg} at a fraction of
@@ -88,15 +91,15 @@ public class MultiResolutionRendererFX extends MultiResolutionRendererGeneric<Bu
 {
 
 	public static class MakeWritableImage
-			implements MultiResolutionRendererGeneric.ImageGenerator<BufferExposingWritableImage>
+			implements RenderOutputImage.Factory<BufferExposingWritableImage>
 	{
 
 		@Override
-		public BufferExposingWritableImage create(final int width, final int height)
+		public RenderOutputImage create(final int width, final int height)
 		{
 			try
 			{
-				return new BufferExposingWritableImage(width, height);
+				return new MyRenderOutputImage(new BufferExposingWritableImage(width, height));
 			} catch (final Exception e)
 			{
 				throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException(e);
@@ -104,13 +107,48 @@ public class MultiResolutionRendererFX extends MultiResolutionRendererGeneric<Bu
 		}
 
 		@Override
-		public BufferExposingWritableImage create(final int width, final int height, final BufferExposingWritableImage
-				other)
-		{
-			// TODO can we somehow re-use smaller image?
+		public RenderOutputImage create(int width, int height, RenderOutputImage other) {
 			return create(width, height);
 		}
 
+		@Override
+		public RenderOutputImage wrap(BufferExposingWritableImage image) {
+			return new MyRenderOutputImage(image);
+		}
+
+		@Override
+		public BufferExposingWritableImage unwrap(RenderOutputImage image) {
+			return ((MyRenderOutputImage) image).image;
+		}
+
+	}
+
+	public static class MyRenderOutputImage implements RenderOutputImage {
+
+		private final BufferExposingWritableImage image;
+
+		public MyRenderOutputImage(BufferExposingWritableImage image) {
+			this.image = image;
+		}
+
+		@Override
+		public int width() {
+			return (int) image.getWidth();
+		}
+
+		@Override
+		public int height() {
+			return (int) image.getHeight();
+		}
+
+		@Override
+		public ArrayImg<ARGBType, IntAccess> asArrayImg() {
+			return image.asArrayImg();
+		}
+
+		public BufferExposingWritableImage image() {
+			return image();
+		}
 	}
 
 	public MultiResolutionRendererFX(
@@ -136,11 +174,7 @@ public class MultiResolutionRendererFX extends MultiResolutionRendererGeneric<Bu
 				useVolatileIfAvailable,
 				accumulateProjectorFactory,
 				cacheControl,
-				BufferExposingWritableImage::asArrayImg,
-				new MakeWritableImage(),
-				img -> (int) img.getWidth(),
-				img -> (int) img.getHeight()
+				new MakeWritableImage()
 		     );
 	}
-
 }

--- a/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererFX.java
+++ b/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererFX.java
@@ -110,20 +110,9 @@ public class MultiResolutionRendererFX extends MultiResolutionRendererGeneric<Bu
 		public RenderOutputImage create(int width, int height, RenderOutputImage other) {
 			return create(width, height);
 		}
-
-		@Override
-		public RenderOutputImage wrap(BufferExposingWritableImage image) {
-			return new MyRenderOutputImage(image);
-		}
-
-		@Override
-		public BufferExposingWritableImage unwrap(RenderOutputImage image) {
-			return ((MyRenderOutputImage) image).image;
-		}
-
 	}
 
-	public static class MyRenderOutputImage implements RenderOutputImage {
+	public static class MyRenderOutputImage implements RenderOutputImage<BufferExposingWritableImage> {
 
 		private final BufferExposingWritableImage image;
 
@@ -146,8 +135,9 @@ public class MultiResolutionRendererFX extends MultiResolutionRendererGeneric<Bu
 			return image.asArrayImg();
 		}
 
-		public BufferExposingWritableImage image() {
-			return image();
+		@Override
+		public BufferExposingWritableImage unwrap() {
+			return image;
 		}
 	}
 

--- a/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererGeneric.java
+++ b/src/main/java/bdv/fx/viewer/render/MultiResolutionRendererGeneric.java
@@ -261,13 +261,14 @@ public class MultiResolutionRendererGeneric<T>
 	private final boolean useVolatileIfAvailable;
 
 	/**
-	 * Whether a repaint was {@link #requestRepaint(Interval) requested}. This will cause {@link
-	 * CacheControl#prepareNextFrame()}.
+	 * Whether a repaint was {@link #requestRepaint(Interval) requested}. This will
+	 * cause {@link CacheControl#prepareNextFrame()}.
 	 */
 	private boolean newFrameRequest;
 
 	/**
-	 * The timepoint for which last a projector was {@link #createProjector created}.
+	 * The timepoint for which last a projector was
+	 * {@link #createProjector  created}.
 	 */
 	private int previousTimepoint;
 
@@ -283,24 +284,29 @@ public class MultiResolutionRendererGeneric<T>
 	 * @param display
 	 * 		The canvas that will display the images we render.
 	 * @param painterThread
-	 * 		Thread that triggers repainting of the display. Requests for repainting are send there.
+	 *            Thread that triggers repainting of the display. Requests for
+	 *            repainting are send there.
 	 * @param screenScales
-	 * 		Scale factors from the viewer canvas to screen images of different resolutions. A scale factor of 1 means 1
-	 * 		pixel in the screen image is displayed as 1 pixel on the canvas, a scale factor of 0.5 means 1 pixel in the
-	 * 		screen image is displayed as 2 pixel on the canvas, etc.
+	 *            Scale factors from the viewer canvas to screen images of
+	 *            different resolutions. A scale factor of 1 means 1 pixel in
+	 *            the screen image is displayed as 1 pixel on the canvas, a
+	 *            scale factor of 0.5 means 1 pixel in the screen image is
+	 *            displayed as 2 pixel on the canvas, etc.
 	 * @param targetRenderNanos
-	 * 		Target rendering time in nanoseconds. The rendering time for the coarsest rendered scale should be below
-	 * 		this
-	 * 		threshold.
+	 *            Target rendering time in nanoseconds. The rendering time for
+	 *            the coarsest rendered scale should be below this threshold.
 	 * @param doubleBuffered
 	 * 		Whether to use double buffered rendering.
 	 * @param numRenderingThreads
 	 * 		How many threads to use for rendering.
 	 * @param renderingExecutorService
-	 * 		if non-null, this is used for rendering. Note, that it is still important to supply the numRenderingThreads
-	 * 		parameter, because that is used to determine into how many sub-tasks rendering is split.
+	 *            if non-null, this is used for rendering. Note, that it is
+	 *            still important to supply the numRenderingThreads parameter,
+	 *            because that is used to determine into how many sub-tasks
+	 *            rendering is split.
 	 * @param useVolatileIfAvailable
-	 * 		whether volatile versions of sources should be used if available.
+	 *            whether volatile versions of sources should be used if
+	 *            available.
 	 * @param accumulateProjectorFactory
 	 * 		can be used to customize how sources are combined.
 	 * @param cacheControl

--- a/src/main/java/bdv/fx/viewer/render/RenderOutputImage.java
+++ b/src/main/java/bdv/fx/viewer/render/RenderOutputImage.java
@@ -4,7 +4,7 @@ import net.imglib2.img.array.ArrayImg;
 import net.imglib2.img.basictypeaccess.IntAccess;
 import net.imglib2.type.numeric.ARGBType;
 
-public interface RenderOutputImage {
+public interface RenderOutputImage<T> {
 
 	int width();
 
@@ -12,14 +12,12 @@ public interface RenderOutputImage {
 
 	ArrayImg<ARGBType, IntAccess> asArrayImg();
 
+	T unwrap();
+
 	interface Factory<T> {
 
-		RenderOutputImage create( int width, int height );
+		RenderOutputImage< T > create( int width, int height );
 
-		RenderOutputImage create( int width, int heihgt, RenderOutputImage other);
-
-		RenderOutputImage wrap(T image);
-
-		T unwrap(RenderOutputImage image);
+		RenderOutputImage< T > create( int width, int heihgt, RenderOutputImage< T > other);
 	}
 }

--- a/src/main/java/bdv/fx/viewer/render/RenderOutputImage.java
+++ b/src/main/java/bdv/fx/viewer/render/RenderOutputImage.java
@@ -1,0 +1,25 @@
+package bdv.fx.viewer.render;
+
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.basictypeaccess.IntAccess;
+import net.imglib2.type.numeric.ARGBType;
+
+public interface RenderOutputImage {
+
+	int width();
+
+	int height();
+
+	ArrayImg<ARGBType, IntAccess> asArrayImg();
+
+	interface Factory<T> {
+
+		RenderOutputImage create( int width, int height );
+
+		RenderOutputImage create( int width, int heihgt, RenderOutputImage other);
+
+		RenderOutputImage wrap(T image);
+
+		T unwrap(RenderOutputImage image);
+	}
+}


### PR DESCRIPTION
The MultiResolutionRendererGeneric in Paintera is a fork of the MultiResolutionRenderer in BigDataViewer. This PR is part of an effort. That tries to reintegrate the changes made in Paintera into BigDataViewer.

See also https://github.com/bigdataviewer/bigdataviewer-core/pull/59

Currently I try to reduce the differences between the MultiResolutionRenderer in BigDataViewer and Paintera.