### PR TITLE
Explicitly add https repo for jcenter.bintray in changelog creation script

### DIFF
--- a/create-changelog.kts
+++ b/create-changelog.kts
@@ -1,5 +1,7 @@
 #!/usr/bin/env kscript
 
+@file:MavenRepository("bintray.https", "https://jcenter.bintray.com")
+
 @file:DependsOn("org.json:json:20180813")
 @file:DependsOn("org.apache.maven:maven-model:3.6.1")
 @file:DependsOn("org.eclipse.jgit:org.eclipse.jgit:5.4.0.201906121030-r")


### PR DESCRIPTION
This is necessary becayse `http://jcenter.bintray.com` would be used instead and jcenter.bintray fails with 403 instead of redirecting to https