### PR TITLE
Specify dist: trusty to move back to Trusty images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk: oraclejdk8
+dist: trusty
 branches:
   only:
   - master


### PR DESCRIPTION
See also: https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038/8