### PR TITLE
Exclude all special value labels when committing canvas

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/data/n5/BackgroundCanvasIterable.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/data/n5/BackgroundCanvasIterable.java
@@ -1,13 +1,13 @@
 package org.janelia.saalfeldlab.paintera.data.n5;
 
-import java.util.Iterator;
-
 import net.imglib2.converter.Converter;
 import net.imglib2.type.label.FromIntegerTypeConverter;
-import net.imglib2.type.label.Label;
 import net.imglib2.type.label.LabelMultisetType;
 import net.imglib2.type.numeric.integer.UnsignedLongType;
 import net.imglib2.util.Pair;
+import org.janelia.saalfeldlab.labels.Label;
+
+import java.util.Iterator;
 
 /**
  * @author Philipp Hanslovsky
@@ -49,12 +49,11 @@ public class BackgroundCanvasIterable implements Iterable<LabelMultisetType> {
 			public LabelMultisetType next() {
 				final Pair<LabelMultisetType, UnsignedLongType> p = iterator.next();
 				final UnsignedLongType b = p.getB();
-				if (b.getIntegerLong() == Label.INVALID) {
-					return p.getA();
-				} else {
+				if (Label.regular(b.getIntegerLong())) {
 					conv.convert(b, type);
 					return type;
-				}
+				} else
+					return p.getA();
 			}
 		};
 	}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/data/n5/CommitCanvasN5.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/data/n5/CommitCanvasN5.java
@@ -768,10 +768,10 @@ public class CommitCanvasN5 implements PersistCanvas
 
 	private static <I extends IntegerType<I>, C extends IntegerType<C>> void pickFirstIfSecondIsInvalid(final I s1, final C s2, final I t) {
 		final long val = s2.getIntegerLong();
-		if (val == Label.INVALID)
-			t.set(s1);
-		else
+		if (Label.regular(val))
 			t.setInteger(val);
+		else
+			t.set(s1);
 	}
 
 }

--- a/src/test/java/org/janelia/saalfeldlab/paintera/data/n5/BackgroundCanvasIterableTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/paintera/data/n5/BackgroundCanvasIterableTest.java
@@ -60,11 +60,9 @@ public class BackgroundCanvasIterableTest {
 
 
 		final LabelMultisetType v3 = iterator.next();
-		Assert.assertNotSame(background[3], v3);
-		Assert.assertEquals(v0.entrySet().size(), 1);
-		Assert.assertEquals(1, v3.entrySet().iterator().next().getCount());
-		Assert.assertEquals(Label.TRANSPARENT, v3.entrySet().iterator().next().getElement().id());
-		Assert.assertEquals(Label.TRANSPARENT, v3.argMax());
+		// Transparent should remove only in canvas and not be propagated into background
+		// As discussed in saalfeldlab/paintera#305
+		Assert.assertSame(background[3], v3);
 	}
 
 


### PR DESCRIPTION
Fixes #294

We currently have special values

```
TRANSPARENT = -0x1L // -1L or uint64.MAX_VALUE
INVALID = -0x2L // -2L or uint64.MAX_VALUE - 1
OUTSIDE = -0x3L // -3L or uint64.MAX_VALUE - 2
MAX_ID = -0x4L // -4L or uint64.MAX_VALUE - 3
```

@axtimwalde @igorpisarev do you see any use case where we should actually paint a special value? In that case, this check would be to aggressive.