### PR TITLE
Always change brush radius by multiplication and remove upper bound for brush radius

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/PaintActions2D.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/PaintActions2D.java
@@ -157,8 +157,7 @@ public class PaintActions2D
 			Optional.ofNullable(maskedSource.get()).ifPresent(ms -> ms.applyMask(
 					canvas.get(),
 					interval.get(),
-					FOREGROUND_CHECK
-			                                                                    ));
+					FOREGROUND_CHECK));
 		}
 
 	}
@@ -172,8 +171,6 @@ public class PaintActions2D
 	private final BrushOverlay brushOverlay;
 
 	private final SimpleDoubleProperty brushRadius = new SimpleDoubleProperty(5.0);
-
-	private final SimpleDoubleProperty brushRadiusIncrement = new SimpleDoubleProperty(1.0);
 
 	private final SimpleDoubleProperty brushRadiusScale = new SimpleDoubleProperty(1.1);
 
@@ -380,14 +377,13 @@ public class PaintActions2D
 		return this.brushRadius;
 	}
 
-	public DoubleProperty brushRadiusIncrementProperty()
-	{
-		return this.brushRadiusIncrement;
-	}
-
 	public DoubleProperty brushDepthProperty()
 	{
 		return this.brushDepth;
+	}
+
+	public DoubleProperty brushRadiusScaleProperty() {
+		return this.brushRadiusScale;
 	}
 
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/PaintActions2D.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/PaintActions2D.java
@@ -1,25 +1,5 @@
 package org.janelia.saalfeldlab.paintera.control.paint;
 
-import java.lang.invoke.MethodHandles;
-import java.util.Optional;
-import java.util.concurrent.ExecutorService;
-import java.util.function.BiConsumer;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
-
-import org.janelia.saalfeldlab.fx.event.EventFX;
-import org.janelia.saalfeldlab.fx.event.MouseDragFX;
-import org.janelia.saalfeldlab.paintera.data.DataSource;
-import org.janelia.saalfeldlab.paintera.data.mask.Mask;
-import org.janelia.saalfeldlab.paintera.data.mask.MaskInfo;
-import org.janelia.saalfeldlab.paintera.data.mask.MaskedSource;
-import org.janelia.saalfeldlab.paintera.data.mask.exception.MaskInUse;
-import org.janelia.saalfeldlab.paintera.state.GlobalTransformManager;
-import org.janelia.saalfeldlab.paintera.state.SourceInfo;
-import org.janelia.saalfeldlab.paintera.state.SourceState;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import bdv.fx.viewer.ViewerPanelFX;
 import bdv.fx.viewer.ViewerState;
 import bdv.util.Affine3DHelpers;
@@ -35,6 +15,25 @@ import net.imglib2.type.numeric.integer.UnsignedLongType;
 import net.imglib2.util.Intervals;
 import net.imglib2.util.LinAlgHelpers;
 import net.imglib2.view.Views;
+import org.janelia.saalfeldlab.fx.event.EventFX;
+import org.janelia.saalfeldlab.fx.event.MouseDragFX;
+import org.janelia.saalfeldlab.paintera.data.DataSource;
+import org.janelia.saalfeldlab.paintera.data.mask.Mask;
+import org.janelia.saalfeldlab.paintera.data.mask.MaskInfo;
+import org.janelia.saalfeldlab.paintera.data.mask.MaskedSource;
+import org.janelia.saalfeldlab.paintera.data.mask.exception.MaskInUse;
+import org.janelia.saalfeldlab.paintera.state.GlobalTransformManager;
+import org.janelia.saalfeldlab.paintera.state.SourceInfo;
+import org.janelia.saalfeldlab.paintera.state.SourceState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 public class PaintActions2D
 {
@@ -237,26 +236,18 @@ public class PaintActions2D
 
 	public void decreaseBrushRadius()
 	{
-		setBrushRadius(
-				Math.min(
-						brushRadius.get() - brushRadiusIncrement.get(),
-						brushRadius.get() / brushRadiusScale.get()));
+		setBrushRadius(brushRadius.get() / brushRadiusScale.get());
 	}
 
 	public void increaseBrushRadius()
 	{
-		setBrushRadius(
-				Math.max(
-						brushRadius.get() + brushRadiusIncrement.get(),
-						brushRadius.get() * brushRadiusScale.get()));
+		setBrushRadius(brushRadius.get() * brushRadiusScale.get());
 	}
 
 	public void setBrushRadius(final double radius)
 	{
-		if (radius > 0 && radius < Math.min(viewer.getWidth(), viewer.getHeight()))
-		{
+		if (radius > 0)
 			this.brushRadius.set(radius);
-		}
 	}
 
 	public MouseDragFX dragPaintLabel(final String name, final Supplier<Long> id, final Predicate<MouseEvent>

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceState.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceState.java
@@ -207,6 +207,10 @@ public class LabelSourceState<D extends IntegerType<D>, T>
 		return this.labelBlockLookup;
 	}
 
+	public LabelSourceStatePaintHandler.BrushProperties getBrushProperties() {
+		return paintHandler.getBrushProperties();
+	}
+
 	@Override
 	public LongFunction<Converter<D, BoolType>> maskForLabel()
 	{

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceStatePreferencePaneNode.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceStatePreferencePaneNode.kt
@@ -1,30 +1,16 @@
 package org.janelia.saalfeldlab.paintera.state
 
 import javafx.event.EventHandler
+import javafx.geometry.Insets
 import javafx.geometry.Pos
 import javafx.scene.Node
-import javafx.scene.control.Alert
-import javafx.scene.control.Button
-import javafx.scene.control.ButtonBar
-import javafx.scene.control.ButtonType
-import javafx.scene.control.CheckBox
-import javafx.scene.control.Label
-import javafx.scene.control.TextArea
-import javafx.scene.control.TextField
-import javafx.scene.control.TitledPane
-import javafx.scene.control.Tooltip
-import javafx.scene.layout.GridPane
-import javafx.scene.layout.HBox
-import javafx.scene.layout.Priority
-import javafx.scene.layout.Region
-import javafx.scene.layout.VBox
+import javafx.scene.control.*
+import javafx.scene.layout.*
 import javafx.stage.Modality
-import org.janelia.saalfeldlab.fx.Buttons
-import org.janelia.saalfeldlab.fx.Labels
-import org.janelia.saalfeldlab.fx.TextFieldExtensions
-import org.janelia.saalfeldlab.fx.TitledPaneExtensions
-import org.janelia.saalfeldlab.fx.TitledPanes
+import org.janelia.saalfeldlab.fx.*
 import org.janelia.saalfeldlab.fx.ui.Exceptions
+import org.janelia.saalfeldlab.fx.ui.NumberField
+import org.janelia.saalfeldlab.fx.ui.ObjectField
 import org.janelia.saalfeldlab.fx.undo.UndoFromEvents
 import org.janelia.saalfeldlab.paintera.Paintera
 import org.janelia.saalfeldlab.paintera.control.assignment.FragmentSegmentAssignmentState
@@ -40,6 +26,7 @@ import org.janelia.saalfeldlab.paintera.stream.HighlightingStreamConverterConfig
 import org.janelia.saalfeldlab.paintera.ui.PainteraAlerts
 import org.slf4j.LoggerFactory
 import java.lang.invoke.MethodHandles
+import java.util.function.DoublePredicate
 
 typealias TFE = TextFieldExtensions
 
@@ -53,7 +40,7 @@ class LabelSourceStatePreferencePaneNode(val state: LabelSourceState<*, *>) {
 					SelectedIdsNode(state).node,
 					LabelSourceStateMeshPaneNode(state.meshManager(), meshInfosFromState(state)).node,
 					AssignmentsNode(state.assignment()).node,
-					MaskedSourceNode(state.getDataSource()).node)
+					MaskedSourceNode(state.getDataSource(), state.getBrushProperties()).node)
 			box.children.addAll(nodes.filterNotNull())
 			return box
 		}
@@ -243,7 +230,9 @@ class LabelSourceStatePreferencePaneNode(val state: LabelSourceState<*, *>) {
 
 	}
 
-	private class MaskedSourceNode(private val source: DataSource<*, *>) {
+	private class MaskedSourceNode(
+        private val source: DataSource<*, *>,
+        private val brushProperties: LabelSourceStatePaintHandler.BrushProperties) {
 
 		val node: Node?
 			get() {
@@ -254,7 +243,7 @@ class LabelSourceStatePreferencePaneNode(val state: LabelSourceState<*, *>) {
 					val clearButton = Buttons.withTooltip(
 							"Clear",
 							"Clear any modifications to the canvas. Any changes that have not been committed will be lost.")
-					{ showForgetAlert(source) }
+                    { showForgetAlert(source) }
 
 					val helpDialog = PainteraAlerts
 							.alert(Alert.AlertType.INFORMATION, true)
@@ -270,8 +259,38 @@ class LabelSourceStatePreferencePaneNode(val state: LabelSourceState<*, *>) {
 							Button("?").also { bt -> bt.onAction = EventHandler { helpDialog.show() } })
 							.also { it.alignment = Pos.CENTER }
 
+                    val brushSizeLabel = Labels.withTooltip(
+                        "Brush Size",
+                        "Brush Size. Has to be positive.")
+                        .also { it.alignment = Pos.CENTER_LEFT }
+                    val brushSizeField =
+                        NumberField.doubleField(brushProperties.brushRadius, DoublePredicate { it > 0.0 }, *ObjectField.SubmitOn.values())
+                    brushSizeField.valueProperty().bindBidirectional(brushProperties.brushRadiusProperty())
+                    brushSizeField.textField.alignment = Pos.CENTER_RIGHT
+
+                    val brushSizeScaleLabel = Labels.withTooltip(
+                        "Brush Size Scale",
+                        "Scale brush size by this factor when adjusting the size. Has to be larger than 1.")
+                        .also { it.alignment = Pos.CENTER_LEFT }
+                    val brushSizeScaleField =
+                        NumberField.doubleField(brushProperties.brushRadius, DoublePredicate { it > 1.0 }, *ObjectField.SubmitOn.values())
+                    brushSizeScaleField.valueProperty().bindBidirectional(brushProperties.brushRadiusScaleProperty())
+                    brushSizeScaleField.textField.alignment = Pos.CENTER_RIGHT
+
+                    GridPane.setHgrow(brushSizeField.textField, Priority.ALWAYS)
+                    GridPane.setHgrow(brushSizeScaleField.textField, Priority.ALWAYS)
+                    val paintSettingsPane = GridPane()
+                        .also { it.hgap = 5.0 }
+                        .also { it.padding = Insets.EMPTY }
+                        .also { it.add(brushSizeLabel, 0, 0) }
+                        .also { it.add(brushSizeField.textField, 1, 0) }
+                        .also { it.add(brushSizeScaleLabel, 0, 1) }
+                        .also { it.add(brushSizeScaleField.textField, 1, 1) }
+
+                    val contents = VBox(paintSettingsPane).also { it.padding = Insets.EMPTY }
+
 					return TitledPanes
-							.createCollapsed(null, null)
+							.createCollapsed(null, contents)
 							.also { with (TPE) { it.graphicsOnly(tpGraphics) } }
 							.also { it.alignment = Pos.CENTER_RIGHT }
 							.also { it.tooltip = null /* TODO */ }


### PR DESCRIPTION
Fixes #354

I removed the upper bound for the brush radius completely but it may make sense to actually have an upper bound, e.g. the longest diagonal of the dataset in world space.