### PR TITLE
Fix creating bookmark node after deserialization when its note is null

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/BookmarkConfigNode.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/BookmarkConfigNode.kt
@@ -119,7 +119,7 @@ class BookmarkConfigNode(private val applyBookmark: Consumer<BookmarkConfig.Book
 
             closeIt.tooltip = Tooltip("Remove bookmark $oneBasedId")
 
-            val noteLabel = Labels.withTooltip(Optional.ofNullable(bookmark.note).map { n -> n.replace("\n", " ") }.orElse(null))
+            val noteLabel = Labels.withTooltip(Optional.ofNullable(bookmark.note).map { n -> n.replace("\n", " ") }.orElse(""))
             noteLabel.prefWidth = 100.0
             val hBox = HBox(noteLabel, goThere, updateNote, closeIt)
             hBox.alignment = Pos.CENTER


### PR DESCRIPTION
When the bookmark note is `null` in the deserialized project configuration, the following exception was printed:

```
Exception in thread "JavaFX Application Thread" java.lang.IllegalStateException: Optional.ofNullable(book…"\n", " ") }.orElse(null) must not be null
	at org.janelia.saalfeldlab.paintera.config.BookmarkConfigNode$BookmarkTitledPane.<init>(BookmarkConfigNode.kt:122)
	at org.janelia.saalfeldlab.paintera.config.BookmarkConfigNode.updateChildren(BookmarkConfigNode.kt:153)
	at org.janelia.saalfeldlab.paintera.config.BookmarkConfigNode.access$updateChildren(BookmarkConfigNode.kt:29)
	at org.janelia.saalfeldlab.paintera.config.BookmarkConfigNode$configListener$1.changed(BookmarkConfigNode.kt:55)
	at org.janelia.saalfeldlab.paintera.config.BookmarkConfigNode$configListener$1.changed(BookmarkConfigNode.kt:29)
	at com.sun.javafx.binding.ExpressionHelper$SingleChange.fireValueChangedEvent(ExpressionHelper.java:182)
	at com.sun.javafx.binding.ExpressionHelper.fireValueChangedEvent(ExpressionHelper.java:81)
	at javafx.beans.property.ObjectPropertyBase.fireValueChangedEvent(ObjectPropertyBase.java:105)
	at javafx.beans.property.ObjectPropertyBase.markInvalid(ObjectPropertyBase.java:112)
	at javafx.beans.property.ObjectPropertyBase.set(ObjectPropertyBase.java:146)
	at org.janelia.saalfeldlab.paintera.config.BookmarkConfigNode.<init>(BookmarkConfigNode.kt:32)
	at org.janelia.saalfeldlab.paintera.BorderPaneWithStatusBars2.<init>(BorderPaneWithStatusBars2.kt:221)
	at org.janelia.saalfeldlab.paintera.PainteraMainWindow.initProperties(PainteraMainWindow.kt:147)
	at org.janelia.saalfeldlab.paintera.PainteraMainWindow.initProperties(PainteraMainWindow.kt:155)
	at org.janelia.saalfeldlab.paintera.PainteraMainWindow.deserialize(PainteraMainWindow.kt:280)
	at org.janelia.saalfeldlab.paintera.PainteraMainWindow.deserialize(PainteraMainWindow.kt:173)
	at org.janelia.saalfeldlab.paintera.Paintera2.start(Paintera2.kt:40)
	at com.sun.javafx.application.LauncherImpl.lambda$launchApplication1$419(LauncherImpl.java:863)
	at com.sun.javafx.application.PlatformImpl.lambda$runAndWait$399(PlatformImpl.java:326)
	at com.sun.javafx.application.PlatformImpl.lambda$null$397(PlatformImpl.java:295)
	at java.security.AccessController.doPrivileged(Native Method)
	at com.sun.javafx.application.PlatformImpl.lambda$runLater$398(PlatformImpl.java:294)
	at com.sun.glass.ui.InvokeLaterDispatcher$Future.run(InvokeLaterDispatcher.java:95)
	at com.sun.glass.ui.gtk.GtkApplication._runLoop(Native Method)
	at com.sun.glass.ui.gtk.GtkApplication.lambda$null$203(GtkApplication.java:139)
	at java.lang.Thread.run(Thread.java:748)
```