### PR TITLE
Add src/main/java to kapt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,17 @@
 						<phase>test-compile</phase>
 						<goals> <goal>test-compile</goal> </goals>
 					</execution>
+					<execution>
+						<id>kapt</id>
+						<goals>
+							<goal>kapt</goal>
+						</goals>
+						<configuration>
+							<sourceDirs>
+								<sourceDir>${project.basedir}/src/main/java</sourceDir>
+							</sourceDirs>
+						</configuration>
+					</execution>
 				</executions>
 				<configuration>
 					<jvmTarget>1.8</jvmTarget>


### PR DESCRIPTION
Addresses plugin detection: Add `src/main/java` to sources for kotlin annotator processing.

@igorpisarev If you re-visit the Windows issues, please use this branch.