### PR TITLE
Fix threading in shape interpolation mode

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/ShapeInterpolationMode.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/ShapeInterpolationMode.java
@@ -207,7 +207,7 @@ public class ShapeInterpolationMode<D extends IntegerType<D>>
 
 		this.doneApplyingMaskListener = (obs, oldv, newv) -> {
 			if (!newv)
-				doneApplyingMask();
+				InvokeOnJavaFXApplicationThread.invoke(this::doneApplyingMask);
 		};
 	}
 


### PR DESCRIPTION
Just a minor fix for this exception that appears after exiting shape interpolation mode:
```
Exception in thread "pool-3-thread-1" java.lang.IllegalStateException: Not on FX application thread; currentThread = pool-3-thread-1
	at com.sun.javafx.tk.Toolkit.checkFxUserThread(Toolkit.java:279)
	at com.sun.javafx.tk.quantum.QuantumToolkit.checkFxUserThread(QuantumToolkit.java:423)
	at javafx.scene.Parent$2.onProposedChange(Parent.java:367)
	at com.sun.javafx.collections.VetoableListDecorator.setAll(VetoableListDecorator.java:113)
	at org.janelia.saalfeldlab.paintera.meshes.MeshManagerWithAssignmentForSegments.removeMeshes(MeshManagerWithAssignmentForSegments.java:245)
	at org.janelia.saalfeldlab.paintera.meshes.MeshManagerWithAssignmentForSegments.update(MeshManagerWithAssignmentForSegments.java:159)
	at org.janelia.saalfeldlab.paintera.meshes.MeshManagerWithAssignmentForSegments.lambda$0(MeshManagerWithAssignmentForSegments.java:113)
	at org.janelia.saalfeldlab.fx.ObservableWithListenersList.stateChanged(ObservableWithListenersList.java:29)
	at org.janelia.saalfeldlab.paintera.control.selection.SelectedSegments.update(SelectedSegments.java:65)
	at org.janelia.saalfeldlab.paintera.control.selection.SelectedSegments.lambda$0(SelectedSegments.java:35)
	at org.janelia.saalfeldlab.fx.ObservableWithListenersList.stateChanged(ObservableWithListenersList.java:29)
	at org.janelia.saalfeldlab.paintera.control.selection.SelectedIds.deactivateAll(SelectedIds.java:65)
	at org.janelia.saalfeldlab.paintera.control.selection.SelectedIds.deactivateAll(SelectedIds.java:57)
	at org.janelia.saalfeldlab.paintera.state.LabelSourceState.refreshMeshes(LabelSourceState.java:248)
	at org.janelia.saalfeldlab.paintera.control.ShapeInterpolationMode.doneApplyingMask(ShapeInterpolationMode.java:555)
	at org.janelia.saalfeldlab.paintera.control.ShapeInterpolationMode.lambda$1(ShapeInterpolationMode.java:210)
	at com.sun.javafx.binding.ExpressionHelper$Generic.fireValueChangedEvent(ExpressionHelper.java:361)
	at com.sun.javafx.binding.ExpressionHelper.fireValueChangedEvent(ExpressionHelper.java:81)
	at javafx.beans.property.BooleanPropertyBase.fireValueChangedEvent(BooleanPropertyBase.java:103)
	at javafx.beans.property.BooleanPropertyBase.markInvalid(BooleanPropertyBase.java:110)
	at javafx.beans.property.BooleanPropertyBase.set(BooleanPropertyBase.java:144)
	at org.janelia.saalfeldlab.paintera.data.mask.MaskedSource.lambda$7(MaskedSource.java:464)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```