### PR TITLE
Fix "not a label multiset" error

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/data/n5/CommitCanvasN5.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/data/n5/CommitCanvasN5.java
@@ -608,6 +608,7 @@ public class CommitCanvasN5 implements PersistCanvas
 		return t;
 	}
 
+	// TODO: switch to N5LabelMultisets for writing label multiset data
 	private static void writeBlocksLabelMultisetType(
 			final RandomAccessibleInterval<UnsignedLongType> canvas,
 			final long[] blocks,
@@ -644,6 +645,7 @@ public class CommitCanvasN5 implements PersistCanvas
 		}
 	}
 
+	// TODO: switch to N5LabelMultisets for writing label multiset data
 	private static void downsampleAndWriteBlocksLabelMultisetType(
 			final long[] affectedBlocks,
 			final N5Writer n5,

--- a/src/main/java/org/janelia/saalfeldlab/paintera/data/n5/CommitCanvasN5.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/data/n5/CommitCanvasN5.java
@@ -657,6 +657,11 @@ public class CommitCanvasN5 implements PersistCanvas
 			final TLongObjectHashMap<BlockDiff> blockDiffsAt
 			) throws IOException {
 
+		// In older converted data the "isLabelMultiset" attribute may not be present in s1,s2,... datasets.
+		// Make sure the attribute is set to avoid "is not a label multiset" exception.
+		n5.setAttribute(previousDataset.dataset, N5Helpers.IS_LABEL_MULTISET_KEY, true);
+		n5.setAttribute(targetDataset.dataset, N5Helpers.IS_LABEL_MULTISET_KEY, true);
+
 		final RandomAccessibleInterval<LabelMultisetType>  previousData = N5LabelMultisets.openLabelMultiset(n5, previousDataset.dataset);
 
 		for (final long targetBlock : affectedBlocks)

--- a/src/main/java/org/janelia/saalfeldlab/paintera/ui/dialogs/create/CreateDataset.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/ui/dialogs/create/CreateDataset.java
@@ -201,7 +201,7 @@ public class CreateDataset
 
 				if (name == null || name.equals(""))
 					throw new IOException("Name not specified!");
-				N5Data.createEmptyLabeLDataset(
+				N5Data.createEmptyLabelDataset(
 						container,
 						dataset,
 						dimensions.getAs(new long[3]),

--- a/src/main/java/org/janelia/saalfeldlab/util/n5/N5Data.java
+++ b/src/main/java/org/janelia/saalfeldlab/util/n5/N5Data.java
@@ -471,6 +471,7 @@ public class N5Data {
 		return openLabelMultiset(reader, dataset, transform, globalCache, priority);
 	}
 
+	// TODO: switch to N5LabelMultisets for reading label multiset data. Currently it is not possible because of using a global cache.
 	public static ImagesWithInvalidate<LabelMultisetType, VolatileLabelMultisetType> openLabelMultiset(
 			final N5Reader reader,
 			final String dataset,

--- a/src/main/java/org/janelia/saalfeldlab/util/n5/N5Data.java
+++ b/src/main/java/org/janelia/saalfeldlab/util/n5/N5Data.java
@@ -673,7 +673,7 @@ public class N5Data {
 	 * @param maxNumEntries limit number of entries in each {@link LabelMultiset} (set to less than or equal to zero for unbounded)
 	 * @throws IOException if any n5 operation throws {@link IOException}
 	 */
-	public static void createEmptyLabeLDataset(
+	public static void createEmptyLabelDataset(
 			final String container,
 			final String group,
 			final long[] dimensions,
@@ -683,7 +683,7 @@ public class N5Data {
 			final double[][] relativeScaleFactors,
 			final int[] maxNumEntries) throws IOException
 	{
-		createEmptyLabeLDataset(container, group, dimensions, blockSize, resolution, offset,relativeScaleFactors, maxNumEntries, false);
+		createEmptyLabelDataset(container, group, dimensions, blockSize, resolution, offset,relativeScaleFactors, maxNumEntries, false);
 	}
 
 	/**
@@ -701,7 +701,7 @@ public class N5Data {
 	 * @throws IOException if any n5 operation throws {@link IOException} or {@code group}
 	 * already exists and {@code ignorExisting} is {@code false}
 	 */
-	public static void createEmptyLabeLDataset(
+	public static void createEmptyLabelDataset(
 			final String container,
 			final String group,
 			final long[] dimensions,
@@ -765,11 +765,12 @@ public class N5Data {
 			n5.createDataset(dataset, scaledDimensions, blockSize, DataType.UINT8, new GzipCompression());
 			n5.createDataset(uniqeLabelsDataset, scaledDimensions, blockSize, DataType.UINT64, new GzipCompression());
 
-			// {"maxNumEntries":-1,"compression":{"type":"gzip","level":-1},"downsamplingFactors":[2.0,2.0,1.0],"blockSize":[64,64,64],"dataType":"uint8","dimensions":[625,625,125]}%
+			// {"maxNumEntries":-1,"compression":{"type":"gzip","level":-1},"downsamplingFactors":[2.0,2.0,1.0],"blockSize":[64,64,64],"dataType":"uint8","dimensions":[625,625,125],
+			// "isLabelMultiset":true}%
 			n5.setAttribute(dataset, N5Helpers.MAX_NUM_ENTRIES_KEY, maxNum);
-			if (scaleLevel == 0)
-				n5.setAttribute(dataset, N5Helpers.IS_LABEL_MULTISET_KEY, true);
-			else
+			n5.setAttribute(dataset, N5Helpers.IS_LABEL_MULTISET_KEY, true);
+
+			if (scaleLevel != 0)
 			{
 				n5.setAttribute(dataset, N5Helpers.DOWNSAMPLING_FACTORS_KEY, accumulatedFactors);
 				n5.setAttribute(uniqeLabelsDataset, N5Helpers.DOWNSAMPLING_FACTORS_KEY, accumulatedFactors);


### PR DESCRIPTION
Closes #297 

It seems that I did a pretty shallow search for usages of label multisets when doing #281, so the only affected place is persisting the canvas, which will now ensure that the attribute "isLabelMultiset" is set for downscaled datasets.

The code still uses the old way of reading label multiset data when opening the project, and it's using a global cache for that, which is not currently exposed via `N5LabelMultisets`. Changing the attributes would also be quite hacky there because we need an `N5Writer` for that, and the rest of the opener code assumes `N5Reader`. I added a TODO there and suggest to keep it for now as it is.