### PR TITLE
Remember 3d viewer transform

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/Viewer3DConfig.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/Viewer3DConfig.java
@@ -2,6 +2,8 @@ package org.janelia.saalfeldlab.paintera.config;
 
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.scene.paint.Color;
 import javafx.scene.transform.Affine;
 import org.janelia.saalfeldlab.paintera.viewer3d.Viewer3DFX;
 import org.slf4j.Logger;
@@ -18,6 +20,8 @@ public class Viewer3DConfig
 
 	private final SimpleBooleanProperty areMeshesEnabled = new SimpleBooleanProperty(true);
 
+	private final SimpleObjectProperty<Color> backgroundColor = new SimpleObjectProperty<>(Color.BLACK);
+
 	private final Affine affine = new Affine();
 
 	// TODO this is only necessary while projects without serialized transform exist
@@ -28,14 +32,19 @@ public class Viewer3DConfig
 		return this.areMeshesEnabled;
 	}
 
+	public SimpleObjectProperty<Color> backgroundColorProperty() {
+		return backgroundColor;
+	}
+
 	public void bindViewerToConfig(final Viewer3DFX viewer)
 	{
 		viewer.isMeshesEnabledProperty().bind(this.areMeshesEnabled);
 		final Affine affineCopy = this.affine.clone();
 		final boolean wasAffineSet = this.wasAffineSet;
 		viewer.addAffineListener(this::setAffine);
+		viewer.backgroundFillProperty().bindBidirectional(this.backgroundColor);
 		if (wasAffineSet) {
-			LOG.debug("Setting viewer affine to {} ({})", affineCopy, wasAffineSet);
+			LOG.debug("Setting viewer affine to {}", affineCopy);
 			viewer.setAffine(affineCopy);
 		}
 	}
@@ -47,6 +56,7 @@ public class Viewer3DConfig
 	public void set(final Viewer3DConfig that)
 	{
 		this.areMeshesEnabled.set(that.areMeshesEnabled.get());
+		this.backgroundColor.set(that.backgroundColor.get());
 		if (that.wasAffineSet)
 			setAffine(that.affine);
 	}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/Viewer3DConfig.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/Viewer3DConfig.java
@@ -2,14 +2,28 @@ package org.janelia.saalfeldlab.paintera.config;
 
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
+import javafx.scene.transform.Affine;
 import org.janelia.saalfeldlab.paintera.viewer3d.Viewer3DFX;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
 
 public class Viewer3DConfig
 {
 
+	// TODO the Viewer3DFX and handler should probably hold an instance of this
+
+	private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
 	private final SimpleBooleanProperty areMeshesEnabled = new SimpleBooleanProperty(true);
 
-	public BooleanProperty areMeshesenabledProperty()
+	private final Affine affine = new Affine();
+
+	// TODO this is only necessary while projects without serialized transform exist
+	private boolean wasAffineSet = false;
+
+	public BooleanProperty areMeshesEnabledProperty()
 	{
 		return this.areMeshesEnabled;
 	}
@@ -17,11 +31,34 @@ public class Viewer3DConfig
 	public void bindViewerToConfig(final Viewer3DFX viewer)
 	{
 		viewer.isMeshesEnabledProperty().bind(this.areMeshesEnabled);
+		final Affine affineCopy = this.affine.clone();
+		final boolean wasAffineSet = this.wasAffineSet;
+		viewer.addAffineListener(this::setAffine);
+		if (wasAffineSet) {
+			LOG.debug("Setting viewer affine to {} ({})", affineCopy, wasAffineSet);
+			viewer.setAffine(affineCopy);
+		}
+	}
+
+	public boolean isWasAffineSet() {
+		return wasAffineSet;
 	}
 
 	public void set(final Viewer3DConfig that)
 	{
 		this.areMeshesEnabled.set(that.areMeshesEnabled.get());
+		if (that.wasAffineSet)
+			setAffine(that.affine);
+	}
+
+	public void setAffine(final Affine affine) {
+		LOG.debug("Set affine {} to {}", this.affine, affine);
+		this.affine.setToTransform(affine);
+		this.wasAffineSet = true;
+	}
+
+	public Affine getAffineCopy() {
+		return this.affine.clone();
 	}
 
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/Viewer3DConfigNode.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/Viewer3DConfigNode.java
@@ -1,26 +1,49 @@
 package org.janelia.saalfeldlab.paintera.config;
 
+import javafx.geometry.Insets;
 import javafx.scene.Node;
 import javafx.scene.control.CheckBox;
+import javafx.scene.control.ColorPicker;
+import javafx.scene.control.Label;
 import javafx.scene.control.TitledPane;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.Priority;
+import javafx.scene.paint.Color;
+import org.janelia.saalfeldlab.fx.Labels;
 
 public class Viewer3DConfigNode
 {
 
+	private static final double PREF_CELL_WIDTH = 50.0;
+
 	private final TitledPane contents = new TitledPane("3D Viewer", null);
 
 	private final CheckBox areMeshesEnabledCheckBox = new CheckBox();
+
+	private final ColorPicker backgroundColorPicker = new ColorPicker(Color.BLACK);
 
 	public Viewer3DConfigNode()
 	{
 		contents.setGraphic(areMeshesEnabledCheckBox);
 		contents.setExpanded(false);
 		contents.collapsibleProperty().bind(areMeshesEnabledCheckBox.selectedProperty());
+		final GridPane settingsGrid = new GridPane();
+		final Label backgroundColorLabel = Labels.withTooltip("Background", "Set background color of 3D viewer.");
+		settingsGrid.add(backgroundColorLabel, 0, 0);
+		settingsGrid.add(backgroundColorPicker, 1, 0);
+
+		settingsGrid.setPadding(Insets.EMPTY);
+		GridPane.setHgrow(backgroundColorLabel, Priority.ALWAYS);
+		backgroundColorPicker.setPrefWidth(PREF_CELL_WIDTH);
+
+		contents.setPadding(Insets.EMPTY);
+		contents.setContent(settingsGrid);
 	}
 
 	public void bind(final Viewer3DConfig config)
 	{
 		areMeshesEnabledCheckBox.selectedProperty().bindBidirectional(config.areMeshesEnabledProperty());
+		backgroundColorPicker.valueProperty().bindBidirectional(config.backgroundColorProperty());
 	}
 
 	public Node getContents()

--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/Viewer3DConfigNode.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/Viewer3DConfigNode.java
@@ -20,7 +20,7 @@ public class Viewer3DConfigNode
 
 	public void bind(final Viewer3DConfig config)
 	{
-		areMeshesEnabledCheckBox.selectedProperty().bindBidirectional(config.areMeshesenabledProperty());
+		areMeshesEnabledCheckBox.selectedProperty().bindBidirectional(config.areMeshesEnabledProperty());
 	}
 
 	public Node getContents()

--- a/src/main/java/org/janelia/saalfeldlab/paintera/serialization/Viewer3DConfigSerializer.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/serialization/Viewer3DConfigSerializer.java
@@ -5,8 +5,10 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializationContext;
+import javafx.scene.paint.Color;
 import javafx.scene.transform.Affine;
 import org.janelia.saalfeldlab.paintera.config.Viewer3DConfig;
+import org.janelia.saalfeldlab.util.Colors;
 import org.scijava.plugin.Plugin;
 
 import java.lang.reflect.Type;
@@ -17,6 +19,8 @@ public class Viewer3DConfigSerializer implements PainteraSerialization.PainteraA
 	private static final String AFFINE_KEY = "affine";
 
 	private static final String ARE_MESHES_ENABLED_KEY = "meshesEnabled";
+
+	private static final String BACKGROUND_KEY = "background";
 
 	@Override
 	public Viewer3DConfig deserialize(
@@ -29,6 +33,8 @@ public class Viewer3DConfigSerializer implements PainteraSerialization.PainteraA
 			config.setAffine(context.deserialize(map.get(AFFINE_KEY), Affine.class));
 		if (map.has(ARE_MESHES_ENABLED_KEY))
 			config.areMeshesEnabledProperty().set(map.get(ARE_MESHES_ENABLED_KEY).getAsBoolean());
+		if (map.has(BACKGROUND_KEY))
+			config.backgroundColorProperty().set(Color.web(map.get(BACKGROUND_KEY).getAsString()));
 		return config;
 	}
 
@@ -41,6 +47,7 @@ public class Viewer3DConfigSerializer implements PainteraSerialization.PainteraA
 		if (config.isWasAffineSet())
 			map.add(AFFINE_KEY, context.serialize(config.getAffineCopy()));
 		map.addProperty(ARE_MESHES_ENABLED_KEY, config.areMeshesEnabledProperty().get());
+		map.addProperty(BACKGROUND_KEY, Colors.toHTML(config.backgroundColorProperty().get()));
 		return map;
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/serialization/Viewer3DConfigSerializer.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/serialization/Viewer3DConfigSerializer.java
@@ -1,0 +1,56 @@
+package org.janelia.saalfeldlab.paintera.serialization;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import javafx.scene.transform.Affine;
+import org.janelia.saalfeldlab.paintera.config.Viewer3DConfig;
+import org.scijava.plugin.Plugin;
+
+import java.lang.reflect.Type;
+
+@Plugin(type = PainteraSerialization.PainteraAdapter.class)
+public class Viewer3DConfigSerializer implements PainteraSerialization.PainteraAdapter<Viewer3DConfig> {
+
+	private static final String AFFINE_KEY = "affine";
+
+	private static final String ARE_MESHES_ENABLED_KEY = "meshesEnabled";
+
+	@Override
+	public Viewer3DConfig deserialize(
+			final JsonElement json,
+			final Type typeOfT,
+			final JsonDeserializationContext context) throws JsonParseException {
+		final Viewer3DConfig config = new Viewer3DConfig();
+		final JsonObject map = json.getAsJsonObject();
+		if (map.has(AFFINE_KEY))
+			config.setAffine(context.deserialize(map.get(AFFINE_KEY), Affine.class));
+		if (map.has(ARE_MESHES_ENABLED_KEY))
+			config.areMeshesEnabledProperty().set(map.get(ARE_MESHES_ENABLED_KEY).getAsBoolean());
+		return config;
+	}
+
+	@Override
+	public JsonElement serialize(
+			final Viewer3DConfig config,
+			final Type typeOfSrc,
+			final JsonSerializationContext context) {
+		final JsonObject map = new JsonObject();
+		if (config.isWasAffineSet())
+			map.add(AFFINE_KEY, context.serialize(config.getAffineCopy()));
+		map.addProperty(ARE_MESHES_ENABLED_KEY, config.areMeshesEnabledProperty().get());
+		return map;
+	}
+
+	@Override
+	public Class<Viewer3DConfig> getTargetClass() {
+		return Viewer3DConfig.class;
+	}
+
+	@Override
+	public boolean isHierarchyAdapter() {
+		return false;
+	}
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/Viewer3DFX.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/Viewer3DFX.java
@@ -21,6 +21,7 @@ import javafx.scene.transform.Translate;
 import javafx.util.Duration;
 import net.imglib2.Interval;
 import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.ui.TransformListener;
 import net.imglib2.util.SimilarityTransformInterpolator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -147,6 +148,10 @@ public class Viewer3DFX extends Pane
 
 	public void setAffine(final Affine affine) {
 		handler.setAffine(affine);
+	}
+
+	public void addAffineListener(final TransformListener<Affine> listener) {
+		handler.addAffineListener(listener);
 	}
 
 	private static Affine fromAffineTransform3D(final AffineTransform3D affineTransform3D) {

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/Viewer3DFX.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/Viewer3DFX.java
@@ -6,8 +6,10 @@ import javafx.animation.KeyValue;
 import javafx.animation.Timeline;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleDoubleProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.AmbientLight;
 import javafx.scene.Group;
 import javafx.scene.PerspectiveCamera;
@@ -55,6 +57,8 @@ public class Viewer3DFX extends Pane
 
 	private final BooleanProperty isMeshesEnabled = new SimpleBooleanProperty();
 
+	private final ObjectProperty<Color> backgroundFill = new SimpleObjectProperty<>(Color.BLACK);
+
 	public Viewer3DFX(final double width, final double height)
 	{
 		super();
@@ -64,7 +68,7 @@ public class Viewer3DFX extends Pane
 		this.setWidth(width);
 		this.setHeight(height);
 		this.scene = new SubScene(root, width, height, true, SceneAntialiasing.BALANCED);
-		this.scene.setFill(Color.BLACK);
+		this.scene.fillProperty().bind(backgroundFill);
 
 		this.camera = new PerspectiveCamera(true);
 		this.camera.setNearClip(0.01);
@@ -152,6 +156,10 @@ public class Viewer3DFX extends Pane
 
 	public void addAffineListener(final TransformListener<Affine> listener) {
 		handler.addAffineListener(listener);
+	}
+
+	public ObjectProperty<Color> backgroundFillProperty() {
+		return backgroundFill;
 	}
 
 	private static Affine fromAffineTransform3D(final AffineTransform3D affineTransform3D) {


### PR DESCRIPTION
Fixes #244 

Also adds a background color setting for the 3D viewer (in the future this could be extended to using a gradient).

Deserializing configurations and binding UI elements to the config is a little messy, not just for the 3D viewer, because the `Properties` object holds both config and sources. This should be addressed in a separate PR in a larger refactoring effort. It should be fairly easy to maintain backwards compatibility for existing Paintera projects.