### PR TITLE
Intersecting source state dialog

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/serialization/sourcestate/IntersectingSourceStateDeserializer.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/serialization/sourcestate/IntersectingSourceStateDeserializer.java
@@ -1,11 +1,5 @@
 package org.janelia.saalfeldlab.paintera.serialization.sourcestate;
 
-import java.lang.invoke.MethodHandles;
-import java.lang.reflect.Type;
-import java.util.concurrent.ExecutorService;
-import java.util.function.IntFunction;
-import java.util.function.Supplier;
-
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
@@ -25,6 +19,12 @@ import org.janelia.saalfeldlab.paintera.state.ThresholdingSourceState;
 import org.scijava.plugin.Plugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Type;
+import java.util.concurrent.ExecutorService;
+import java.util.function.IntFunction;
+import java.util.function.Supplier;
 
 public class IntersectingSourceStateDeserializer implements JsonDeserializer<IntersectingSourceState>
 {
@@ -126,11 +126,9 @@ public class IntersectingSourceStateDeserializer implements JsonDeserializer<Int
 
 		try
 		{
-			final Class<? extends Composite<ARGBType, ARGBType>> compositeType = (Class<Composite<ARGBType,
-					ARGBType>>) Class.forName(
-					map.get(COMPOSITE_TYPE_KEY).getAsString());
-			final Composite<ARGBType, ARGBType>                  composite     = context.deserialize(map.get(
-					COMPOSITE_KEY), compositeType);
+			final Class<? extends Composite<ARGBType, ARGBType>> compositeType =
+					(Class<Composite<ARGBType, ARGBType>>) Class.forName(map.get(COMPOSITE_TYPE_KEY).getAsString());
+			final Composite<ARGBType, ARGBType> composite = context.deserialize(map.get(COMPOSITE_KEY), compositeType);
 
 			final String name = map.get(NAME_KEY).getAsString();
 
@@ -139,8 +137,7 @@ public class IntersectingSourceStateDeserializer implements JsonDeserializer<Int
 					"Creating {} with thresholded={} labels={}",
 					IntersectingSourceState.class.getSimpleName(),
 					thresholdedState,
-					labelState
-			         );
+					labelState);
 			final IntersectingSourceState state = new IntersectingSourceState(
 					(ThresholdingSourceState) thresholdedState,
 					(LabelSourceState) labelState,
@@ -150,8 +147,7 @@ public class IntersectingSourceStateDeserializer implements JsonDeserializer<Int
 					priority,
 					meshesGroup,
 					manager,
-					workers
-			);
+					workers);
 
 			return state;
 		} catch (final ClassNotFoundException | InvalidAccessException e)

--- a/src/main/java/org/janelia/saalfeldlab/paintera/ui/opendialog/menu/intersecting/IntersectingSourceStateOpener.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/ui/opendialog/menu/intersecting/IntersectingSourceStateOpener.java
@@ -1,0 +1,186 @@
+package org.janelia.saalfeldlab.paintera.ui.opendialog.menu.intersecting;
+
+import bdv.viewer.Source;
+import javafx.beans.binding.BooleanBinding;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.collections.FXCollections;
+import javafx.geometry.Pos;
+import javafx.scene.control.Alert;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.ListCell;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import org.janelia.saalfeldlab.fx.Labels;
+import org.janelia.saalfeldlab.fx.ui.Exceptions;
+import org.janelia.saalfeldlab.paintera.PainteraBaseView;
+import org.janelia.saalfeldlab.paintera.cache.global.InvalidAccessException;
+import org.janelia.saalfeldlab.paintera.composition.ARGBCompositeAlphaAdd;
+import org.janelia.saalfeldlab.paintera.state.IntersectingSourceState;
+import org.janelia.saalfeldlab.paintera.state.LabelSourceState;
+import org.janelia.saalfeldlab.paintera.state.SourceInfo;
+import org.janelia.saalfeldlab.paintera.state.SourceState;
+import org.janelia.saalfeldlab.paintera.state.ThresholdingSourceState;
+import org.janelia.saalfeldlab.paintera.ui.PainteraAlerts;
+import org.janelia.saalfeldlab.paintera.ui.opendialog.menu.OpenDialogMenuEntry;
+import org.scijava.plugin.Plugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+
+public class IntersectingSourceStateOpener {
+
+	private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+	private static class Action implements BiConsumer<PainteraBaseView, String>  {
+
+		@Override
+		public void accept(PainteraBaseView viewer, String projectDirectory) {
+			final ObjectProperty<LabelSourceState<?, ?>> labelSourceState = new SimpleObjectProperty<>();
+			final ObjectProperty<ThresholdingSourceState<?, ?>> thresholdingState = new SimpleObjectProperty<>();
+			final BooleanBinding isValidSelection = labelSourceState.isNotNull().and(thresholdingState.isNotNull());
+			final Alert dialog = makeDialog(viewer, labelSourceState, thresholdingState);
+			final Optional<ButtonType> returnType = dialog.showAndWait();
+			if (
+					Alert.AlertType.CONFIRMATION.equals(dialog.getAlertType())
+							&& ButtonType.OK.equals(returnType.orElse(ButtonType.CANCEL))
+							&& isValidSelection.get()) {
+				try {
+					final IntersectingSourceState intersectingState = new IntersectingSourceState(
+							thresholdingState.get(),
+							(LabelSourceState) labelSourceState.get(),
+							new ARGBCompositeAlphaAdd(),
+							"blub",
+							viewer.getGlobalCache(),
+							0,
+							viewer.viewer3D().meshesGroup(),
+							viewer.getMeshManagerExecutorService(),
+							viewer.getMeshWorkerExecutorService());
+					viewer.addState(intersectingState);
+				} catch (final InvalidAccessException e) {
+					LOG.error("Unable to create intersecting state", e);
+					Exceptions.exceptionAlert("Unable to create intersecting state", e);
+				}
+			}
+		}
+	}
+
+	@Plugin(type = OpenDialogMenuEntry.class, menuPath = "_Derived>_Intersecting")
+	public static class MenuEntry implements OpenDialogMenuEntry {
+
+		@Override
+		public BiConsumer<PainteraBaseView, String> onAction() {
+			return new Action();
+		}
+	}
+
+	private static Alert makeDialog(
+			final PainteraBaseView viewer,
+			final ObjectProperty<LabelSourceState<?, ?>> labelSourceState,
+			final ObjectProperty<ThresholdingSourceState<?, ?>> thresholdingState) {
+		final SourceInfo sourceInfo = viewer.sourceInfo();
+		final List<Source<?>> sources = new ArrayList<>(sourceInfo.trackSources());
+		final List<SourceState<?, ?>> states = sources.stream().map(sourceInfo::getState).collect(Collectors.toList());
+		final List<LabelSourceState<?, ?>> labelSourceStates = states
+				.stream()
+				.filter(s -> s instanceof LabelSourceState<?, ?>)
+				.map(s -> (LabelSourceState<?, ?>) s)
+				.collect(Collectors.toList());
+
+		final List<ThresholdingSourceState<?, ?>> thresholdingStates = states
+				.stream()
+				.filter(s -> s instanceof ThresholdingSourceState<?, ?>)
+				.map(s -> (ThresholdingSourceState<?, ?>) s)
+				.collect(Collectors.toList());
+
+		if (labelSourceStates.isEmpty()) {
+			final Alert dialog = PainteraAlerts.alert(Alert.AlertType.ERROR, true);
+			dialog.setContentText("No label data loaded yet, cannot create intersecting state.");
+			return dialog;
+		}
+
+
+
+		if (thresholdingStates.isEmpty()) {
+			final Alert dialog = PainteraAlerts.alert(Alert.AlertType.ERROR, true);
+			dialog.setContentText("No thresholded data available, cannot create intersecting state. Use the `ctrl-T` key combination to create a thresholded dataset from a currently active raw dataset.");
+			return dialog;
+		}
+
+		final Alert dialog = PainteraAlerts.alert(Alert.AlertType.CONFIRMATION, true);
+		dialog.setHeaderText("Choose label and raw source states for thresholded intersection and combined rendering.");
+
+		final Map<SourceState<?, ?>, Integer> sourceIndices = sources
+				.stream()
+				.collect(Collectors.toMap(sourceInfo::getState, sourceInfo::indexOf));
+
+		final ComboBox<LabelSourceState<?, ?>> labelSelection = new ComboBox<>(FXCollections.observableArrayList(labelSourceStates));
+		final ComboBox<ThresholdingSourceState<?, ?>> thresholdedSelection = new ComboBox<>(FXCollections.observableArrayList(thresholdingStates));
+
+		labelSourceState.bind(labelSelection.valueProperty());
+		thresholdingState.bind(thresholdedSelection.valueProperty());
+		dialog.getDialogPane().lookupButton(ButtonType.OK).disableProperty().bind(labelSelection.valueProperty().isNull().or(thresholdedSelection.valueProperty().isNull()));
+
+		labelSelection.setCellFactory(param -> new ListCell<LabelSourceState<?, ?>>() {
+			@Override
+			protected void updateItem(LabelSourceState<?, ?> item, boolean empty) {
+				super.updateItem(item, empty);
+				if (item == null || empty) {
+					setGraphic(null);
+				} else {
+					final Label id = new Label(Integer.toString(sourceIndices.get(item)));
+					final Label name = new Label(item.nameProperty().get());
+					id.setPrefWidth(50.0);
+					final HBox graphic = new HBox(id, name);
+					HBox.setHgrow(name, Priority.ALWAYS);
+					graphic.setAlignment(Pos.CENTER);
+					setGraphic(graphic);
+				}
+			}
+		});
+
+		thresholdedSelection.setCellFactory(param -> new ListCell<ThresholdingSourceState<?, ?>>() {
+			@Override
+			protected void updateItem(ThresholdingSourceState<?, ?> item, boolean empty) {
+				super.updateItem(item, empty);
+				if (item == null || empty) {
+					setGraphic(null);
+				} else {
+					final Label id = new Label(Integer.toString(sourceIndices.get(item)));
+					final Label name = new Label(item.nameProperty().get());
+					id.setPrefWidth(50.0);
+					final HBox graphic = new HBox(id, name);
+					HBox.setHgrow(name, Priority.ALWAYS);
+					graphic.setAlignment(Pos.CENTER);
+					setGraphic(graphic);
+				}
+			}
+		});
+
+		labelSelection.setPromptText("Select label dataset");
+		thresholdedSelection.setPromptText("Select thresholded dataset");
+
+		final GridPane grid = new GridPane();
+		grid.add(Labels.withTooltip("Label data", "Select label dataset to be intersected."), 0, 0);
+		grid.add(Labels.withTooltip("Thresholded data", "Select thresholded dataset to be intersected."), 0, 1);
+		grid.add(labelSelection, 1, 0);
+		grid.add(thresholdedSelection, 1, 1);
+		GridPane.setHgrow(labelSelection, Priority.ALWAYS);
+		GridPane.setHgrow(thresholdedSelection, Priority.ALWAYS);
+
+		dialog.getDialogPane().setContent(grid);
+
+		return dialog;
+	}
+
+}


### PR DESCRIPTION
Confirmed with @cpatrickc that this works: Through the opener menu dialog add an intersecting source state from an already existing label source state and thresholded source state.

Fixes #295 