### PR TITLE
Use correct condition in Label N5Backend

### DIFF
--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/label/n5/N5Backend.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/label/n5/N5Backend.kt
@@ -61,7 +61,7 @@ interface N5Backend<D, T> : ConnectomicsLabelBackend<D, T>, SourceStateBackendN5
                     projectDirectory,
                     propagationQueue,
                     true)
-			else if (!N5Helpers.isMultiScale(container, dataset))
+			else if (N5Helpers.isMultiScale(container, dataset))
 				// not paintera data, assuming multiscale data
 				N5BackendMultiScaleGroup(
 					container,


### PR DESCRIPTION
Previously, the !N5Helpers.isMultiScale was checked when creating a multi-scale backend, resulting in single-scale datasets being created as multi-scale (which worked but was wrong). Thanks @igorpisarev for finding and reporting this bug.