### PR TITLE
Fix key binding for 'select all' action

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceStateIdSelectorHandler.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceStateIdSelectorHandler.java
@@ -121,7 +121,7 @@ public class LabelSourceStateIdSelectorHandler {
 		handler.addOnKeyPressed(EventFX.KEY_PRESSED(
 				bindingKeySelectAll,
 				e -> selector.selectAll(),
-				e -> paintera.allowedActionsProperty().get().isAllowed(LabelActionType.SelectAll) && keyBindings.get(bindingKeySelectAllInCurrentView).getPrimaryCombination().match(e)));
+				e -> paintera.allowedActionsProperty().get().isAllowed(LabelActionType.SelectAll) && keyBindings.get(bindingKeySelectAll).getPrimaryCombination().match(e)));
 		handler.addOnKeyPressed(EventFX.KEY_PRESSED(
 				bindingKeySelectAllInCurrentView,
 				e -> selector.selectAllInCurrentView(vp),


### PR DESCRIPTION
'Select all' is broken in most recent master because of the incorrect key binding.