### PR TITLE
Add SciJava repl

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Usage: Paintera [--add-n5-container=<container>...
 | `B`  | Add bookmark with current global and 3D viewer transforms |
 | `Shift` + `B` | Open dialog to add bookmark with text note |
 | `Ctrl`+`B` | Open dialog to select bookmark |
-| `Ctrl` + `Alt` + `T` | Open scripting REPL |
+| `Shortcut` + `Alt` + `T` | Open scripting REPL |
 
 ### Shape interpolation mode
 

--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ Usage: Paintera [--add-n5-container=<container>...
 | `B`  | Add bookmark with current global and 3D viewer transforms |
 | `Shift` + `B` | Open dialog to add bookmark with text note |
 | `Ctrl`+`B` | Open dialog to select bookmark |
+| `Ctrl` + `Alt` + `T` | Open scripting REPL |
 
 ### Shape interpolation mode
 

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,33 @@
 			<artifactId>commons-io</artifactId>
 		</dependency>
 
+<!--		scripting-->
+		<dependency>
+			<groupId>org.scijava</groupId>
+			<artifactId>scijava-repl-fx</artifactId>
+			<version>0.2.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.scijava</groupId>
+			<artifactId>scripting-beanshell</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.scijava</groupId>
+			<artifactId>scripting-groovy</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.scijava</groupId>
+			<artifactId>scripting-java</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.scijava</groupId>
+			<artifactId>scripting-jython</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.scijava</groupId>
+			<artifactId>scripting-kotlin</artifactId>
+		</dependency>
+
 <!--		markdown rendering-->
 		<dependency>
 			<groupId>com.atlassian.commonmark</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -185,10 +185,6 @@
 			<groupId>org.scijava</groupId>
 			<artifactId>scripting-jython</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.scijava</groupId>
-			<artifactId>scripting-kotlin</artifactId>
-		</dependency>
 
 <!--		markdown rendering-->
 		<dependency>

--- a/src/main/java/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars.java
@@ -79,6 +79,8 @@ public class BorderPaneWithStatusBars
 
 	private final BorderPane pane;
 
+	private final PainteraGateway gateway = new PainteraGateway();
+
 	private final HBox statusBar;
 
 	private final ScrollPane sideBar;
@@ -107,7 +109,7 @@ public class BorderPaneWithStatusBars
 
 	private final BookmarkConfigNode bookmarkConfigNode;
 
-	private final ArbitraryMeshConfigNode arbitraryMeshConfigNode = new ArbitraryMeshConfigNode();
+	private final ArbitraryMeshConfigNode arbitraryMeshConfigNode = new ArbitraryMeshConfigNode(gateway.triangleMeshFormat());
 
 	private final Map<ViewerAndTransforms, Crosshair> crossHairs;
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars2.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars2.kt
@@ -133,7 +133,11 @@ class BorderPaneWithStatusBars2(private val paintera: PainteraMainWindow) {
 			.also { it.acceleratorProperty().bind(namedKeyCombinations["toggle side bar"]!!.primaryCombinationProperty()) }
 	private val sideBarMenu = Menu("_Side Bar", null, toggleSideBarMenuItem)
 
-	private val viewMenu = Menu("_View", null, menuBarMenu, sideBarMenu, statusBarMenu)
+	private val replItem = MenuItem("Show _REPL")
+			.also { it.onAction = EventHandler { paintera.namedActions[PainteraMainWindow.BindingKeys.SHOW_REPL_TABS]!!.action.run() } }
+			.also { it.acceleratorProperty().bind(namedKeyCombinations[PainteraMainWindow.BindingKeys.SHOW_REPL_TABS]!!.primaryCombinationProperty()) }
+
+	private val viewMenu = Menu("_View", null, menuBarMenu, sideBarMenu, statusBarMenu, replItem)
 
 	private val showVersion = MenuItem("Show _Version").also { it.onAction = EventHandler { PainteraAlerts.versionDialog().show() } }
 	private val showReadme = MenuItem("Show _Readme")

--- a/src/main/java/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars2.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars2.kt
@@ -133,11 +133,15 @@ class BorderPaneWithStatusBars2(private val paintera: PainteraMainWindow) {
 			.also { it.acceleratorProperty().bind(namedKeyCombinations["toggle side bar"]!!.primaryCombinationProperty()) }
 	private val sideBarMenu = Menu("_Side Bar", null, toggleSideBarMenuItem)
 
+	private val fullScreenItem = MenuItem("Toggle _Fullscreen")
+			.also { it.onAction = EventHandler { paintera.namedActions[PainteraMainWindow.BindingKeys.TOGGLE_FULL_SCREEN]!!.action.run() } }
+			.also { it.acceleratorProperty().bind(namedKeyCombinations[PainteraMainWindow.BindingKeys.TOGGLE_FULL_SCREEN]!!.primaryCombinationProperty()) }
+
 	private val replItem = MenuItem("Show _REPL")
 			.also { it.onAction = EventHandler { paintera.namedActions[PainteraMainWindow.BindingKeys.SHOW_REPL_TABS]!!.action.run() } }
 			.also { it.acceleratorProperty().bind(namedKeyCombinations[PainteraMainWindow.BindingKeys.SHOW_REPL_TABS]!!.primaryCombinationProperty()) }
 
-	private val viewMenu = Menu("_View", null, menuBarMenu, sideBarMenu, statusBarMenu, replItem)
+	private val viewMenu = Menu("_View", null, menuBarMenu, sideBarMenu, statusBarMenu, fullScreenItem, replItem)
 
 	private val showVersion = MenuItem("Show _Version").also { it.onAction = EventHandler { PainteraAlerts.versionDialog().show() } }
 	private val showReadme = MenuItem("Show _Readme")

--- a/src/main/java/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars2.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars2.kt
@@ -213,7 +213,7 @@ class BorderPaneWithStatusBars2(private val paintera: PainteraMainWindow) {
 			}
 	)
 
-    private val arbitraryMeshConfigNode = ArbitraryMeshConfigNode(properties.arbitraryMeshConfig)
+    private val arbitraryMeshConfigNode = ArbitraryMeshConfigNode(paintera.gateway.triangleMeshFormat, properties.arbitraryMeshConfig)
 
     private val currentFocusHolderWithState: ObservableObjectValue<ViewerAndTransforms?>
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars2.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars2.kt
@@ -29,7 +29,6 @@ import org.janelia.saalfeldlab.paintera.config.*
 import org.janelia.saalfeldlab.paintera.control.navigation.CoordinateDisplayListener
 import org.janelia.saalfeldlab.paintera.ui.Crosshair
 import org.janelia.saalfeldlab.paintera.ui.PainteraAlerts
-import org.janelia.saalfeldlab.paintera.ui.opendialog.menu.OpenDialogMenu
 import org.janelia.saalfeldlab.paintera.ui.source.SourceTabs2
 import org.janelia.saalfeldlab.paintera.viewer3d.OrthoSliceFX
 import org.janelia.saalfeldlab.util.Colors
@@ -61,8 +60,15 @@ class BorderPaneWithStatusBars2(private val paintera: PainteraMainWindow) {
 	private val saveAsItem = MenuItem("Save _As")
 			.also { it.onAction = EventHandler { paintera.namedActions["save as"]!!.action.run() } }
 			.also { it.acceleratorProperty().bind(namedKeyCombinations["save as"]!!.primaryCombinationProperty()) }
-	private val openDataMenu = OpenDialogMenu { LOG.error("Unable to open data", it); Exceptions.exceptionAlert("Unable to open data", it) }
-			.getMenu("_Data", center) { paintera.projectDirectory.actualDirectory.absolutePath }
+	private val openDataMenu = paintera
+			.gateway
+			.openDialogMenu()// { LOG.error("Unable to open data", it); Exceptions.exceptionAlert("Unable to open data", it) }
+			.getMenu(
+					"_Data",
+					center,
+					{ paintera.projectDirectory.actualDirectory.absolutePath },
+					{ LOG.error("Unable to open data", it); Exceptions.exceptionAlert("Unable to open data", it).show() })
+			.get()
 			.also { it.acceleratorProperty().bind(namedKeyCombinations["open data"]!!.primaryCombinationProperty()) }
 	private val openMenu = Menu("_Open", null, openDataMenu)
 	private val quitItem = MenuItem("_Quit")

--- a/src/main/java/org/janelia/saalfeldlab/paintera/Paintera.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/Paintera.java
@@ -38,6 +38,7 @@ import org.janelia.saalfeldlab.paintera.state.SourceState;
 import org.janelia.saalfeldlab.paintera.ui.PainteraAlerts;
 import org.janelia.saalfeldlab.paintera.viewer3d.Viewer3DFX;
 import org.janelia.saalfeldlab.util.n5.N5Helpers;
+import org.scijava.Context;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -253,7 +254,7 @@ public class Paintera extends Application
 				SaveProject.persistProperties(
 						projectDir,
 						properties,
-						GsonHelpers.builderWithAllRequiredSerializers(baseView, () -> projectDir).setPrettyPrinting()
+						GsonHelpers.builderWithAllRequiredSerializers(new Context(), baseView, () -> projectDir).setPrettyPrinting()
 				                             );
 			} catch (final IOException e)
 			{
@@ -320,6 +321,7 @@ public class Paintera extends Application
 								projectDir,
 								properties,
 								GsonHelpers.builderWithAllRequiredSerializers(
+										new Context(),
 										baseView,
 										() -> projectDir).setPrettyPrinting()
 						                             );

--- a/src/main/java/org/janelia/saalfeldlab/paintera/Paintera2.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/Paintera2.kt
@@ -6,7 +6,6 @@ import javafx.scene.Scene
 import javafx.scene.input.MouseEvent
 import javafx.stage.Stage
 import org.janelia.saalfeldlab.paintera.config.ScreenScalesConfig
-import org.janelia.saalfeldlab.paintera.serialization.GsonHelpers
 import org.janelia.saalfeldlab.paintera.ui.PainteraAlerts
 import org.slf4j.LoggerFactory
 import picocli.CommandLine
@@ -68,12 +67,6 @@ class Paintera2 : Application() {
 	}
 
 	companion object {
-
-		private fun gsonBuilder(
-				baseView: PainteraBaseView,
-				projectDirectory: ProjectDirectory) = GsonHelpers
-					.builderWithAllRequiredSerializers(baseView) { projectDirectory.actualDirectory.absolutePath }
-					.setPrettyPrinting()
 
 		private val LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass())
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/PainteraDefaultHandlers.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/PainteraDefaultHandlers.java
@@ -90,6 +90,8 @@ public class PainteraDefaultHandlers
 
 	private final PainteraBaseView baseView;
 
+	private final PainteraGateway gateway = new PainteraGateway();
+
 	@SuppressWarnings("unused")
 	private final KeyTracker keyTracker;
 
@@ -210,6 +212,7 @@ public class PainteraDefaultHandlers
 				baseView.orthogonalViews().bottomLeft().viewer());
 
 		this.openDatasetContextMenuHandler = addOpenDatasetContextMenuHandler(
+				gateway,
 				paneWithStatus.getPane(),
 				baseView,
 				keyTracker,
@@ -560,6 +563,7 @@ public class PainteraDefaultHandlers
 	}
 
 	public static EventHandler<KeyEvent> addOpenDatasetContextMenuHandler(
+			final PainteraGateway gateway,
 			final Node target,
 			final PainteraBaseView baseView,
 			final KeyTracker keyTracker,
@@ -572,6 +576,7 @@ public class PainteraDefaultHandlers
 		assert triggers.length > 0;
 
 		final EventHandler<KeyEvent> handler = OpenDialogMenu.keyPressedHandler(
+				gateway,
 				target,
 				exception -> Exceptions.exceptionAlert(Paintera.NAME, "Unable to show open dataset menu", exception),
 				e -> baseView.allowedActionsProperty().get().isAllowed(MenuActionType.AddSource) && keyTracker.areOnlyTheseKeysDown(triggers),

--- a/src/main/java/org/janelia/saalfeldlab/paintera/PainteraDefaultHandlers2.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/PainteraDefaultHandlers2.kt
@@ -50,10 +50,9 @@ import java.util.function.DoubleSupplier
 import java.util.function.Predicate
 import java.util.function.Supplier
 
-typealias PMW = PainteraMainWindow
-
 class PainteraDefaultHandlers2(
-        private val paintera: PainteraMainWindow, paneWithStatus: BorderPaneWithStatusBars2) {
+        private val paintera: PainteraMainWindow,
+		paneWithStatus: BorderPaneWithStatusBars2) {
 
 	private val baseView = paintera.baseView
 
@@ -161,6 +160,7 @@ class PainteraDefaultHandlers2(
                 baseView.orthogonalViews().bottomLeft().viewer())
 
         this.openDatasetContextMenuHandler = addOpenDatasetContextMenuHandler(
+				paintera.gateway,
                 paneWithStatus.pane,
                 baseView,
                 keyTracker,
@@ -461,6 +461,7 @@ class PainteraDefaultHandlers2(
         }
 
         fun addOpenDatasetContextMenuHandler(
+				gateway: PainteraGateway,
                 target: Node,
                 baseView: PainteraBaseView,
                 keyTracker: KeyTracker,
@@ -472,6 +473,7 @@ class PainteraDefaultHandlers2(
             assert(triggers.isNotEmpty())
 
             val handler = OpenDialogMenu.keyPressedHandler(
+					gateway,
                     target,
                     Consumer { exception -> Exceptions.exceptionAlert(Paintera.NAME, "Unable to show open dataset menu", exception) },
                     Predicate { baseView.allowedActionsProperty().get().isAllowed(MenuActionType.AddSource) && keyTracker.areOnlyTheseKeysDown(*triggers) },

--- a/src/main/java/org/janelia/saalfeldlab/paintera/PainteraDefaultHandlers2.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/PainteraDefaultHandlers2.kt
@@ -327,17 +327,9 @@ class PainteraDefaultHandlers2(
             }
         }
 
-		// full screen
-		paneWithStatus.pane.addEventHandler(KeyEvent.KEY_PRESSED) { ev ->
-			if (DEFAULT_FULL_SCREEN_COMBINATIONS.firstOrNull { it.match(ev) } != null) {
-				ev.consume()
-				properties.windowProperties.isFullScreen.let { it.value = !it.value }
-			}
-		}
-
     }
 
-    fun toggleInterpolation() {
+    private fun toggleInterpolation() {
         if (globalInterpolationProperty.get() != null) {
             globalInterpolationProperty.set(if (globalInterpolationProperty.get() == Interpolation.NLINEAR) Interpolation.NEARESTNEIGHBOR else Interpolation.NLINEAR)
             baseView.orthogonalViews().requestRepaint()
@@ -370,8 +362,6 @@ class PainteraDefaultHandlers2(
         private val LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass())
 
         private val DEFAULT_HANDLER = EventHandler<Event> { LOG.debug("Default event handler: Use if no source is present") }
-
-		private val DEFAULT_FULL_SCREEN_COMBINATIONS = arrayOf(KeyCodeCombination(KeyCode.F11))
 
         fun updateDisplayTransformOnResize(
                 views: OrthogonalViews<*>,

--- a/src/main/java/org/janelia/saalfeldlab/paintera/PainteraGateway.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/PainteraGateway.kt
@@ -6,6 +6,7 @@ import org.scijava.AbstractGateway
 import org.scijava.Context
 import org.scijava.Gateway
 import org.scijava.plugin.Plugin
+import org.scijava.script.ScriptService
 import org.scijava.service.Service
 
 @Plugin(type = Gateway::class)
@@ -26,7 +27,8 @@ class PainteraGateway(context: Context) : AbstractGateway(Paintera.NAME, context
 	companion object {
 		private val DEFAULT_SERVICES = arrayOf<Class<out Service>>(
 				OpenDialogMenu::class.java,
-				TriangleMeshFormatService::class.java
+				TriangleMeshFormatService::class.java,
+				ScriptService::class.java
 		)
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/PainteraGateway.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/PainteraGateway.kt
@@ -1,5 +1,6 @@
 package org.janelia.saalfeldlab.paintera
 
+import org.janelia.saalfeldlab.paintera.meshes.io.TriangleMeshFormatService
 import org.janelia.saalfeldlab.paintera.ui.opendialog.menu.OpenDialogMenu
 import org.scijava.AbstractGateway
 import org.scijava.Context
@@ -14,9 +15,18 @@ class PainteraGateway(context: Context) : AbstractGateway(Paintera.NAME, context
 
 	fun openDialogMenu() = this[OpenDialogMenu::class.java]
 
+	val openDialogMenu: OpenDialogMenu
+		get() = openDialogMenu()
+
+	fun triangleMeshFormat() = this[TriangleMeshFormatService::class.java]
+
+	val triangleMeshFormat: TriangleMeshFormatService
+		get() = triangleMeshFormat()
+
 	companion object {
 		private val DEFAULT_SERVICES = arrayOf<Class<out Service>>(
-				OpenDialogMenu::class.java
+				OpenDialogMenu::class.java,
+				TriangleMeshFormatService::class.java
 		)
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/PainteraGateway.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/PainteraGateway.kt
@@ -1,0 +1,23 @@
+package org.janelia.saalfeldlab.paintera
+
+import org.janelia.saalfeldlab.paintera.ui.opendialog.menu.OpenDialogMenu
+import org.scijava.AbstractGateway
+import org.scijava.Context
+import org.scijava.Gateway
+import org.scijava.plugin.Plugin
+import org.scijava.service.Service
+
+@Plugin(type = Gateway::class)
+class PainteraGateway(context: Context) : AbstractGateway(Paintera.NAME, context) {
+
+	constructor() : this(Context(*DEFAULT_SERVICES))
+
+	fun openDialogMenu() = this[OpenDialogMenu::class.java]
+
+	companion object {
+		private val DEFAULT_SERVICES = arrayOf<Class<out Service>>(
+				OpenDialogMenu::class.java
+		)
+	}
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/PainteraMainWindow.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/PainteraMainWindow.kt
@@ -167,6 +167,7 @@ class PainteraMainWindow(val gateway: PainteraGateway = PainteraGateway()) {
 		val indexToState = mutableMapOf<Int, SourceState<*, *>>()
 		val builder = GsonHelpers
 				.builderWithAllRequiredDeserializers(
+						gateway.context,
 						StatefulSerializer.Arguments(baseView),
 						{ projectDirectory.actualDirectory.absolutePath },
 						{ indexToState[it] })
@@ -181,7 +182,7 @@ class PainteraMainWindow(val gateway: PainteraGateway = PainteraGateway()) {
 
 	fun save() {
 		val builder = GsonHelpers
-				.builderWithAllRequiredSerializers(baseView) { projectDirectory.actualDirectory.absolutePath }
+				.builderWithAllRequiredSerializers(gateway.context, baseView) { projectDirectory.actualDirectory.absolutePath }
 				.setPrettyPrinting()
 		N5FSWriter(projectDirectory.actualDirectory.absolutePath, builder).setAttribute("/", PAINTERA_KEY, this)
 	}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/PainteraMainWindow.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/PainteraMainWindow.kt
@@ -16,6 +16,7 @@ import javafx.scene.image.Image
 import javafx.scene.input.KeyCode
 import javafx.scene.input.KeyCodeCombination
 import javafx.scene.input.KeyCombination
+import javafx.scene.input.KeyEvent
 import javafx.scene.layout.HBox
 import javafx.scene.layout.Priority
 import javafx.scene.layout.VBox
@@ -23,6 +24,7 @@ import javafx.scene.web.WebView
 import javafx.stage.DirectoryChooser
 import javafx.stage.Modality
 import javafx.stage.Stage
+import javafx.stage.Window
 import javafx.util.StringConverter
 import net.imglib2.realtransform.AffineTransform3D
 import org.commonmark.ext.gfm.tables.TablesExtension
@@ -42,16 +44,15 @@ import org.janelia.saalfeldlab.paintera.state.SourceState
 import org.janelia.saalfeldlab.paintera.ui.PainteraAlerts
 import org.janelia.saalfeldlab.paintera.ui.RefreshButton
 import org.janelia.saalfeldlab.paintera.ui.dialogs.create.CreateDatasetHandler
+import org.scijava.Context
 import org.scijava.plugin.Plugin
+import org.scijava.scripting.fx.SciJavaReplFXDialog
 import org.slf4j.LoggerFactory
 import java.io.File
 import java.lang.invoke.MethodHandles
 import java.lang.reflect.Type
 import java.net.URLDecoder
 import java.nio.file.Paths
-import java.util.function.BiConsumer
-
-typealias PropertiesListener = BiConsumer<Properties2?, Properties2?>
 
 class PainteraMainWindow(val gateway: PainteraGateway = PainteraGateway()) {
 
@@ -73,6 +74,7 @@ class PainteraMainWindow(val gateway: PainteraGateway = PainteraGateway()) {
 			NamedAction(BindingKeys.CYCLE_CURRENT_SOURCE_BACKWARD, Runnable { baseView.sourceInfo().decrementCurrentSourceIndex() }),
 			NamedAction(BindingKeys.TOGGLE_CURRENT_SOURCE_VISIBILITY, Runnable { CurrentSourceVisibilityToggle(baseView.sourceInfo().currentState()).toggleIsVisible() }),
 			NamedAction(BindingKeys.CREATE_NEW_LABEL_DATASET, Runnable { CreateDatasetHandler.createAndAddNewLabelDataset(baseView) { projectDirectory.actualDirectory.absolutePath } }),
+			NamedAction(BindingKeys.SHOW_REPL_TABS, Runnable { replDialog.show() }),
 			NamedAction("open help", Runnable {
 				val readmeButton = Buttons.withTooltip("_README", "Open README.md") {
 					// TODO make render when loaded from jar
@@ -130,6 +132,8 @@ class PainteraMainWindow(val gateway: PainteraGateway = PainteraGateway()) {
     val mouseTracker = MouseTracker()
 
     val projectDirectory = ProjectDirectory()
+
+	private val replDialog = ReplDialog(gateway.context, { pane.scene.window }, Pair("paintera", this))
 
     private lateinit var defaultHandlers: PainteraDefaultHandlers2
 
@@ -333,6 +337,7 @@ class PainteraMainWindow(val gateway: PainteraGateway = PainteraGateway()) {
 		const val MAXIMIZE_VIEWER_AND_3D = "toggle maximize viewer and 3D"
 		const val SHOW_OPEN_DATASET_MENU = "show open dataset menu"
 		const val CREATE_NEW_LABEL_DATASET = "create new label dataset"
+		const val SHOW_REPL_TABS = "open repl"
 	}
 
 
@@ -378,12 +383,35 @@ class PainteraMainWindow(val gateway: PainteraGateway = PainteraGateway()) {
 				NamedKeyCombination(BindingKeys.CYCLE_INTERPOLATION_MODES, KeyCodeCombination(KeyCode.I)),
 				NamedKeyCombination(BindingKeys.MAXIMIZE_VIEWER, KeyCodeCombination(KeyCode.M)),
 				NamedKeyCombination(BindingKeys.MAXIMIZE_VIEWER_AND_3D, KeyCodeCombination(KeyCode.M, KeyCombination.SHIFT_DOWN)),
-				NamedKeyCombination(BindingKeys.CREATE_NEW_LABEL_DATASET, KeyCodeCombination(KeyCode.N, KeyCombination.CONTROL_DOWN, KeyCombination.SHIFT_DOWN)))
+				NamedKeyCombination(BindingKeys.CREATE_NEW_LABEL_DATASET, KeyCodeCombination(KeyCode.N, KeyCombination.CONTROL_DOWN, KeyCombination.SHIFT_DOWN)),
+				NamedKeyCombination(BindingKeys.SHOW_REPL_TABS, KeyCodeCombination(KeyCode.T, KeyCombination.SHORTCUT_DOWN, KeyCombination.ALT_DOWN)))
 
 
 		@JvmStatic
 		val namedCombinations
 			get() = NAMED_COMBINATIONS.deepCopy
+
+		private class ReplDialog(
+				private val context: Context,
+				private val window: () -> Window,
+				private vararg val bindings: Pair<String, *>
+		) {
+			private lateinit var dialog: SciJavaReplFXDialog
+
+			fun show() {
+				synchronized(this) {
+					if (!this::dialog.isInitialized)
+						dialog = SciJavaReplFXDialog(context, *bindings).also { it.initOwner(window()) }
+				}
+				dialog.show()
+				dialog.dialogPane.addEventHandler(KeyEvent.KEY_PRESSED) {
+					if (KeyCodeCombination(KeyCode.W, KeyCombination.CONTROL_DOWN).match(it)) {
+						it.consume()
+						dialog.hide()
+					}
+				}
+			}
+		}
 
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/PainteraMainWindow.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/PainteraMainWindow.kt
@@ -75,6 +75,7 @@ class PainteraMainWindow(val gateway: PainteraGateway = PainteraGateway()) {
 			NamedAction(BindingKeys.TOGGLE_CURRENT_SOURCE_VISIBILITY, Runnable { CurrentSourceVisibilityToggle(baseView.sourceInfo().currentState()).toggleIsVisible() }),
 			NamedAction(BindingKeys.CREATE_NEW_LABEL_DATASET, Runnable { CreateDatasetHandler.createAndAddNewLabelDataset(baseView) { projectDirectory.actualDirectory.absolutePath } }),
 			NamedAction(BindingKeys.SHOW_REPL_TABS, Runnable { replDialog.show() }),
+			NamedAction(BindingKeys.TOGGLE_FULL_SCREEN, Runnable { properties.windowProperties.isFullScreen.let { it.value = !it.value } }),
 			NamedAction("open help", Runnable {
 				val readmeButton = Buttons.withTooltip("_README", "Open README.md") {
 					// TODO make render when loaded from jar
@@ -283,7 +284,7 @@ class PainteraMainWindow(val gateway: PainteraGateway = PainteraGateway()) {
 				Image(javaClass.getResourceAsStream("/icon-64.png")),
 				Image(javaClass.getResourceAsStream("/icon-96.png")),
 				Image(javaClass.getResourceAsStream("/icon-128.png")))
-		stage.fullScreenExitKeyCombination = KeyCodeCombination(KeyCode.F11)
+		stage.fullScreenExitKeyProperty().bind(NAMED_COMBINATIONS[BindingKeys.TOGGLE_FULL_SCREEN]!!.primaryCombinationProperty())
 		// to disable message entirely:
 		// stage.fullScreenExitKeyCombination = KeyCombination.NO_MATCH
 		stage.onCloseRequest = EventHandler { if(!askQuit()) it.consume() }
@@ -339,6 +340,7 @@ class PainteraMainWindow(val gateway: PainteraGateway = PainteraGateway()) {
 		const val SHOW_OPEN_DATASET_MENU = "show open dataset menu"
 		const val CREATE_NEW_LABEL_DATASET = "create new label dataset"
 		const val SHOW_REPL_TABS = "open repl"
+		const val TOGGLE_FULL_SCREEN = "toggle full screen"
 	}
 
 
@@ -385,7 +387,8 @@ class PainteraMainWindow(val gateway: PainteraGateway = PainteraGateway()) {
 				NamedKeyCombination(BindingKeys.MAXIMIZE_VIEWER, KeyCodeCombination(KeyCode.M)),
 				NamedKeyCombination(BindingKeys.MAXIMIZE_VIEWER_AND_3D, KeyCodeCombination(KeyCode.M, KeyCombination.SHIFT_DOWN)),
 				NamedKeyCombination(BindingKeys.CREATE_NEW_LABEL_DATASET, KeyCodeCombination(KeyCode.N, KeyCombination.CONTROL_DOWN, KeyCombination.SHIFT_DOWN)),
-				NamedKeyCombination(BindingKeys.SHOW_REPL_TABS, KeyCodeCombination(KeyCode.T, KeyCombination.SHORTCUT_DOWN, KeyCombination.ALT_DOWN)))
+				NamedKeyCombination(BindingKeys.SHOW_REPL_TABS, KeyCodeCombination(KeyCode.T, KeyCombination.SHORTCUT_DOWN, KeyCombination.ALT_DOWN)),
+				NamedKeyCombination(BindingKeys.TOGGLE_FULL_SCREEN, KeyCodeCombination(KeyCode.F11)))
 
 
 		@JvmStatic

--- a/src/main/java/org/janelia/saalfeldlab/paintera/PainteraMainWindow.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/PainteraMainWindow.kt
@@ -402,7 +402,9 @@ class PainteraMainWindow(val gateway: PainteraGateway = PainteraGateway()) {
 			fun show() {
 				synchronized(this) {
 					if (!this::dialog.isInitialized)
-						dialog = SciJavaReplFXDialog(context, *bindings).also { it.initOwner(window()) }
+						dialog = SciJavaReplFXDialog(context, *bindings)
+								.also { it.initOwner(window()) }
+								.also { it.title = "${Paintera.NAME} - Scripting REPL" }
 				}
 				dialog.show()
 				dialog.dialogPane.addEventHandler(KeyEvent.KEY_PRESSED) {

--- a/src/main/java/org/janelia/saalfeldlab/paintera/PainteraMainWindow.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/PainteraMainWindow.kt
@@ -53,7 +53,7 @@ import java.util.function.BiConsumer
 
 typealias PropertiesListener = BiConsumer<Properties2?, Properties2?>
 
-class PainteraMainWindow() {
+class PainteraMainWindow(val gateway: PainteraGateway = PainteraGateway()) {
 
 	val baseView = PainteraBaseView(
 			PainteraBaseView.reasonableNumFetcherThreads(),
@@ -141,7 +141,7 @@ class PainteraMainWindow() {
 	val properties: Properties2
 		get() = _properties
 
-	constructor(properties: Properties2): this() {
+	@JvmOverloads constructor(properties: Properties2, gateway: PainteraGateway = PainteraGateway()): this(gateway = gateway) {
 		initProperties(properties)
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/SaveOnExitDialog.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/SaveOnExitDialog.java
@@ -12,6 +12,7 @@ import org.janelia.saalfeldlab.paintera.control.CommitChanges.Commitable;
 import org.janelia.saalfeldlab.paintera.data.mask.MaskedSource;
 import org.janelia.saalfeldlab.paintera.serialization.GsonHelpers;
 import org.janelia.saalfeldlab.paintera.serialization.Properties;
+import org.scijava.Context;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,7 +73,7 @@ public class SaveOnExitDialog implements EventHandler<WindowEvent>
 					SaveProject.persistProperties(
 							project,
 							properties,
-							GsonHelpers.builderWithAllRequiredSerializers(baseView, this::project).setPrettyPrinting()
+							GsonHelpers.builderWithAllRequiredSerializers(new Context(), baseView, this::project).setPrettyPrinting()
 					                             );
 					checkForUncommitedCanvases();
 				} catch (final IOException e)

--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/ArbitraryMeshConfigNode.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/ArbitraryMeshConfigNode.kt
@@ -21,6 +21,7 @@ import org.janelia.saalfeldlab.fx.ui.Exceptions
 import org.janelia.saalfeldlab.fx.ui.NumberField
 import org.janelia.saalfeldlab.fx.ui.ObjectField
 import org.janelia.saalfeldlab.paintera.meshes.io.TriangleMeshFormat
+import org.janelia.saalfeldlab.paintera.meshes.io.TriangleMeshFormatService
 import org.janelia.saalfeldlab.paintera.ui.PainteraAlerts
 import java.nio.file.Path
 import java.util.*
@@ -28,7 +29,9 @@ import java.util.function.Consumer
 import java.util.function.DoublePredicate
 import java.util.stream.Collectors
 
-class ArbitraryMeshConfigNode(val config: ArbitraryMeshConfig = ArbitraryMeshConfig()) : TitledPane("Triangle Meshes", null) {
+class ArbitraryMeshConfigNode @JvmOverloads constructor(
+		triangleMeshFormat: TriangleMeshFormatService,
+		val config: ArbitraryMeshConfig = ArbitraryMeshConfig()) : TitledPane("Triangle Meshes", null) {
 
     private val isVisibleCheckbox = CheckBox()
 			.also { it.selectedProperty().bindBidirectional(config.isVisibleProperty) }
@@ -50,8 +53,8 @@ class ArbitraryMeshConfigNode(val config: ArbitraryMeshConfig = ArbitraryMeshCon
             (dialog.dialogPane.lookupButton(ButtonType.OK) as Button).text = "_OK"
             (dialog.dialogPane.lookupButton(ButtonType.CANCEL) as Button).text = "_Cancel"
             dialog.headerText = "Open mesh from file"
-            val formats = FXCollections.observableArrayList(TriangleMeshFormat.availableFormats())
-            val extensionFormatMapping = TriangleMeshFormat.extensionsToFormatMapping()
+            val formats = FXCollections.observableArrayList(TriangleMeshFormat.availableFormats(triangleMeshFormat))
+            val extensionFormatMapping = TriangleMeshFormat.extensionsToFormatMapping(triangleMeshFormat)
             val formatChoiceBox = ComboBox(formats)
             formatChoiceBox.promptText = "Format"
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/meshes/io/TriangleMeshFormat.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/meshes/io/TriangleMeshFormat.java
@@ -1,51 +1,12 @@
 package org.janelia.saalfeldlab.paintera.meshes.io;
 
-import javafx.scene.shape.TriangleMesh;
-import org.scijava.Context;
-import org.scijava.InstantiableException;
-import org.scijava.plugin.DefaultPluginService;
-import org.scijava.plugin.Plugin;
-import org.scijava.plugin.PluginInfo;
-import org.scijava.plugin.PluginService;
 import org.scijava.plugin.SciJavaPlugin;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.lang.invoke.MethodHandles;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public interface TriangleMeshFormat extends SciJavaPlugin {
-
-	class FormatFinder {
-
-		private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
-		private static List<TriangleMeshFormat> meshFormats = new ArrayList<>();
-
-		private static Map<String, List<TriangleMeshFormat>> extensionToFormatMapping = new HashMap<>();
-
-		static {
-			final Context context = new Context();
-			final PluginService pluginService = context.getService(PluginService.class);
-			final List<PluginInfo<TriangleMeshFormat>> pluginInfos = pluginService.getPluginsOfType(TriangleMeshFormat.class);
-			for (PluginInfo<TriangleMeshFormat> pluginInfo : pluginInfos) {
-				try {
-					final TriangleMeshFormat instance = pluginInfo.createInstance();
-					meshFormats.add(instance);
-					for (final String ext : instance.knownExtensions())
-						extensionToFormatMapping.computeIfAbsent(ext, k -> new ArrayList<>()).add(instance);
-				} catch (InstantiableException e) {
-					LOG.error("Unable to instantiate plugin {}", pluginInfo, e);
-				}
-			}
-		}
-
-	}
 
 	String formatName();
 
@@ -55,11 +16,11 @@ public interface TriangleMeshFormat extends SciJavaPlugin {
 
 	TriangleMeshLoader getLoader();
 
-	static List<TriangleMeshFormat> availableFormats() {
-		return Collections.unmodifiableList(FormatFinder.meshFormats);
+	static List<TriangleMeshFormat> availableFormats(final TriangleMeshFormatService triangleMeshFormat) {
+		return triangleMeshFormat.getMeshFormats();
 	}
 
-	static Map<String, List<TriangleMeshFormat>> extensionsToFormatMapping() {
-		return Collections.unmodifiableMap(FormatFinder.extensionToFormatMapping);
+	static Map<String, List<TriangleMeshFormat>> extensionsToFormatMapping(final TriangleMeshFormatService triangleMeshFormat) {
+		return triangleMeshFormat.getExtensionToFormatMapping();
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/meshes/io/TriangleMeshFormatService.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/meshes/io/TriangleMeshFormatService.kt
@@ -1,0 +1,63 @@
+package org.janelia.saalfeldlab.paintera.meshes.io
+
+import org.scijava.Context
+import org.scijava.InstantiableException
+import org.scijava.plugin.Plugin
+import org.scijava.plugin.PluginService
+import org.scijava.service.AbstractService
+import org.scijava.service.SciJavaService
+import org.scijava.service.Service
+import org.slf4j.LoggerFactory
+import java.lang.invoke.MethodHandles
+
+@Plugin(type = Service::class)
+class TriangleMeshFormatService : AbstractService(), SciJavaService {
+
+
+	private lateinit var _meshFormats: List<TriangleMeshFormat>
+
+	private lateinit var _extensionToFormatMapping: Map<String, List<TriangleMeshFormat>>
+
+	val meshFormats: List<TriangleMeshFormat>
+		@Synchronized get() {
+			if (!this::_meshFormats.isInitialized)
+				initFormatsAndExtensions()
+			return _meshFormats
+		}
+
+	val extensionToFormatMapping: Map<String, List<TriangleMeshFormat>>
+		@Synchronized get() {
+			if (!this::_extensionToFormatMapping.isInitialized)
+				initFormatsAndExtensions()
+			return _extensionToFormatMapping
+		}
+
+	private fun initFormatsAndExtensions() {
+		val p = makeMeshFormats(context)
+		_meshFormats = p.first
+		_extensionToFormatMapping = p.second
+	}
+
+	companion object {
+
+		private val LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass())
+
+		private fun makeMeshFormats(context: Context): Pair<List<TriangleMeshFormat>, Map<String, List<TriangleMeshFormat>>> {
+			val pluginService = context.getService(PluginService::class.java)
+			val pluginInfos = pluginService.getPluginsOfType(TriangleMeshFormat::class.java)
+			val meshFormats = mutableListOf<TriangleMeshFormat>()
+			val extensionToFormatMapping = mutableMapOf<String, MutableList<TriangleMeshFormat>>()
+			for (pluginInfo in pluginInfos) {
+				try {
+					val instance = pluginInfo.createInstance();
+					meshFormats.add(instance);
+					for (ext in instance.knownExtensions())
+						extensionToFormatMapping.computeIfAbsent(ext) { mutableListOf() } += instance
+				} catch (e: InstantiableException) {
+					LOG.error("Unable to instantiate plugin {}", pluginInfo, e);
+				}
+			}
+			return Pair(meshFormats, extensionToFormatMapping)
+		}
+	}
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/serialization/GsonHelpers.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/serialization/GsonHelpers.java
@@ -1,63 +1,11 @@
 package org.janelia.saalfeldlab.paintera.serialization;
 
 import com.google.gson.GsonBuilder;
-import javafx.beans.property.SimpleBooleanProperty;
-import javafx.beans.property.SimpleDoubleProperty;
-import javafx.beans.property.SimpleIntegerProperty;
-import javafx.beans.property.SimpleLongProperty;
 import javafx.util.Pair;
-import net.imglib2.converter.ARGBColorConverter;
-import net.imglib2.converter.ARGBCompositeColorConverter;
-import net.imglib2.realtransform.AffineTransform3D;
 import org.janelia.saalfeldlab.paintera.PainteraBaseView;
-import org.janelia.saalfeldlab.paintera.composition.Composite;
-import org.janelia.saalfeldlab.paintera.config.CrosshairConfig;
-import org.janelia.saalfeldlab.paintera.config.ScreenScalesConfig;
-import org.janelia.saalfeldlab.paintera.control.assignment.FragmentSegmentAssignmentOnlyLocal;
-import org.janelia.saalfeldlab.paintera.control.selection.SelectedIds;
-import org.janelia.saalfeldlab.paintera.data.mask.MaskedSource;
-import org.janelia.saalfeldlab.paintera.data.mask.MaskedSourceDeserializer;
-import org.janelia.saalfeldlab.paintera.data.mask.MaskedSourceSerializer;
-import org.janelia.saalfeldlab.paintera.data.n5.CommitCanvasN5;
-import org.janelia.saalfeldlab.paintera.data.n5.N5ChannelDataSource;
-import org.janelia.saalfeldlab.paintera.data.n5.N5ChannelDataSourceDeserializer;
-import org.janelia.saalfeldlab.paintera.data.n5.N5ChannelDataSourceSerializer;
-import org.janelia.saalfeldlab.paintera.data.n5.N5DataSource;
-import org.janelia.saalfeldlab.paintera.data.n5.N5DataSourceDeserializer;
-import org.janelia.saalfeldlab.paintera.data.n5.N5DataSourceSerializer;
-import org.janelia.saalfeldlab.paintera.meshes.ManagedMeshSettings;
-import org.janelia.saalfeldlab.paintera.meshes.MeshSettings;
 import org.janelia.saalfeldlab.paintera.serialization.StatefulSerializer.Arguments;
-import org.janelia.saalfeldlab.paintera.serialization.config.CrosshairConfigSerializer;
-import org.janelia.saalfeldlab.paintera.serialization.config.MeshSettingsSerializer;
-import org.janelia.saalfeldlab.paintera.serialization.converter.ARGBColorConverterSerializer;
-import org.janelia.saalfeldlab.paintera.serialization.converter.ARGBCompositeColorConverterSerializer;
-import org.janelia.saalfeldlab.paintera.serialization.converter.HighlightingStreamConverterSerializer;
-import org.janelia.saalfeldlab.paintera.serialization.fx.SimpleBooleanPropertySerializer;
-import org.janelia.saalfeldlab.paintera.serialization.fx.SimpleDoublePropertySerializer;
-import org.janelia.saalfeldlab.paintera.serialization.fx.SimpleIntegerPropertySerializer;
-import org.janelia.saalfeldlab.paintera.serialization.fx.SimpleLongPropertySerializer;
-import org.janelia.saalfeldlab.paintera.serialization.sourcestate.ChannelSourceStateDeserializer;
-import org.janelia.saalfeldlab.paintera.serialization.sourcestate.ChannelSourceStateSerializer;
-import org.janelia.saalfeldlab.paintera.serialization.sourcestate.IntersectingSourceStateDeserializer;
-import org.janelia.saalfeldlab.paintera.serialization.sourcestate.IntersectingSourceStateSerializer;
-import org.janelia.saalfeldlab.paintera.serialization.sourcestate.InvertingSourceStateDeserializer;
-import org.janelia.saalfeldlab.paintera.serialization.sourcestate.InvertingSourceStateSerializer;
-import org.janelia.saalfeldlab.paintera.serialization.sourcestate.LabelSourceStateDeserializer;
-import org.janelia.saalfeldlab.paintera.serialization.sourcestate.LabelSourceStateSerializer;
-import org.janelia.saalfeldlab.paintera.serialization.sourcestate.RawSourceStateDeserializer;
-import org.janelia.saalfeldlab.paintera.serialization.sourcestate.RawSourceStateSerializer;
-import org.janelia.saalfeldlab.paintera.serialization.sourcestate.ThresholdingSourceStateDeserializer;
-import org.janelia.saalfeldlab.paintera.serialization.sourcestate.ThresholdingSourceStateSerializer;
-import org.janelia.saalfeldlab.paintera.state.ChannelSourceState;
-import org.janelia.saalfeldlab.paintera.state.IntersectingSourceState;
-import org.janelia.saalfeldlab.paintera.state.InvertingRawSourceState;
-import org.janelia.saalfeldlab.paintera.state.LabelSourceState;
-import org.janelia.saalfeldlab.paintera.state.RawSourceState;
-import org.janelia.saalfeldlab.paintera.state.SourceInfo;
 import org.janelia.saalfeldlab.paintera.state.SourceState;
-import org.janelia.saalfeldlab.paintera.state.ThresholdingSourceState;
-import org.janelia.saalfeldlab.paintera.stream.HighlightingStreamConverter;
+import org.scijava.Context;
 import org.scijava.InstantiableException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,21 +22,23 @@ public class GsonHelpers {
 	private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
 	public static GsonBuilder builderWithAllRequiredDeserializers(
+			final Context context,
 			final PainteraBaseView viewer,
 			final Supplier<String> projectDirectory) throws InstantiableException {
 		final IntFunction<SourceState<?, ?>> dependencyFromIndex = index -> viewer.sourceInfo().getState(viewer
 				.sourceInfo().trackSources().get(
 						index));
-		return builderWithAllRequiredDeserializers(new Arguments(viewer), projectDirectory, dependencyFromIndex);
+		return builderWithAllRequiredDeserializers(context, new Arguments(viewer), projectDirectory, dependencyFromIndex);
 	}
 
 	public static GsonBuilder builderWithAllRequiredDeserializers(
+			final Context context,
 			final Arguments arguments,
 			final Supplier<String> projectDirectory,
 			final IntFunction<SourceState<?, ?>> dependencyFromIndex) {
 
-		final Map<Class<?>, List<Pair<PainteraSerialization.PainteraDeserializer, Double>>> deserializers = PainteraSerialization.getDeserializers();
-		final Map<Class<?>, List<Pair<StatefulSerializer.DeserializerFactory, Double>>> deserializerFactories = StatefulSerializer.getDeserializers();
+		final Map<Class<?>, List<Pair<PainteraSerialization.PainteraDeserializer, Double>>> deserializers = PainteraSerialization.getDeserializers(context);
+		final Map<Class<?>, List<Pair<StatefulSerializer.DeserializerFactory, Double>>> deserializerFactories = StatefulSerializer.getDeserializers(context);
 
 		final GsonBuilder builder = new GsonBuilder();
 
@@ -114,20 +64,22 @@ public class GsonHelpers {
 	}
 
 	public static GsonBuilder builderWithAllRequiredSerializers(
+			final Context context,
 			final PainteraBaseView viewer,
 			final Supplier<String> projectDirectory) {
 		final ToIntFunction<SourceState<?, ?>> dependencyFromIndex =
 				state -> viewer.sourceInfo().trackSources().indexOf(state.getDataSource());
-		return builderWithAllRequiredSerializers(projectDirectory, dependencyFromIndex);
+		return builderWithAllRequiredSerializers(context, projectDirectory, dependencyFromIndex);
 	}
 
 	public static GsonBuilder builderWithAllRequiredSerializers(
+			final Context context,
 			final Supplier<String> projectDirectory,
 			final ToIntFunction<SourceState<?, ?>> dependencyToIndex) {
 		LOG.debug("Creating builder with required serializers.");
 
-		final Map<Class<?>, List<Pair<PainteraSerialization.PainteraSerializer, Double>>> serializers = PainteraSerialization.getSerializers();
-		final Map<Class<?>, List<Pair<StatefulSerializer.SerializerFactory, Double>>> serializerFactories = StatefulSerializer.getSerializers();
+		final Map<Class<?>, List<Pair<PainteraSerialization.PainteraSerializer, Double>>> serializers = PainteraSerialization.getSerializers(context);
+		final Map<Class<?>, List<Pair<StatefulSerializer.SerializerFactory, Double>>> serializerFactories = StatefulSerializer.getSerializers(context);
 		LOG.debug("Found serializer factories for these classes: {}", serializerFactories.keySet());
 
 		final GsonBuilder builder = new GsonBuilder();

--- a/src/main/java/org/janelia/saalfeldlab/paintera/serialization/PainteraSerialization.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/serialization/PainteraSerialization.java
@@ -2,24 +2,20 @@ package org.janelia.saalfeldlab.paintera.serialization;
 
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonSerializer;
-import javafx.beans.property.SimpleDoubleProperty;
 import javafx.util.Pair;
 import org.janelia.saalfeldlab.util.SciJavaUtils;
 import org.scijava.Context;
 import org.scijava.InstantiableException;
-import org.scijava.plugin.PluginInfo;
-import org.scijava.plugin.PluginService;
 import org.scijava.plugin.SciJavaPlugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+// TODO make service for this
 public class PainteraSerialization {
 
 	private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -55,11 +51,11 @@ public class PainteraSerialization {
 
 	}
 
-	public static Map<Class<?>, List<Pair<PainteraSerializer, Double>>> getSerializers()
+	public static Map<Class<?>, List<Pair<PainteraSerializer, Double>>> getSerializers(final Context context)
 	{
 		if (SERIALIZERS_SORTED_BY_PRIORITY == null) {
 			try {
-				SERIALIZERS_SORTED_BY_PRIORITY = Collections.unmodifiableMap(SciJavaUtils.byTargetClassSortedByPriorities(PainteraSerializer.class));
+				SERIALIZERS_SORTED_BY_PRIORITY = Collections.unmodifiableMap(SciJavaUtils.byTargetClassSortedByPriorities(PainteraSerializer.class, context));
 			} catch (InstantiableException e) {
 				throw new RuntimeException(e);
 			}
@@ -67,11 +63,11 @@ public class PainteraSerialization {
 		return SERIALIZERS_SORTED_BY_PRIORITY;
 	}
 
-	public static Map<Class<?>, List<Pair<PainteraDeserializer, Double>>> getDeserializers()
+	public static Map<Class<?>, List<Pair<PainteraDeserializer, Double>>> getDeserializers(final Context context)
 	{
 		if (DESERIALIZERS_SORTED_BY_PRIORITY == null) {
 			try {
-				DESERIALIZERS_SORTED_BY_PRIORITY = Collections.unmodifiableMap(SciJavaUtils.byTargetClassSortedByPriorities(PainteraDeserializer.class));
+				DESERIALIZERS_SORTED_BY_PRIORITY = Collections.unmodifiableMap(SciJavaUtils.byTargetClassSortedByPriorities(PainteraDeserializer.class, context));
 			} catch (InstantiableException e) {
 				throw new RuntimeException(e);
 			}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/serialization/Properties.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/serialization/Properties.java
@@ -24,6 +24,7 @@ import org.janelia.saalfeldlab.paintera.config.Viewer3DConfig;
 import org.janelia.saalfeldlab.paintera.serialization.StatefulSerializer.Arguments;
 import org.janelia.saalfeldlab.paintera.state.SourceInfo;
 import org.janelia.saalfeldlab.paintera.state.SourceState;
+import org.scijava.Context;
 import org.scijava.InstantiableException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -163,7 +164,7 @@ public class Properties implements TransformListener<AffineTransform3D>
 				removeExistingSources,
 				indexToState,
 				manager,
-				GsonHelpers.builderWithAllRequiredDeserializers(arguments, projectDirectory, indexToState::get).create());
+				GsonHelpers.builderWithAllRequiredDeserializers(new Context(), arguments, projectDirectory, indexToState::get).create());
 	}
 
 	public static Properties fromSerializedProperties(

--- a/src/main/java/org/janelia/saalfeldlab/paintera/serialization/StatefulSerializer.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/serialization/StatefulSerializer.java
@@ -8,6 +8,7 @@ import org.janelia.saalfeldlab.paintera.PainteraBaseView;
 import org.janelia.saalfeldlab.paintera.cache.global.GlobalCache;
 import org.janelia.saalfeldlab.paintera.state.SourceState;
 import org.janelia.saalfeldlab.util.SciJavaUtils;
+import org.scijava.Context;
 import org.scijava.InstantiableException;
 import org.scijava.plugin.SciJavaPlugin;
 
@@ -19,6 +20,7 @@ import java.util.function.IntFunction;
 import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
 
+// TODO make service for this
 public class StatefulSerializer
 {
 
@@ -75,11 +77,13 @@ public class StatefulSerializer
 
 	}
 
-	public static Map<Class<?>, List<Pair<SerializerFactory, Double>>> getSerializers()
+	public static Map<Class<?>, List<Pair<SerializerFactory, Double>>> getSerializers(final Context context)
 	{
 		if (SERIALIZER_FACTORIES_SORTED_BY_PRIORITY == null) {
 			try {
-				SERIALIZER_FACTORIES_SORTED_BY_PRIORITY = Collections.unmodifiableMap(SciJavaUtils.byTargetClassSortedByPriorities(SerializerFactory.class));
+				SERIALIZER_FACTORIES_SORTED_BY_PRIORITY = Collections.unmodifiableMap(SciJavaUtils.byTargetClassSortedByPriorities(
+						SerializerFactory.class,
+						context));
 			} catch (InstantiableException e) {
 				throw new RuntimeException(e);
 			}
@@ -87,11 +91,13 @@ public class StatefulSerializer
 		return SERIALIZER_FACTORIES_SORTED_BY_PRIORITY;
 	}
 
-	public static Map<Class<?>, List<Pair<DeserializerFactory, Double>>> getDeserializers()
+	public static Map<Class<?>, List<Pair<DeserializerFactory, Double>>> getDeserializers(final Context context)
 	{
 		if (DESERIALIZER_FACTORIES_SORTED_BY_PRIORITY == null) {
 			try {
-				DESERIALIZER_FACTORIES_SORTED_BY_PRIORITY = Collections.unmodifiableMap(SciJavaUtils.byTargetClassSortedByPriorities(DeserializerFactory.class));
+				DESERIALIZER_FACTORIES_SORTED_BY_PRIORITY = Collections.unmodifiableMap(SciJavaUtils.byTargetClassSortedByPriorities(
+						DeserializerFactory.class,
+						context));
 			} catch (InstantiableException e) {
 				throw new RuntimeException(e);
 			}

--- a/src/main/java/org/janelia/saalfeldlab/util/SciJavaUtils.java
+++ b/src/main/java/org/janelia/saalfeldlab/util/SciJavaUtils.java
@@ -1,7 +1,6 @@
 package org.janelia.saalfeldlab.util;
 
 import javafx.util.Pair;
-import org.janelia.saalfeldlab.paintera.serialization.PainteraSerialization;
 import org.scijava.Context;
 import org.scijava.InstantiableException;
 import org.scijava.plugin.PluginInfo;
@@ -14,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.ToDoubleFunction;
 
+// TODO make service for this
 public class SciJavaUtils {
 
 	public interface HasTargetClass<T> {
@@ -31,9 +31,10 @@ public class SciJavaUtils {
 	}
 
 	public static <T extends SciJavaPlugin & HasTargetClass<?>> Map<Class<?>, List<Pair<T, Double>>> byTargetClassSortedByPriorities(
-			Class<T> clazz
+			final Class<T> clazz,
+			final Context context
 	) throws InstantiableException {
-		return byTargetClassSortedByPriorities(getAllMatchingPluginInfos(clazz));
+		return byTargetClassSortedByPriorities(getAllMatchingPluginInfos(clazz, context));
 	}
 
 	public static <T extends SciJavaPlugin & HasTargetClass<?>> Map<Class<?>, List<Pair<T, Double>>> byTargetClassSortedByPriorities(
@@ -56,13 +57,6 @@ public class SciJavaUtils {
 		}
 		return byClassWithPriorities;
 	}
-
-	public static <T extends SciJavaPlugin> List<? extends PluginInfo<T>> getAllMatchingPluginInfos(
-			final Class<T> clazz)
-	{
-		return getAllMatchingPluginInfos(clazz, new Context(PluginService.class));
-	}
-
 	public static <T extends SciJavaPlugin> List<? extends PluginInfo<T>> getAllMatchingPluginInfos(
 			final Class<T> clazz,
 			final Context context)


### PR DESCRIPTION
This adds a REPL that can be opened via the menu (`View>Show REPL`) or via `Ctrl+Alt+T`.

In order to re-use context, I added a new `PainteraGateway` to include all relevant services.

Fixes #138 