### PR TITLE
Fix deadlock at startup

### DIFF
--- a/src/main/java/bdv/fx/viewer/ViewerPanelFX.java
+++ b/src/main/java/bdv/fx/viewer/ViewerPanelFX.java
@@ -186,10 +186,6 @@ public class ViewerPanelFX
 		this.renderingExecutorService = Executors.newFixedThreadPool(optional.values.getNumRenderingThreads(), new RenderThreadFactory());
 		options = optional.values;
 
-		this.state = new ViewerState(axisOrder);
-
-		state.numTimepoints.set(numTimepoints);
-
 		threadGroup = new ThreadGroup(this.toString());
 		viewerTransform = new AffineTransform3D();
 
@@ -214,11 +210,14 @@ public class ViewerPanelFX
 		this.heightProperty().addListener((obs, oldv, newv) -> this.renderUnit.setDimensions((long)getWidth(), (long)getHeight()));
 		setWidth(options.getWidth());
 		setHeight(options.getHeight());
-		setAllSources(sources);
+
 		// TODO why is this necessary?
 		transformListeners.add(tf -> getDisplay().drawOverlays());
 
+		this.state = new ViewerState(axisOrder, numTimepoints);
 		state.addListener(obs -> requestRepaint());
+
+		setAllSources(sources);
 	}
 
 	/**
@@ -349,13 +348,9 @@ public class ViewerPanelFX
 	public synchronized void transformChanged(final AffineTransform3D transform)
 	{
 		viewerTransform.set(transform);
-		synchronized (state)
-		{
-		    state.setViewerTransform(transform);
-		}
+		state.setViewerTransform(transform);
 		for (final TransformListener<AffineTransform3D> l : transformListeners)
 			l.transformChanged(viewerTransform);
-		requestRepaint();
 	}
 
 	/**

--- a/src/main/java/bdv/fx/viewer/ViewerState.java
+++ b/src/main/java/bdv/fx/viewer/ViewerState.java
@@ -33,10 +33,6 @@ public class ViewerState
 
 	private final Function<Source<?>, AxisOrder> axisOrder;
 
-	protected final ObservableMap<Source<?>, SourceAndConverter<?>> sources = asMap(
-			sourcesAndConverters,
-			SourceAndConverter::getSpimSource
-	                                                                               );
 
 	protected synchronized void setViewerTransform(final AffineTransform3D to)
 	{
@@ -91,28 +87,6 @@ public class ViewerState
 		state.numTimepoints.set(numTimepoints.get());
 		state.sourcesAndConverters.setAll(sourcesAndConverters);
 		return state;
-	}
-
-	public static <S, T> ObservableList<T> mapObservableList(final ObservableList<? extends S> source, final
-	Function<S, T> mapping)
-	{
-		final ObservableList<T> target = FXCollections.observableArrayList();
-		source.addListener((ListChangeListener<? super S>) change -> target.setAll(source.stream().map(mapping)
-				.collect(
-				Collectors.toList())));
-		return target;
-	}
-
-	public static <S, T> ObservableMap<T, S> asMap(final ObservableList<? extends S> source, final Function<S, T>
-			generateKeyFromValue)
-	{
-		final ObservableMap<T, S> target = FXCollections.observableHashMap();
-		source.addListener((ListChangeListener<? super S>) change -> {
-			final Map<T, S> tmp = new HashMap<>();
-			source.forEach(s -> tmp.put(generateKeyFromValue.apply(s), s));
-			target.putAll(tmp);
-		});
-		return target;
 	}
 
 	public AxisOrder axisOrder(final Source<?> source)

--- a/src/main/java/bdv/fx/viewer/ViewerState.java
+++ b/src/main/java/bdv/fx/viewer/ViewerState.java
@@ -32,6 +32,10 @@ public class ViewerState extends ObservableWithListenersList
 
 	private final Function<Source<?>, AxisOrder> axisOrder;
 
+	public ViewerState(final Function<Source<?>, AxisOrder> axisOrder)
+	{
+		this.axisOrder = axisOrder;
+	}
 
 	protected synchronized void setViewerTransform(final AffineTransform3D to)
 	{
@@ -43,9 +47,9 @@ public class ViewerState extends ObservableWithListenersList
 		to.set(this.viewerTransform);
 	}
 
-	public ReadOnlyIntegerProperty timepointProperty()
+	public synchronized int getTimepoint()
 	{
-		return this.timepoint;
+		return this.timepoint.get();
 	}
 
 	public synchronized List<SourceAndConverter<?>> getSources()
@@ -83,11 +87,6 @@ public class ViewerState extends ObservableWithListenersList
 		return getBestMipMapLevel(screenScaleTransform, sourcesAndConverters.get(sourceIndex).getSpimSource());
 	}
 
-	public ViewerState(final Function<Source<?>, AxisOrder> axisOrder)
-	{
-		this.axisOrder = axisOrder;
-	}
-
 	public synchronized ViewerState copy()
 	{
 		final ViewerState state = new ViewerState(this.axisOrder);
@@ -98,7 +97,7 @@ public class ViewerState extends ObservableWithListenersList
 		return state;
 	}
 
-	public AxisOrder axisOrder(final Source<?> source)
+	public synchronized AxisOrder axisOrder(final Source<?> source)
 	{
 		return this.axisOrder.apply(source);
 	}

--- a/src/main/java/bdv/fx/viewer/multibox/MultiBoxOverlayRendererFX.java
+++ b/src/main/java/bdv/fx/viewer/multibox/MultiBoxOverlayRendererFX.java
@@ -153,7 +153,7 @@ public class MultiBoxOverlayRendererFX implements OverlayRendererGeneric<Graphic
 	{
 		synchronized (viewerState)
 		{
-			final int timepoint = viewerState.timepointProperty().get();
+			final int timepoint = viewerState.getTimepoint();
 
 			final int numSources        = this.allSources.size();
 			final int numPresentSources = (int) IntStream.range(

--- a/src/main/java/bdv/fx/viewer/render/RenderUnit.java
+++ b/src/main/java/bdv/fx/viewer/render/RenderUnit.java
@@ -236,7 +236,7 @@ public class RenderUnit implements PainterThread.Paintable {
 				synchronized (viewerState)
 				{
 					viewerState.getViewerTransform(viewerTransform);
-					timepoint = viewerState.timepointProperty().get();
+					timepoint = viewerState.getTimepoint();
 					sacs.addAll(viewerState.getSources());
 				}
 			}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/ShapeInterpolationMode.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/ShapeInterpolationMode.java
@@ -378,7 +378,7 @@ public class ShapeInterpolationMode<D extends IntegerType<D>>
 
 	private void createMask() throws MaskInUse
 	{
-		final int time = activeViewer.getState().timepointProperty().get();
+		final int time = activeViewer.getState().getTimepoint();
 		final int level = MASK_SCALE_LEVEL;
 		final MaskInfo<UnsignedLongType> maskInfo = new MaskInfo<>(time, level, new UnsignedLongType(newLabelId));
 		mask = source.generateMask(maskInfo, FOREGROUND_CHECK);
@@ -935,7 +935,7 @@ public class ShapeInterpolationMode<D extends IntegerType<D>>
 	private D getDataValue(final double x, final double y)
 	{
 		final RealPoint sourcePos = getSourceCoordinates(x, y);
-		final int time = activeViewer.getState().timepointProperty().get();
+		final int time = activeViewer.getState().getTimepoint();
 		final int level = MASK_SCALE_LEVEL;
 		final RandomAccessibleInterval<D> data = source.getDataSource(time, level);
 		final RandomAccess<D> dataAccess = data.randomAccess();
@@ -947,7 +947,7 @@ public class ShapeInterpolationMode<D extends IntegerType<D>>
 	private AffineTransform3D getMaskTransform()
 	{
 		final AffineTransform3D maskTransform = new AffineTransform3D();
-		final int time = activeViewer.getState().timepointProperty().get();
+		final int time = activeViewer.getState().getTimepoint();
 		final int level = MASK_SCALE_LEVEL;
 		source.getSourceTransform(time, level, maskTransform);
 		return maskTransform;
@@ -979,7 +979,7 @@ public class ShapeInterpolationMode<D extends IntegerType<D>>
 		if (targetLevel != maskLevel)
 		{
 			// scale with respect to the given mipmap level
-			final int time = activeViewer.getState().timepointProperty().get();
+			final int time = activeViewer.getState().getTimepoint();
 			final Scale3D relativeScaleTransform = new Scale3D(DataSource.getRelativeScales(source, time, maskLevel, targetLevel));
 			maskMipmapDisplayTransform.preConcatenate(relativeScaleTransform.inverse());
 		}
@@ -1000,7 +1000,7 @@ public class ShapeInterpolationMode<D extends IntegerType<D>>
 		Arrays.setAll(viewerScale, d -> Affine3DHelpers.extractScale(viewerTransform, d));
 		final Scale3D scalingTransform = new Scale3D(viewerScale);
 		// neutralize mask scaling if there is any
-		final int time = activeViewer.getState().timepointProperty().get();
+		final int time = activeViewer.getState().getTimepoint();
 		final int level = MASK_SCALE_LEVEL;
 		scalingTransform.concatenate(new Scale3D(DataSource.getScale(source, time, level)));
 		// build the resulting transform

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFill.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFill.java
@@ -162,7 +162,7 @@ public class FloodFill
 
 		final int               level          = 0;
 		final AffineTransform3D labelTransform = new AffineTransform3D();
-		final int               time           = viewerState.timepointProperty().get();
+		final int               time           = viewerState.getTimepoint();
 		source.getSourceTransform(time, level, labelTransform);
 
 		final RealPoint rp = setCoordinates(x, y, viewer, labelTransform);

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFill2D.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/FloodFill2D.java
@@ -162,7 +162,7 @@ public class FloodFill2D
 		}
 
 		final int level = 0;
-		final int time = viewerState.timepointProperty().get();
+		final int time = viewerState.getTimepoint();
 		final MaskInfo<UnsignedLongType> maskInfo = new MaskInfo<>(time, level, new UnsignedLongType(fill));
 
 		final Scene  scene          = viewer.getScene();

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/RestrictPainting.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/RestrictPainting.java
@@ -137,7 +137,7 @@ public class RestrictPainting
 		synchronized (viewerState)
 		{
 			level = viewerState.getBestMipMapLevel(screenScaleTransform, sourceInfo.currentSourceIndexInVisibleSources().get());
-			time = viewerState.timepointProperty().get();
+			time = viewerState.getTimepoint();
 		}
 		final AffineTransform3D labelTransform = new AffineTransform3D();
 		source.getSourceTransform(time, level, labelTransform);


### PR DESCRIPTION
Closes #239 
The cause for the deadlock was that the list of sources in `ViewerState` was modified under the lock, and since it was an `ObservableList`, it immediately notified the listeners about the change while still holding the lock.

I've changed it to a regular list and `ViewerState` to implement `Observable` instead. It will fire the invalidated event after releasing the lock which eliminates the risk of running into a deadlock.
For consistency it will also fire when the viewer transform or the timepoint changes. I also slightly changed types and visibility of the class members in `ViewerState` to make it more straightforward.