### PR TITLE
Move locked segments into state rather than backend [BUGFIX]

### DIFF
--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/label/ConnectomicsLabelBackend.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/label/ConnectomicsLabelBackend.kt
@@ -9,9 +9,6 @@ import org.janelia.saalfeldlab.paintera.state.SourceStateBackend
 
 interface ConnectomicsLabelBackend<D, T> : SourceStateBackend<D, T> {
 
-	// TODO should these be properties or rather factory methods?
-	val lockedSegments: LockedSegmentsState
-
 	val fragmentSegmentAssignment: FragmentSegmentAssignmentState
 
 	val providesLookup: Boolean

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/label/LabelSourceStateFallbackDeserializer.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/label/LabelSourceStateFallbackDeserializer.kt
@@ -84,6 +84,7 @@ class LabelSourceStateFallbackDeserializer<D, T>(
                     .also { s -> with (GsonExtensions) { s.applyActions(json.getProperty("assignment")?.getProperty("data")?.getJsonArray("actions"), context) } }
                     .also { s -> with (GsonExtensions) { s.loadMeshSettings(json.getJsonObject("meshSettings"), context) } }
                     .also { arguments.convertDeprecatedDatasets.wereAnyConverted.value = true }
+                    .also { s -> with (GsonExtensions) { json.getProperty("lockedSegments")?.let { context.deserialize<LongArray>(it, LongArray::class.java) }?.forEach { s.lockedSegments.lock(it) } } }
 		} ?: run {
 			// TODO should this throw an exception instead? could be handled downstream with fall-back and a warning dialog
               LOG.warn(

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/label/n5/N5BackendMultiScaleGroup.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/label/n5/N5BackendMultiScaleGroup.kt
@@ -56,7 +56,6 @@ class N5BackendMultiScaleGroup<D, T> constructor(
 			propagationExecutorService)
 	}
 
-	override val lockedSegments: LockedSegmentsState = LockedSegmentsOnlyLocal(Consumer {})
 	override val fragmentSegmentAssignment = FragmentSegmentAssignmentOnlyLocal(
 		FragmentSegmentAssignmentOnlyLocal.NO_INITIAL_LUT_AVAILABLE,
 		FragmentSegmentAssignmentOnlyLocal.doesNotPersist(persistError(dataset)))
@@ -98,7 +97,6 @@ class N5BackendMultiScaleGroup<D, T> constructor(
 		const val CONTAINER = "container"
 		const val DATASET = "dataset"
 		const val FRAGMENT_SEGMENT_ASSIGNMENT = "fragmentSegmentAssignment"
-		const val LOCKED_SEGMENTS = "lockedSegments"
 	}
 
 	@Plugin(type = PainteraSerialization.PainteraSerializer::class)
@@ -114,7 +112,6 @@ class N5BackendMultiScaleGroup<D, T> constructor(
 				map.add(CONTAINER, SerializationHelpers.serializeWithClassInfo(backend.container, context))
 				map.addProperty(DATASET, backend.dataset)
 				map.add(FRAGMENT_SEGMENT_ASSIGNMENT, context.serialize(FragmentSegmentAssignmentActions(backend.fragmentSegmentAssignment)))
-				map.add(LOCKED_SEGMENTS, context.serialize(backend.lockedSegments.lockedSegmentsCopy()))
 			}
 			return map
 		}

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/label/n5/N5BackendPainteraDataset.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/label/n5/N5BackendPainteraDataset.kt
@@ -64,7 +64,6 @@ class N5BackendPainteraDataset<D, T> constructor(
 			propagationExecutorService)
 	}
 
-	override val lockedSegments: LockedSegmentsState = LockedSegmentsOnlyLocal(Consumer {})
 	override val fragmentSegmentAssignment = N5Helpers.assignments(container, dataset)!!
 	override val providesLookup = true
 
@@ -152,7 +151,6 @@ class N5BackendPainteraDataset<D, T> constructor(
 		const val CONTAINER = "container"
 		const val DATASET = "dataset"
 		const val FRAGMENT_SEGMENT_ASSIGNMENT = "fragmentSegmentAssignment"
-		const val LOCKED_SEGMENTS = "lockedSegments"
 	}
 
 	@Plugin(type = PainteraSerialization.PainteraSerializer::class)
@@ -168,7 +166,6 @@ class N5BackendPainteraDataset<D, T> constructor(
 				map.add(CONTAINER, SerializationHelpers.serializeWithClassInfo(backend.container, context))
 				map.addProperty(DATASET, backend.dataset)
 				map.add(FRAGMENT_SEGMENT_ASSIGNMENT, context.serialize(FragmentSegmentAssignmentActions(backend.fragmentSegmentAssignment)))
-				map.add(LOCKED_SEGMENTS, context.serialize(backend.lockedSegments.lockedSegmentsCopy()))
 			}
 			return map
 		}

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/label/n5/N5BackendSingleScaleDataset.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/label/n5/N5BackendSingleScaleDataset.kt
@@ -56,7 +56,6 @@ class N5BackendSingleScaleDataset<D, T> constructor(
 			propagationExecutorService)
 	}
 
-	override val lockedSegments: LockedSegmentsState = LockedSegmentsOnlyLocal(Consumer {})
 	override val fragmentSegmentAssignment = FragmentSegmentAssignmentOnlyLocal(
 		FragmentSegmentAssignmentOnlyLocal.NO_INITIAL_LUT_AVAILABLE,
 		FragmentSegmentAssignmentOnlyLocal.doesNotPersist(persistError(dataset)))
@@ -94,7 +93,6 @@ class N5BackendSingleScaleDataset<D, T> constructor(
 		const val CONTAINER = "container"
 		const val DATASET = "dataset"
 		const val FRAGMENT_SEGMENT_ASSIGNMENT = "fragmentSegmentAssignment"
-		const val LOCKED_SEGMENTS = "lockedSegments"
 	}
 
 	@Plugin(type = PainteraSerialization.PainteraSerializer::class)
@@ -110,7 +108,6 @@ class N5BackendSingleScaleDataset<D, T> constructor(
 				map.add(CONTAINER, SerializationHelpers.serializeWithClassInfo(backend.container, context))
 				map.addProperty(DATASET, backend.dataset)
 				map.add(FRAGMENT_SEGMENT_ASSIGNMENT, context.serialize(FragmentSegmentAssignmentActions(backend.fragmentSegmentAssignment)))
-				map.add(LOCKED_SEGMENTS, context.serialize(backend.lockedSegments.lockedSegmentsCopy()))
 			}
 			return map
 		}


### PR DESCRIPTION
So far, there is no reason to provide locked segments via the backend but it may happen in the future.

@cpatrickc noticed that locked segments did not appear locked when converting deprecated datasets. This commit addresses this issue.