### PR TITLE
Fix display status of ConnectomicsLabelState

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars.java
@@ -185,7 +185,7 @@ public class BorderPaneWithStatusBars
 			currentSourceStatus.textProperty().unbind();
 			currentSourceStatus.textProperty().bind(Bindings.createStringBinding(
 					() -> {
-						if (newv.statusTextProperty() != null && newv.statusTextProperty().get() != null)
+						if (newv.statusTextProperty() != null && newv.statusTextProperty().get() != null && !newv.statusTextProperty().get().isEmpty())
 							return newv.statusTextProperty().get();
 						else if (newv.nameProperty().get() != null)
 							return newv.nameProperty().get();

--- a/src/main/java/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars2.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars2.kt
@@ -274,7 +274,7 @@ class BorderPaneWithStatusBars2(private val paintera: PainteraMainWindow) {
             newv?.let {
 				currentSourceStatus.textProperty().bind(Bindings.createStringBinding(
 						Callable {
-							if (it.statusTextProperty() != null && it.statusTextProperty().get() != null)
+							if (it.statusTextProperty() != null && it.statusTextProperty().get() != null && !it.statusTextProperty().get().isEmpty())
 								newv.statusTextProperty().get()
 							else if (newv.nameProperty().get() != null)
 								newv.nameProperty().get()

--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/SelectNextId.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/paint/SelectNextId.java
@@ -1,18 +1,12 @@
 package org.janelia.saalfeldlab.paintera.control.paint;
 
-import java.lang.invoke.MethodHandles;
-import java.util.function.BiConsumer;
-
-import bdv.viewer.Source;
 import org.janelia.saalfeldlab.paintera.control.selection.SelectedIds;
 import org.janelia.saalfeldlab.paintera.id.IdService;
-import org.janelia.saalfeldlab.paintera.state.HasIdService;
-import org.janelia.saalfeldlab.paintera.state.HasSelectedIds;
-import org.janelia.saalfeldlab.paintera.state.LabelSourceState;
-import org.janelia.saalfeldlab.paintera.state.SourceInfo;
-import org.janelia.saalfeldlab.paintera.state.SourceState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.util.function.BiConsumer;
 
 public class SelectNextId
 {

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/HasFloodFillState.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/HasFloodFillState.java
@@ -2,6 +2,7 @@ package org.janelia.saalfeldlab.paintera.state;
 
 import javafx.beans.property.ObjectProperty;
 
+@Deprecated
 public interface HasFloodFillState {
 
 	public static class FloodFillState {

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/HasFragmentSegmentAssignments.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/HasFragmentSegmentAssignments.java
@@ -2,6 +2,7 @@ package org.janelia.saalfeldlab.paintera.state;
 
 import org.janelia.saalfeldlab.paintera.control.assignment.FragmentSegmentAssignmentState;
 
+@Deprecated
 public interface HasFragmentSegmentAssignments {
 
 	public FragmentSegmentAssignmentState assignment();

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/HasHighlightingStreamConverter.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/HasHighlightingStreamConverter.java
@@ -2,6 +2,7 @@ package org.janelia.saalfeldlab.paintera.state;
 
 import org.janelia.saalfeldlab.paintera.stream.HighlightingStreamConverter;
 
+@Deprecated
 public interface HasHighlightingStreamConverter<T> {
 
 	HighlightingStreamConverter<T> highlightingStreamConverter();

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/HasIdService.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/HasIdService.java
@@ -2,6 +2,7 @@ package org.janelia.saalfeldlab.paintera.state;
 
 import org.janelia.saalfeldlab.paintera.id.IdService;
 
+@Deprecated
 public interface HasIdService {
 
 	IdService idService();

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/HasLockedSegments.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/HasLockedSegments.java
@@ -2,6 +2,7 @@ package org.janelia.saalfeldlab.paintera.state;
 
 import org.janelia.saalfeldlab.paintera.control.lock.LockedSegmentsState;
 
+@Deprecated
 public interface HasLockedSegments {
 
 	LockedSegmentsState lockedSegments();

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/HasMaskForLabel.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/HasMaskForLabel.java
@@ -6,6 +6,7 @@ import net.imglib2.type.numeric.IntegerType;
 
 import java.util.function.LongFunction;
 
+@Deprecated
 public interface HasMaskForLabel<T extends IntegerType<T>> {
 
 	LongFunction<Converter<T, BoolType>> maskForLabel();

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/HasMeshCache.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/HasMeshCache.java
@@ -2,6 +2,7 @@ package org.janelia.saalfeldlab.paintera.state;
 
 import java.util.function.Predicate;
 
+@Deprecated
 public interface HasMeshCache<T>
 {
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/HasMeshes.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/HasMeshes.java
@@ -3,6 +3,7 @@ package org.janelia.saalfeldlab.paintera.state;
 import org.janelia.saalfeldlab.paintera.meshes.ManagedMeshSettings;
 import org.janelia.saalfeldlab.paintera.meshes.MeshManager;
 
+@Deprecated
 public interface HasMeshes<T>
 {
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/HasSelectedIds.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/HasSelectedIds.java
@@ -2,6 +2,7 @@ package org.janelia.saalfeldlab.paintera.state;
 
 import org.janelia.saalfeldlab.paintera.control.selection.SelectedIds;
 
+@Deprecated
 public interface HasSelectedIds {
 
 	SelectedIds selectedIds();

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/label/ConnectomicsLabelState.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/label/ConnectomicsLabelState.kt
@@ -325,7 +325,7 @@ class ConnectomicsLabelState<D: IntegerType<D>, T>(
 			},
 			false,
 			"_Skip")
-}
+    }
 
 	override fun onShutdown(paintera: PainteraBaseView) {
 		CommitHandler.showCommitDialog(
@@ -373,7 +373,9 @@ class ConnectomicsLabelState<D: IntegerType<D>, T>(
 						activeIdText.append("Segment: $segmentId").append(". ")
 					activeIdText.append("Fragment: $lastSelectedLabelId")
 					lastSelectedLabelColorRectTooltip.text = activeIdText.toString()
-				}
+				} else {
+                    lastSelectedLabelColorRect.isVisible = false;
+                }
 			}
 		}
 		selectedIds.addListener(lastSelectedIdUpdater)
@@ -417,8 +419,7 @@ class ConnectomicsLabelState<D: IntegerType<D>, T>(
 			val maskedSource = this.dataSource as MaskedSource<D, *>
 			maskedSource.isApplyingMaskProperty().addListener { _, _, newv ->
 				InvokeOnJavaFXApplicationThread.invoke {
-					paintingProgressIndicator.isVisible =
-						newv!!
+					paintingProgressIndicator.isVisible = newv
 					if (newv) {
 						val currentMask = maskedSource.getCurrentMask()
 						if (currentMask != null)
@@ -428,7 +429,7 @@ class ConnectomicsLabelState<D: IntegerType<D>, T>(
 			}
 		}
 
-		this.floodFillState.addListener { obs, oldv, newv ->
+		this.floodFillState.addListener { _, _, newv ->
 			InvokeOnJavaFXApplicationThread.invoke {
 				if (newv != null) {
 					paintingProgressIndicator.isVisible = true


### PR DESCRIPTION
Fixes #370

Progress indication and cancellation of 3D flood-fill didn't work because `ConnectomicsLabelState` didn't implement `HasFloodFillState`. I added an implementation of this interface and also implemented the rest of the 'marker' interfaces similar to how it's done in `LabelSourceState` (such as `HasMeshes`, `HasSelectedIds`, and so on). I'm not quite sure where and if it's actually used, but some of these interfaces are a bit superfluous, and perhaps they can be removed or merged into one less granular interface.