### PR TITLE
Orthoslices transparency

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars.java
@@ -155,7 +155,6 @@ public class BorderPaneWithStatusBars
 		this.orthoSlicesManager = new OrthoSlicesManager(
 				center.viewer3D().sceneGroup(),
 				center.orthogonalViews(),
-				center.manager(),
 				center.viewer3D().eyeToWorldTransformProperty());
 
 		final StackPane sourceDisplayStatus = new StackPane();

--- a/src/main/java/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars.java
@@ -11,22 +11,10 @@ import javafx.beans.value.ObservableObjectValue;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.geometry.Insets;
-import javafx.scene.Group;
-import javafx.scene.control.Button;
-import javafx.scene.control.CheckBox;
-import javafx.scene.control.Label;
-import javafx.scene.control.ScrollPane;
+import javafx.scene.control.*;
 import javafx.scene.control.ScrollPane.ScrollBarPolicy;
-import javafx.scene.control.TitledPane;
-import javafx.scene.control.Tooltip;
 import javafx.scene.input.MouseEvent;
-import javafx.scene.layout.BorderPane;
-import javafx.scene.layout.GridPane;
-import javafx.scene.layout.HBox;
-import javafx.scene.layout.Priority;
-import javafx.scene.layout.Region;
-import javafx.scene.layout.StackPane;
-import javafx.scene.layout.VBox;
+import javafx.scene.layout.*;
 import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
 import net.imglib2.RealPoint;
@@ -34,19 +22,12 @@ import org.janelia.saalfeldlab.fx.ortho.OrthogonalViews;
 import org.janelia.saalfeldlab.fx.ortho.OrthogonalViews.ViewerAndTransforms;
 import org.janelia.saalfeldlab.fx.ui.ResizeOnLeftSide;
 import org.janelia.saalfeldlab.fx.util.InvokeOnJavaFXApplicationThread;
-import org.janelia.saalfeldlab.paintera.config.ArbitraryMeshConfigNode;
-import org.janelia.saalfeldlab.paintera.config.BookmarkConfigNode;
-import org.janelia.saalfeldlab.paintera.config.CrosshairConfigNode;
-import org.janelia.saalfeldlab.paintera.config.NavigationConfigNode;
-import org.janelia.saalfeldlab.paintera.config.OrthoSliceConfigNode;
-import org.janelia.saalfeldlab.paintera.config.ScaleBarOverlayConfigNode;
-import org.janelia.saalfeldlab.paintera.config.ScreenScalesConfigNode;
-import org.janelia.saalfeldlab.paintera.config.Viewer3DConfigNode;
+import org.janelia.saalfeldlab.paintera.config.*;
 import org.janelia.saalfeldlab.paintera.control.navigation.CoordinateDisplayListener;
-import org.janelia.saalfeldlab.paintera.state.SourceInfo;
 import org.janelia.saalfeldlab.paintera.ui.Crosshair;
 import org.janelia.saalfeldlab.paintera.ui.source.SourceTabs2;
 import org.janelia.saalfeldlab.paintera.viewer3d.OrthoSliceFX;
+import org.janelia.saalfeldlab.paintera.viewer3d.OrthoSlicesManager;
 import org.janelia.saalfeldlab.util.Colors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -99,7 +80,7 @@ public class BorderPaneWithStatusBars
 
 	private final Map<ViewerAndTransforms, Crosshair> crossHairs;
 
-	private final Map<ViewerAndTransforms, OrthoSliceFX> orthoSlices;
+	private final OrthoSlicesManager orthoSlicesManager;
 
 	private final ObservableObjectValue<ViewerAndTransforms> currentFocusHolderWithState;
 
@@ -143,7 +124,7 @@ public class BorderPaneWithStatusBars
 
 	public Map<ViewerAndTransforms, OrthoSliceFX> orthoSlices()
 	{
-		return Collections.unmodifiableMap(this.orthoSlices);
+		return this.orthoSlicesManager.getOrthoSlices();
 	}
 
 	public BorderPaneWithStatusBars(
@@ -171,13 +152,11 @@ public class BorderPaneWithStatusBars
 		this.crossHairs = makeCrosshairs(center.orthogonalViews(), Colors.CREMI, Color.WHITE.deriveColor(0, 1, 1,
 				0.5));
 
-		final Group orthoslicesGroup = new Group();
-		center.viewer3D().sceneGroup().getChildren().add(orthoslicesGroup);
-		this.orthoSlices = makeOrthoSlices(
+		this.orthoSlicesManager = new OrthoSlicesManager(
+				center.viewer3D().sceneGroup(),
 				center.orthogonalViews(),
-				orthoslicesGroup,
-				center.sourceInfo()
-			);
+				center.manager(),
+				center.viewer3D().eyeToWorldTransformProperty());
 
 		final StackPane sourceDisplayStatus = new StackPane();
 
@@ -322,18 +301,6 @@ public class BorderPaneWithStatusBars
 		ch.wasChangedProperty().addListener((obs, oldv, newv) -> viewer.getDisplay().drawOverlays());
 		ch.isHighlightProperty().bind(viewer.focusedProperty());
 		return ch;
-	}
-
-	public static Map<ViewerAndTransforms, OrthoSliceFX> makeOrthoSlices(
-			final OrthogonalViews<?> views,
-			final Group scene,
-			final SourceInfo sourceInfo)
-	{
-		final Map<ViewerAndTransforms, OrthoSliceFX> map = new HashMap<>();
-		map.put(views.topLeft(), new OrthoSliceFX(scene, views.topLeft().viewer()));
-		map.put(views.topRight(), new OrthoSliceFX(scene, views.topRight().viewer()));
-		map.put(views.bottomLeft(), new OrthoSliceFX(scene, views.bottomLeft().viewer()));
-		return map;
 	}
 
 	public static ObservableObjectValue<ViewerAndTransforms> currentFocusHolder(final OrthogonalViews<?> views)

--- a/src/main/java/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars2.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars2.kt
@@ -183,7 +183,6 @@ class BorderPaneWithStatusBars2(private val paintera: PainteraMainWindow) {
 	private val orthoSlicesManager = OrthoSlicesManager(
 		center.viewer3D().sceneGroup(),
 		center.orthogonalViews(),
-        center.manager(),
 		center.viewer3D().eyeToWorldTransformProperty())
 
 	private val crossHairs = makeCrosshairs(

--- a/src/main/java/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars2.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars2.kt
@@ -18,7 +18,8 @@ import net.imglib2.RealPoint
 import org.janelia.saalfeldlab.fx.Buttons
 import org.janelia.saalfeldlab.fx.ortho.OrthogonalViews
 import org.janelia.saalfeldlab.fx.ortho.OrthogonalViews.ViewerAndTransforms
-import org.janelia.saalfeldlab.fx.ui.*
+import org.janelia.saalfeldlab.fx.ui.Exceptions
+import org.janelia.saalfeldlab.fx.ui.ResizeOnLeftSide
 import org.janelia.saalfeldlab.fx.util.InvokeOnJavaFXApplicationThread
 import org.janelia.saalfeldlab.paintera.config.*
 import org.janelia.saalfeldlab.paintera.control.navigation.CoordinateDisplayListener
@@ -27,7 +28,7 @@ import org.janelia.saalfeldlab.paintera.ui.FontAwesome
 import org.janelia.saalfeldlab.paintera.ui.PainteraAlerts
 import org.janelia.saalfeldlab.paintera.ui.source.SourceTabs2
 import org.janelia.saalfeldlab.paintera.viewer3d.OrthoSliceFX
-import org.janelia.saalfeldlab.paintera.viewer3d.Viewer3DFX
+import org.janelia.saalfeldlab.paintera.viewer3d.OrthoSlicesManager
 import org.janelia.saalfeldlab.util.Colors
 import org.slf4j.LoggerFactory
 import java.io.File
@@ -179,7 +180,11 @@ class BorderPaneWithStatusBars2(private val paintera: PainteraMainWindow) {
 
 	private val scrollPane: ScrollPane
 
-	private val orthoSlices = makeOrthoSlices(center.orthogonalViews(), center.viewer3D())
+	private val orthoSlicesManager = OrthoSlicesManager(
+		center.viewer3D().sceneGroup(),
+		center.orthogonalViews(),
+        center.manager(),
+		center.viewer3D().eyeToWorldTransformProperty())
 
 	private val crossHairs = makeCrosshairs(
 			center.orthogonalViews(),
@@ -202,7 +207,7 @@ class BorderPaneWithStatusBars2(private val paintera: PainteraMainWindow) {
 
     private val crosshairConfigNode = CrosshairConfigNode(properties.crosshairConfig.also { it.bindCrosshairsToConfig(crossHairs.values) })
 
-    private val orthoSliceConfigNode = OrthoSliceConfigNode(OrthoSliceConfig(properties.orthoSliceConfig, center) { orthoSlices[it]!! })
+    private val orthoSliceConfigNode = OrthoSliceConfigNode(OrthoSliceConfig(properties.orthoSliceConfig, center) { orthoSlices()[it]!! })
 
     private val viewer3DConfigNode = Viewer3DConfigNode(properties.viewer3DConfig)
 
@@ -254,7 +259,7 @@ class BorderPaneWithStatusBars2(private val paintera: PainteraMainWindow) {
     }
 
     fun orthoSlices(): Map<ViewerAndTransforms, OrthoSliceFX> {
-        return Collections.unmodifiableMap(this.orthoSlices)
+        return orthoSlicesManager.orthoSlices;
     }
 
     init {
@@ -412,16 +417,6 @@ class BorderPaneWithStatusBars2(private val paintera: PainteraMainWindow) {
             ch.wasChangedProperty().addListener { _, _, _ -> viewer.display.drawOverlays() }
             ch.isHighlightProperty.bind(viewer.focusedProperty())
             return ch
-        }
-
-        fun makeOrthoSlices(views: OrthogonalViews<*>, viewer3D: Viewer3DFX): Map<ViewerAndTransforms, OrthoSliceFX> {
-			val orthoSlicesGroup = Group()
-			viewer3D.sceneGroup().children.add(orthoSlicesGroup)
-            val map = HashMap<ViewerAndTransforms, OrthoSliceFX>()
-            map[views.topLeft()] = OrthoSliceFX(orthoSlicesGroup, views.topLeft().viewer())
-            map[views.topRight()] = OrthoSliceFX(orthoSlicesGroup, views.topRight().viewer())
-            map[views.bottomLeft()] = OrthoSliceFX(orthoSlicesGroup, views.bottomLeft().viewer())
-            return map
         }
 
         fun currentFocusHolder(views: OrthogonalViews<*>): ObservableObjectValue<ViewerAndTransforms?> {

--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/OrthoSliceConfig.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/OrthoSliceConfig.kt
@@ -1,6 +1,7 @@
 package org.janelia.saalfeldlab.paintera.config
 
 import javafx.beans.property.BooleanProperty
+import javafx.beans.property.DoubleProperty
 import javafx.beans.value.ObservableBooleanValue
 import org.janelia.saalfeldlab.fx.ortho.OrthogonalViews
 import org.janelia.saalfeldlab.paintera.PainteraBaseView
@@ -42,6 +43,8 @@ class OrthoSliceConfig(
 
     fun showBottomLeftProperty(): BooleanProperty = this.baseConfig.showBottomLeftProperty()
 
+    fun opacityProperty(): DoubleProperty = this.baseConfig.opacityProperty()
+
     fun bindOrthoSlicesToConfig(
             topLeft: OrthoSliceFX,
             topRight: OrthoSliceFX,
@@ -50,5 +53,9 @@ class OrthoSliceConfig(
         topLeft.isVisibleProperty.bind(baseConfig.showTopLeftProperty().and(enable).and(hasSources).and(isTopLeftVisible))
         topRight.isVisibleProperty.bind(baseConfig.showTopRightProperty().and(enable).and(hasSources).and(isTopRightVisible))
         bottomLeft.isVisibleProperty.bind(baseConfig.showBottomLeftProperty().and(enable).and(hasSources).and(isBottomLeftVisible))
+
+        topLeft.opacityProperty().bind(baseConfig.opacityProperty())
+        topRight.opacityProperty().bind(baseConfig.opacityProperty())
+        bottomLeft.opacityProperty().bind(baseConfig.opacityProperty())
     }
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/OrthoSliceConfig.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/OrthoSliceConfig.kt
@@ -45,6 +45,8 @@ class OrthoSliceConfig(
 
     fun opacityProperty(): DoubleProperty = this.baseConfig.opacityProperty()
 
+    fun shadingProperty(): DoubleProperty = this.baseConfig.shadingProperty()
+
     fun bindOrthoSlicesToConfig(
             topLeft: OrthoSliceFX,
             topRight: OrthoSliceFX,
@@ -57,5 +59,9 @@ class OrthoSliceConfig(
         topLeft.opacityProperty().bind(baseConfig.opacityProperty())
         topRight.opacityProperty().bind(baseConfig.opacityProperty())
         bottomLeft.opacityProperty().bind(baseConfig.opacityProperty())
+
+        topLeft.shadingProperty().bind(baseConfig.shadingProperty())
+        topRight.shadingProperty().bind(baseConfig.shadingProperty())
+        bottomLeft.shadingProperty().bind(baseConfig.shadingProperty())
     }
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/OrthoSliceConfigBase.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/OrthoSliceConfigBase.java
@@ -18,6 +18,8 @@ public class OrthoSliceConfigBase
 
 	private final SimpleDoubleProperty opacity = new SimpleDoubleProperty(1.0);
 
+	private final SimpleDoubleProperty shading = new SimpleDoubleProperty(0.1);
+
 	public BooleanProperty isEnabledProperty()
 	{
 		return this.enabled;
@@ -41,5 +43,10 @@ public class OrthoSliceConfigBase
 	public DoubleProperty opacityProperty()
 	{
 		return this.opacity;
+	}
+
+	public DoubleProperty shadingProperty()
+	{
+		return this.shading;
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/OrthoSliceConfigBase.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/OrthoSliceConfigBase.java
@@ -1,7 +1,9 @@
 package org.janelia.saalfeldlab.paintera.config;
 
 import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleDoubleProperty;
 
 public class OrthoSliceConfigBase
 {
@@ -13,6 +15,8 @@ public class OrthoSliceConfigBase
 	private final SimpleBooleanProperty showTopRight = new SimpleBooleanProperty(true);
 
 	private final SimpleBooleanProperty showBottomLeft = new SimpleBooleanProperty(true);
+
+	private final SimpleDoubleProperty opacity = new SimpleDoubleProperty(1.0);
 
 	public BooleanProperty isEnabledProperty()
 	{
@@ -32,5 +36,10 @@ public class OrthoSliceConfigBase
 	public BooleanProperty showBottomLeftProperty()
 	{
 		return this.showBottomLeft;
+	}
+
+	public DoubleProperty opacityProperty()
+	{
+		return this.opacity;
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/OrthoSliceConfigNode.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/OrthoSliceConfigNode.kt
@@ -39,7 +39,7 @@ class OrthoSliceConfigNode() {
                 .also { it.slider.isShowTickLabels = true }
                 .also { it.slider.tooltip = Tooltip(ttText) }
                 .also { it.textField.prefWidth = textFieldWidth }
-                .also { GridPane.setHgrow(it.slider(), Priority.ALWAYS) }
+                .also { GridPane.setHgrow(it.slider, Priority.ALWAYS) }
         }
 
         grid.add(Labels.withTooltip("Opacity"), 0, row)

--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/OrthoSliceConfigNode.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/OrthoSliceConfigNode.kt
@@ -4,8 +4,11 @@ import javafx.scene.Node
 import javafx.scene.control.CheckBox
 import javafx.scene.control.Label
 import javafx.scene.control.TitledPane
+import javafx.scene.control.Tooltip
 import javafx.scene.layout.GridPane
 import javafx.scene.layout.Priority
+import org.janelia.saalfeldlab.fx.Labels
+import org.janelia.saalfeldlab.fx.ui.NumericSliderWithField
 
 class OrthoSliceConfigNode() {
 
@@ -23,21 +26,43 @@ class OrthoSliceConfigNode() {
 
     private val showOrthoViews = CheckBox()
 
+    private val opacitySlider = NumericSliderWithField(0.0, 1.0, 1.0)
+
     init {
 
         val grid = GridPane()
+        var row = 0
+        val textFieldWidth = 55.0
+
+        val setupSlider = { slider: NumericSliderWithField, ttText: String ->
+            slider
+                .also { it.slider.isShowTickLabels = true }
+                .also { it.slider.tooltip = Tooltip(ttText) }
+                .also { it.textField.prefWidth = textFieldWidth }
+                .also { GridPane.setHgrow(it.slider(), Priority.ALWAYS) }
+        }
+
+        grid.add(Labels.withTooltip("Opacity"), 0, row)
+        grid.add(opacitySlider.slider, 1, row)
+        GridPane.setColumnSpan(opacitySlider.slider, 2)
+        grid.add(opacitySlider.textField, 3, row)
+        setupSlider(opacitySlider, "Opacity")
+        ++row
 
         val topLeftLabel = Label("top left")
         val topRightLabel = Label("top right")
         val bottomLeftLabel = Label("bottom left")
 
-        grid.add(topLeftLabel, 0, 0)
-        grid.add(topRightLabel, 0, 1)
-        grid.add(bottomLeftLabel, 0, 2)
+        grid.add(topLeftLabel, 0, row)
+        grid.add(topLeftCheckBox, 1, row)
+        ++row
 
-        grid.add(topLeftCheckBox, 1, 0)
-        grid.add(topRightCheckBox, 1, 1)
-        grid.add(bottomLeftCheckBox, 1, 2)
+        grid.add(topRightLabel, 0, row)
+        grid.add(topRightCheckBox, 1, row)
+        ++row
+
+        grid.add(bottomLeftLabel, 0, row)
+        grid.add(bottomLeftCheckBox, 1, row)
 
         GridPane.setHgrow(topLeftLabel, Priority.ALWAYS)
         GridPane.setHgrow(topRightLabel, Priority.ALWAYS)
@@ -53,6 +78,7 @@ class OrthoSliceConfigNode() {
         topLeftCheckBox.selectedProperty().bindBidirectional(config.showTopLeftProperty())
         topRightCheckBox.selectedProperty().bindBidirectional(config.showTopRightProperty())
         bottomLeftCheckBox.selectedProperty().bindBidirectional(config.showBottomLeftProperty())
+        opacitySlider.slider.valueProperty().bindBidirectional(config.opacityProperty())
     }
 
     fun getContents(): Node {

--- a/src/main/java/org/janelia/saalfeldlab/paintera/config/OrthoSliceConfigNode.kt
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/config/OrthoSliceConfigNode.kt
@@ -28,6 +28,8 @@ class OrthoSliceConfigNode() {
 
     private val opacitySlider = NumericSliderWithField(0.0, 1.0, 1.0)
 
+    private val shadingSlider = NumericSliderWithField(0.0, 1.0, 0.1)
+
     init {
 
         val grid = GridPane()
@@ -47,6 +49,13 @@ class OrthoSliceConfigNode() {
         GridPane.setColumnSpan(opacitySlider.slider, 2)
         grid.add(opacitySlider.textField, 3, row)
         setupSlider(opacitySlider, "Opacity")
+        ++row
+
+        grid.add(Labels.withTooltip("Shading"), 0, row)
+        grid.add(shadingSlider.slider, 1, row)
+        GridPane.setColumnSpan(shadingSlider.slider, 2)
+        grid.add(shadingSlider.textField, 3, row)
+        setupSlider(shadingSlider, "Shading")
         ++row
 
         val topLeftLabel = Label("top left")
@@ -79,6 +88,7 @@ class OrthoSliceConfigNode() {
         topRightCheckBox.selectedProperty().bindBidirectional(config.showTopRightProperty())
         bottomLeftCheckBox.selectedProperty().bindBidirectional(config.showBottomLeftProperty())
         opacitySlider.slider.valueProperty().bindBidirectional(config.opacityProperty())
+        shadingSlider.slider.valueProperty().bindBidirectional(config.shadingProperty())
     }
 
     fun getContents(): Node {

--- a/src/main/java/org/janelia/saalfeldlab/paintera/serialization/Properties.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/serialization/Properties.java
@@ -203,6 +203,7 @@ public class Properties implements TransformListener<AffineTransform3D>
 					properties.orthoSliceConfig.showTopLeftProperty().set(conf.showTopLeftProperty().get());
 					properties.orthoSliceConfig.showTopRightProperty().set(conf.showTopRightProperty().get());
 					properties.orthoSliceConfig.showBottomLeftProperty().set(conf.showBottomLeftProperty().get());
+					properties.orthoSliceConfig.opacityProperty().set(conf.opacityProperty().get());
 				});
 		Optional
 				.ofNullable(serializedProperties.get(NAVIGATION_CONFIG_KEY))

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/Geom3DUtils.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/Geom3DUtils.java
@@ -60,7 +60,7 @@ public class Geom3DUtils
 	}
 
 	/**
-	 * Returns distance from the camera to a point (the Z plane in camera space where the point is located).
+	 * Returns distance from the camera to a point.
 	 *
 	 * Note that for performance reasons the {@code point} parameter will be modified by this method!
 	 *
@@ -71,6 +71,35 @@ public class Geom3DUtils
 	public static double distanceFromCamera(final AffineTransform3D cameraToWorldTransform, final RealPoint point)
 	{
 		cameraToWorldTransform.applyInverse(point, point);
+		return length(point);
+	}
+
+	/**
+	 * Returns the Z plane coordinate in camera space where the point is located.
+	 *
+	 * Note that for performance reasons the {@code point} parameter will be modified by this method!
+	 *
+	 * @param cameraToWorldTransform
+	 * @param point
+	 * @return
+	 */
+	public static double cameraZPlane(final AffineTransform3D cameraToWorldTransform, final RealPoint point)
+	{
+		cameraToWorldTransform.applyInverse(point, point);
 		return point.getDoublePosition(2);
+	}
+
+	/**
+	 * Returns the length of the vector between (0,0,0) and the given point.
+	 *
+	 * @param point
+	 * @return
+	 */
+	public static double length(final RealPoint point)
+	{
+		double sqLen = 0;
+		for (int d = 0; d < point.numDimensions(); ++d)
+			sqLen += point.getDoublePosition(d) * point.getDoublePosition(d);
+		return Math.sqrt(sqLen);
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/Geom3DUtils.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/Geom3DUtils.java
@@ -1,0 +1,76 @@
+package org.janelia.saalfeldlab.paintera.viewer3d;
+
+import com.sun.javafx.geom.Vec3d;
+import com.sun.javafx.geom.Vec4d;
+import net.imglib2.RealPoint;
+import net.imglib2.realtransform.AffineTransform3D;
+
+@SuppressWarnings("restriction")
+public class Geom3DUtils
+{
+	/**
+	 * Returns a 4D vector [a,b,c,d] that defines a 3D plane in the following way: ax+by+cz+d=0.
+	 *
+	 * The normal vector of the plane is calculated by taking the cross-product of the two vectors within the plane
+	 * formed between 3 points that are passed as parameters: P1->P2 and P1->P3.
+	 *
+	 * @param p1
+	 * @param p2
+	 * @param p3
+	 * @return
+	 */
+	public static Vec4d createPlane(final RealPoint p1, final RealPoint p2, final RealPoint p3)
+	{
+		// p1 -> p2
+		final Vec3d p12 = new Vec3d(
+				p2.getDoublePosition(0) - p1.getDoublePosition(0),
+				p2.getDoublePosition(1) - p1.getDoublePosition(1),
+				p2.getDoublePosition(2) - p1.getDoublePosition(2));
+
+		// p1 -> p3
+		final Vec3d p13 = new Vec3d(
+				p3.getDoublePosition(0) - p1.getDoublePosition(0),
+				p3.getDoublePosition(1) - p1.getDoublePosition(1),
+				p3.getDoublePosition(2) - p1.getDoublePosition(2));
+
+		final Vec3d normal = new Vec3d();
+		normal.cross(p12, p13);
+		normal.normalize();
+
+		// plug the coordinates of any given point in the plane into the plane equation to find the last component of the equation
+		final double d = -normal.dot(new Vec3d(p1.getDoublePosition(0), p1.getDoublePosition(1), p1.getDoublePosition(2)));
+
+		return new Vec4d(normal.x, normal.y, normal.z, d);
+	}
+
+	/**
+	 * Returns distance from the given plane to a point.
+	 *
+	 * @param plane
+	 * @param vector
+	 * @return
+	 */
+	public static double planeToPointDistance(final Vec4d plane, final Vec3d vector)
+	{
+		return
+				plane.x * vector.x +
+				plane.y * vector.y +
+				plane.z * vector.z +
+				plane.w;
+	}
+
+	/**
+	 * Returns distance from the camera to a point (the Z plane in camera space where the point is located).
+	 *
+	 * Note that for performance reasons the {@code point} parameter will be modified by this method!
+	 *
+	 * @param cameraToWorldTransform
+	 * @param point
+	 * @return
+	 */
+	public static double distanceFromCamera(final AffineTransform3D cameraToWorldTransform, final RealPoint point)
+	{
+		cameraToWorldTransform.applyInverse(point, point);
+		return point.getDoublePosition(2);
+	}
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceFX.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceFX.java
@@ -11,7 +11,9 @@ import org.janelia.saalfeldlab.util.fx.Transforms;
 import bdv.fx.viewer.ViewerPanelFX;
 import bdv.fx.viewer.render.RenderUnit;
 import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleDoubleProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
@@ -70,6 +72,13 @@ public class OrthoSliceFX
 					InvokeOnJavaFXApplicationThread.invoke(() -> this.getScene().getChildren().remove(meshesGroup));
 				}
 			}
+		});
+	}
+
+	private final DoubleProperty opacity = new SimpleDoubleProperty(1.0);
+	{
+		this.opacity.addListener((obs, oldv, newv) -> {
+			((PhongMaterial) this.meshViews.get(0).getMaterial()).setDiffuseColor(new Color(0, 0, 0, newv.doubleValue()));
 		});
 	}
 
@@ -200,7 +209,10 @@ public class OrthoSliceFX
 		final PhongMaterial material = new PhongMaterial();
 		mv.setCullFace(CullFace.NONE);
 		mv.setMaterial(material);
-		material.setDiffuseColor(Color.BLACK);
+
+		// NOTE: the opacity property of the MeshView object does not have any effect.
+		// But the transparency can still be controlled by modifying the opacity value of the diffuse color.
+		material.setDiffuseColor(new Color(0, 0, 0, this.opacity.get()));
 		material.setSpecularColor(Color.BLACK);
 
 		newMeshViews.add(mv);
@@ -228,4 +240,8 @@ public class OrthoSliceFX
 		return this.isVisible;
 	}
 
+	public DoubleProperty opacityProperty()
+	{
+		return this.opacity;
+	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceFX.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceFX.java
@@ -174,7 +174,7 @@ public class OrthoSliceFX extends ObservableWithListenersList
 		for (int x = 0; x < (int) textureImagePair.getA().getWidth(); ++x) {
 			for (int y = 0; y < (int) textureImagePair.getA().getHeight(); ++y) {
 				final Color c = pixelReader.getColor(x, y);
-				pixelWriter.setColor(x, y, new Color(c.getRed(), c.getGreen(), c.getBlue(), alpha));
+				pixelWriter.setColor(x, y, c.deriveColor(0, 1, 1, alpha));
 			}
 		}
 	}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceFX.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceFX.java
@@ -9,7 +9,10 @@ import javafx.scene.image.WritableImage;
 import javafx.scene.paint.Color;
 import javafx.scene.paint.PhongMaterial;
 import javafx.scene.transform.Affine;
-import net.imglib2.*;
+import net.imglib2.FinalDimensions;
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
+import net.imglib2.RealPoint;
 import net.imglib2.util.Intervals;
 import net.imglib2.util.Pair;
 import net.imglib2.util.ValuePair;
@@ -59,11 +62,11 @@ public class OrthoSliceFX extends ObservableWithListenersList
 		this.viewer = viewer;
 
 		this.viewer.addTransformListener(tf -> {
-			final Affine newTransform = Transforms.toTransformFX(tf.inverse());
-			InvokeOnJavaFXApplicationThread.invoke(() -> viewerTransformFX.setToTransform(newTransform));
+			viewerTransformFX.setToTransform(Transforms.toTransformFX(tf.inverse()));
+			stateChanged();
 		});
 
-		this.viewer.getRenderUnit().addUpdateListener(() -> InvokeOnJavaFXApplicationThread.invoke(this::initializeMeshes));
+		this.viewer.getRenderUnit().addUpdateListener(this::initializeMeshes);
 		this.viewer.getRenderUnit().getRenderedImageProperty().addListener((obs, oldVal, newVal) -> updateTexture(newVal));
 		this.viewer.getRenderUnit().getScreenScalesProperty().addListener((obs, oldVal, newVal) -> updateScreenScales(newVal));
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceFX.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceFX.java
@@ -33,6 +33,8 @@ public class OrthoSliceFX
 	// this delay is used to avoid blinking when switching between different resolutions of the texture
 	private static final long textureUpdateDelayNanoSec = 1000000 * 50; // 50 msec
 
+	private static final Color textureDiffuseOpaqueColor = new Color(0.1, 0.1, 0.1, 1.0);
+
 	private final Group scene;
 
 	private final ViewerPanelFX viewer;
@@ -78,7 +80,12 @@ public class OrthoSliceFX
 	private final DoubleProperty opacity = new SimpleDoubleProperty(1.0);
 	{
 		this.opacity.addListener((obs, oldv, newv) -> {
-			((PhongMaterial) this.meshView.get().getMaterial()).setDiffuseColor(new Color(0, 0, 0, newv.doubleValue()));
+			((PhongMaterial) this.meshView.get().getMaterial()).setDiffuseColor(new Color(
+					textureDiffuseOpaqueColor.getRed(),
+					textureDiffuseOpaqueColor.getGreen(),
+					textureDiffuseOpaqueColor.getBlue(),
+					newv.doubleValue()));
+
 			if (currentTextureScreenScaleIndex != -1)
 				setTextureAlpha(textures.get(currentTextureScreenScaleIndex), newv.doubleValue());
 		});
@@ -226,8 +233,11 @@ public class OrthoSliceFX
 
 		// NOTE: the opacity property of the MeshView object does not have any effect.
 		// But the transparency can still be controlled by modifying the opacity value of the diffuse color.
-		material.setDiffuseColor(new Color(0, 0, 0, this.opacity.get()));
-		material.setSpecularColor(Color.BLACK);
+		material.setDiffuseColor(new Color(
+				textureDiffuseOpaqueColor.getRed(),
+				textureDiffuseOpaqueColor.getGreen(),
+				textureDiffuseOpaqueColor.getBlue(),
+				this.opacity.get()));
 
 		this.meshView.set(mv);
 	}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceFX.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceFX.java
@@ -12,10 +12,7 @@ import javafx.scene.paint.PhongMaterial;
 import javafx.scene.shape.CullFace;
 import javafx.scene.shape.MeshView;
 import javafx.scene.transform.Affine;
-import net.imglib2.FinalDimensions;
-import net.imglib2.FinalInterval;
-import net.imglib2.Interval;
-import net.imglib2.RealPoint;
+import net.imglib2.*;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.util.Intervals;
 import net.imglib2.util.Pair;
@@ -93,7 +90,6 @@ public class OrthoSliceFX
 
 	public OrthoSliceFX(final Group scene, final ViewerPanelFX viewer)
 	{
-		super();
 		this.scene = scene;
 		this.viewer = viewer;
 
@@ -161,9 +157,9 @@ public class OrthoSliceFX
 		final Runnable updateTextureTask = () -> InvokeOnJavaFXApplicationThread.invoke(
 			() -> {
 				// calculate new texture coordinates depending on the ratio between the screen size and the rendered image
-				final float[] texCoordMin = {0.0f, 0.0f}, texCoordMax = new float[2];
+				final RealPoint texCoordMin = new RealPoint(2), texCoordMax = new RealPoint(2);
 				for (int d = 0; d < 2; ++d)
-					texCoordMax[d] = (float) (dimensions[d] / (textureImageSize[d] / screenScales[newScreenScaleIndex]));
+					texCoordMax.setPosition(dimensions[d] / (textureImageSize[d] / screenScales[newScreenScaleIndex]), d);
 
 				((PhongMaterial) this.meshView.get().getMaterial()).setSelfIlluminationMap(textureImagePair.getB());
 				((OrthoSliceMeshFX) this.meshView.get().getMesh()).setTexCoords(texCoordMin, texCoordMax);
@@ -219,10 +215,8 @@ public class OrthoSliceFX
 		final long[] min = {0, 0}, max = this.dimensions;
 
 		final OrthoSliceMeshFX mesh = new OrthoSliceMeshFX(
-			new RealPoint(min[0], min[1]),
-			new RealPoint(max[0], min[1]),
-			new RealPoint(max[0], max[1]),
-			new RealPoint(min[0], max[1]),
+			new Point(2),
+			new Point(this.dimensions),
 			new AffineTransform3D()
 		);
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceFX.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceFX.java
@@ -72,6 +72,8 @@ public class OrthoSliceFX
 	{
 		this.opacity.addListener((obs, oldv, newv) -> {
 			((PhongMaterial) this.meshView.get().getMaterial()).setDiffuseColor(new Color(0, 0, 0, newv.doubleValue()));
+			if (currentTextureScreenScaleIndex != -1)
+				setTextureAlpha(textures.get(currentTextureScreenScaleIndex), newv.doubleValue());
 		});
 	}
 
@@ -137,6 +139,8 @@ public class OrthoSliceFX
 			(int) roi.min(1)  // src y
 		);
 
+		setTextureAlpha(textureImage, this.opacity.get());
+
 		// setup a task for setting the texture of the mesh
 		final int newScreenScaleIndex = newv.getScreenScaleIndex();
 		final Runnable updateTextureTask = () -> InvokeOnJavaFXApplicationThread.invoke(
@@ -165,6 +169,18 @@ public class OrthoSliceFX
 			// (this is to avoid blinking because of constant switching between low-res and high-res)
 			final int priority = -newv.getScreenScaleIndex();
 			delayedTextureUpdateExecutor.schedule(updateTextureTask, priority);
+		}
+	}
+
+	private void setTextureAlpha(final WritableImage textureImage, final double alpha)
+	{
+		final PixelReader pixelReader = textureImage.getPixelReader();
+		final PixelWriter pixelWriter = textureImage.getPixelWriter();
+		for (int x = 0; x < (int) textureImage.getWidth(); ++x) {
+			for (int y = 0; y < (int) textureImage.getHeight(); ++y) {
+				final Color c = pixelReader.getColor(x, y);
+				pixelWriter.setColor(x, y, new Color(c.getRed(), c.getGreen(), c.getBlue(), alpha));
+			}
 		}
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceMeshFX.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceMeshFX.java
@@ -1,118 +1,188 @@
 package org.janelia.saalfeldlab.paintera.viewer3d;
 
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
-import javafx.collections.ObservableFloatArray;
-import javafx.scene.shape.ObservableFaceArray;
-import javafx.scene.shape.TriangleMesh;
-import javafx.scene.shape.VertexFormat;
-import net.imglib2.RealLocalizable;
-import net.imglib2.RealPoint;
-import net.imglib2.RealPositionable;
-import net.imglib2.realtransform.AffineTransform3D;
-import net.imglib2.realtransform.RealTransform;
+import javafx.scene.paint.PhongMaterial;
+import javafx.scene.shape.*;
+import javafx.scene.transform.Affine;
+import net.imglib2.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Defines a rectangular mesh for displaying an orthoslice in the 3D scene.
  *
- * The mesh is made up of 8 triangles as follows:
+ * An orthoslice view is made up of 4 {@link MeshView}s consisting of 2 triangles each:
  *
- *  -------------
- *  |    /|    /|
- *  |   / |   / |
- *  |  /  |  /  |
- *  | /   | /   |
- *  |/    |/    |
- *  -------------
- *  |    /|    /|
- *  |   / |   / |
- *  |  /  |  /  |
- *  | /   | /   |
- *  |/    |/    |
- *  -------------
+ *  -------  -------
+ *  |    /|  |    /|
+ *  |   / |  |   / |
+ *  |  /  |  |  /  |
+ *  | /   |  | /   |
+ *  |/    |  |/    |
+ *  -------  -------
+ *
+ *  -------  -------
+ *  |    /|  |    /|
+ *  |   / |  |   / |
+ *  |  /  |  |  /  |
+ *  | /   |  | /   |
+ *  |/    |  |/    |
+ *  -------  -------
  */
 
-public class OrthoSliceMeshFX extends TriangleMesh
+public class OrthoSliceMeshFX
 {
 
 	public static Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-	public OrthoSliceMeshFX(
-			final RealLocalizable min,
-			final RealLocalizable max,
-			final AffineTransform3D transform)
+	private static final int[] faces = { 0, 1, 2, 0, 2, 3 };
+
+	private final List<MeshView> meshViews = new ArrayList<>();
+
+	private final List<RealInterval> meshViewIntervals = new ArrayList<>();
+
+	private final PhongMaterial material;
+
+	final float[] buf2D = new float[2];
+	final float[] buf3D = new float[3];
+
+	public OrthoSliceMeshFX(final long[] dimensions, final PhongMaterial material, final Affine viewerTransformFX)
 	{
-		setVertexFormat(VertexFormat.POINT_TEXCOORD);
+		this.material = material;
 
-		setVertices(min, max, transform);
+		final Point min = new Point(2), max = new Point(dimensions);
 
-		setTexCoords(
-				new RealPoint(0, 0),
-				new RealPoint(1, 1));
+		final List<RealPoint> vertexPoints = calculateVertexPoints(min, max);
+		final List<RealPoint> texCoordsPoints = calculateTexCoords(new Point(0, 0), new Point(1, 1));
 
-		setFaces();
+		// create 4 mesh views for each quarter, where each mesh view consists of two triangles
+		for (int row = 0; row < 2; ++row) {
+			for (int col = 0; col < 2; ++col) {
+				final TriangleMesh mesh = new TriangleMesh();
+				mesh.setVertexFormat(VertexFormat.POINT_TEXCOORD);
+
+				final int[] pointIndices = getPointIndicesForQuarter(row, col);
+
+				// set vertices
+				for (final int ptIndex : pointIndices) {
+					vertexPoints.get(ptIndex).localize(buf3D);
+					mesh.getPoints().addAll(buf3D);
+				}
+
+				// set texture coordinates
+				for (final int ptIndex : pointIndices) {
+					texCoordsPoints.get(ptIndex).localize(buf2D);
+					mesh.getTexCoords().addAll(buf2D);
+				}
+
+				// set faces
+				for (final int i : faces)
+					mesh.getFaces().addAll(i, i);
+
+				final MeshView meshView = new MeshView(mesh);
+				meshView.setCullFace(CullFace.NONE);
+				meshView.setMaterial(material);
+				meshView.getTransforms().setAll(viewerTransformFX);
+
+				meshViews.add(meshView);
+
+				final double[] meshViewMin = new double[2], meshViewMax = new double[2];
+				Arrays.fill(meshViewMin, Double.POSITIVE_INFINITY);
+				Arrays.fill(meshViewMax, Double.NEGATIVE_INFINITY);
+				for (final int ptIndex : pointIndices) {
+					final RealPoint pt = vertexPoints.get(ptIndex);
+					for (int d = 0; d < 2; ++d) {
+						meshViewMin[d] = Math.min(pt.getDoublePosition(d), meshViewMin[d]);
+						meshViewMax[d] = Math.max(pt.getDoublePosition(d), meshViewMax[d]);
+					}
+				}
+				final RealInterval meshViewInterval = new FinalRealInterval(meshViewMin, meshViewMax);
+				meshViewIntervals.add(meshViewInterval);
+			}
+		}
+	}
+
+	/**
+	 * @return
+	 * 		list of 4 {@link MeshView}s representing quarters of the orthoslice
+	 */
+	public List<MeshView> getMeshViews()
+	{
+		return meshViews;
+	}
+
+	/**
+	 * @return
+	 * 		list of 4 two-dimensional {@link RealInterval}s representing min and max positions of each quarter in the orthoslice
+	 */
+	public List<RealInterval> getMeshViewIntervals()
+	{
+		return meshViewIntervals;
+	}
+
+	public PhongMaterial getMaterial()
+	{
+		return material;
 	}
 
 	public void setTexCoords(final RealLocalizable texCoordMin, final RealLocalizable texCoordMax)
 	{
-		final ObservableFloatArray texCoords = getTexCoords();
-		texCoords.clear();
-
-		final RealPoint pt = new RealPoint(2);
-		final float[] texCoord = new float[2];
-
-		for (int row = 0; row < 3; ++row) {
-			for (int col = 0; col < 3; ++col) {
-				setCoords2D(col, row, texCoordMin, texCoordMax, pt);
-				pt.localize(texCoord);
-				texCoords.addAll(texCoord);
-			}
-		}
-	}
-
-	private void setVertices(
-			final RealLocalizable min,
-			final RealLocalizable max,
-			final AffineTransform3D transform)
-	{
-		final ObservableFloatArray vertices = getPoints();
-		vertices.clear();
-
-		final RealPoint pt = new RealPoint(3);
-		final float[] vertex = new float[3];
-
-		for (int row = 0; row < 3; ++row) {
-			for (int col = 0; col < 3; ++col) {
-				setCoords2D(col, row, min, max, pt);
-				transformPoint(pt, transform);
-				pt.localize(vertex);
-				vertices.addAll(vertex);
-			}
-		}
-	}
-
-	private void setFaces()
-	{
-		final ObservableFaceArray faces = getFaces();
-		faces.clear();
-
+		final List<RealPoint> texCoordsPoints = calculateTexCoords(texCoordMin, texCoordMax);
 		for (int row = 0; row < 2; ++row) {
 			for (int col = 0; col < 2; ++col) {
-				final int[] indices = {
-						3 * row + col,
-						3 * row + (col + 1),
-						3 * (row + 1) + (col + 1),
+				final MeshView meshView = meshViews.get(2 * row + col);
+				if (meshView == null)
+					continue;
+				final TriangleMesh mesh = (TriangleMesh) meshView.getMesh();
 
-						3 * row + col,
-						3 * (row + 1) + (col + 1),
-						3 * (row + 1) + col,
-				};
-				for (final int i : indices)
-					faces.addAll(i, i);
+				mesh.getTexCoords().clear();
+				final int[] pointIndices = getPointIndicesForQuarter(row, col);
+				for (final int ptIndex : pointIndices) {
+					texCoordsPoints.get(ptIndex).localize(buf2D);
+					mesh.getTexCoords().addAll(buf2D);
+				}
 			}
 		}
+	}
+
+	private static int[] getPointIndicesForQuarter(final int row, final int col)
+	{
+		return new int[] {
+				3 * row + col,
+				3 * row + (col + 1),
+				3 * (row + 1) + (col + 1),
+				3 * (row + 1) + col
+		};
+	}
+
+	private static List<RealPoint> calculateVertexPoints(final RealLocalizable min, final RealLocalizable max)
+	{
+		final List<RealPoint> vertexPoints = new ArrayList<>();
+		for (int row = 0; row < 3; ++row) {
+			for (int col = 0; col < 3; ++col) {
+				final RealPoint pt = new RealPoint(3);
+				setCoords2D(col, row, min, max, pt);
+				vertexPoints.add(pt);
+			}
+		}
+		return vertexPoints;
+	}
+
+	private static List<RealPoint> calculateTexCoords(final RealLocalizable texCoordMin, final RealLocalizable texCoordMax)
+	{
+		final List<RealPoint> texCoords = new ArrayList<>();
+		for (int row = 0; row < 3; ++row) {
+			for (int col = 0; col < 3; ++col) {
+				final RealPoint pt = new RealPoint(2);
+				setCoords2D(col, row, texCoordMin, texCoordMax, pt);
+				texCoords.add(pt);
+			}
+		}
+		return texCoords;
 	}
 
 	private static void setCoords2D(
@@ -136,32 +206,5 @@ public class OrthoSliceMeshFX extends TriangleMesh
 					break;
 			}
 		}
-	}
-
-	private static <T extends RealPositionable & RealLocalizable> void transformPoint(
-			final T point3D,
-			final RealTransform transform)
-	{
-		transformPoint(point3D, point3D, transform);
-	}
-
-	private static <T extends RealPositionable & RealLocalizable> void transformPoint(
-			final RealLocalizable source2D,
-			final T target3D,
-			final RealTransform transform)
-	{
-		transformPoint(source2D, target3D, transform, 0.0);
-	}
-
-	private static <T extends RealPositionable & RealLocalizable> void transformPoint(
-			final RealLocalizable source2D,
-			final T target3D,
-			final RealTransform transform,
-			final double offset)
-	{
-		target3D.setPosition(source2D.getDoublePosition(0), 0);
-		target3D.setPosition(source2D.getDoublePosition(1), 1);
-		target3D.setPosition(offset, 2);
-		transform.apply(target3D, target3D);
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceMeshFX.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceMeshFX.java
@@ -45,15 +45,13 @@ public class OrthoSliceMeshFX
 
 	private final List<RealInterval> meshViewIntervals = new ArrayList<>();
 
-	private final PhongMaterial material;
+	private final PhongMaterial material = new PhongMaterial();
 
 	final float[] buf2D = new float[2];
 	final float[] buf3D = new float[3];
 
-	public OrthoSliceMeshFX(final long[] dimensions, final PhongMaterial material, final Affine viewerTransformFX)
+	public OrthoSliceMeshFX(final long[] dimensions, final Affine viewerTransformFX)
 	{
-		this.material = material;
-
 		final Point min = new Point(2), max = new Point(dimensions);
 
 		final List<RealPoint> vertexPoints = calculateVertexPoints(min, max);

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceMeshFX.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceMeshFX.java
@@ -39,7 +39,9 @@ public class OrthoSliceMeshFX
 
 	public static Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-	private static final int[] faces = { 0, 1, 2, 0, 2, 3 };
+	// two sets of faces are required for proper shading on either side of the orthoslice
+	private static final int[] facesFront = { 0, 1, 2, 0, 2, 3 };
+	private static final int[] facesBack = { 0, 2, 1, 0, 3, 2 };
 
 	private final List<MeshView> meshViews = new ArrayList<>();
 
@@ -78,11 +80,13 @@ public class OrthoSliceMeshFX
 				}
 
 				// set faces
-				for (final int i : faces)
+				for (final int i : facesFront)
+					mesh.getFaces().addAll(i, i);
+				for (final int i : facesBack)
 					mesh.getFaces().addAll(i, i);
 
 				final MeshView meshView = new MeshView(mesh);
-				meshView.setCullFace(CullFace.NONE);
+				meshView.setCullFace(CullFace.BACK);
 				meshView.setMaterial(material);
 				meshView.getTransforms().setAll(viewerTransformFX);
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSlicesManager.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSlicesManager.java
@@ -1,0 +1,95 @@
+package org.janelia.saalfeldlab.paintera.viewer3d;
+
+import javafx.beans.property.ObjectProperty;
+import javafx.scene.Group;
+import javafx.scene.shape.MeshView;
+import net.imglib2.RealInterval;
+import net.imglib2.RealPoint;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.util.Pair;
+import net.imglib2.util.ValuePair;
+import org.janelia.saalfeldlab.fx.ortho.OrthogonalViews;
+import org.janelia.saalfeldlab.fx.ortho.OrthogonalViews.ViewerAndTransforms;
+import org.janelia.saalfeldlab.paintera.state.GlobalTransformManager;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class OrthoSlicesManager
+{
+	private final Group group = new Group();
+
+	private final Map<ViewerAndTransforms, OrthoSliceFX> map = new HashMap<>();
+
+	private final GlobalTransformManager globalTransformManager;
+
+	private final ObjectProperty<AffineTransform3D> eyeToWorldTransformProperty;
+
+	public OrthoSlicesManager(
+			final Group scene,
+			final OrthogonalViews<?> views,
+			final GlobalTransformManager globalTransformManager,
+			final ObjectProperty<AffineTransform3D> eyeToWorldTransformProperty)
+	{
+		this.globalTransformManager = globalTransformManager;
+		this.eyeToWorldTransformProperty = eyeToWorldTransformProperty;
+
+		map.put(views.topLeft(), new OrthoSliceFX(views.topLeft().viewer()));
+		map.put(views.topRight(), new OrthoSliceFX(views.topRight().viewer()));
+		map.put(views.bottomLeft(), new OrthoSliceFX(views.bottomLeft().viewer()));
+
+		scene.getChildren().add(this.group);
+
+		eyeToWorldTransformProperty.addListener(obs -> updateMeshViews());
+		globalTransformManager.addListener(tf -> updateMeshViews());
+		map.values().forEach(orthoSliceFX -> orthoSliceFX.addListener(obs -> updateMeshViews()));
+	}
+
+	public Map<OrthogonalViews.ViewerAndTransforms, OrthoSliceFX> getOrthoSlices()
+	{
+		return Collections.unmodifiableMap(this.map);
+	}
+
+	/**
+	 * To display transparent orthoslices correctly, the {@link MeshView}s representing their quarters
+	 * need to be sorted by the distance to the camera (from the farthest to the closest).
+	 */
+	private void updateMeshViews()
+	{
+		final AffineTransform3D eyeToWorldTransform = eyeToWorldTransformProperty.get();
+		final List<Pair<MeshView, Double>> meshViewsAndPoints = new ArrayList<>();
+		for (final Map.Entry<ViewerAndTransforms, OrthoSliceFX> entry : this.map.entrySet())
+		{
+			final ViewerAndTransforms viewerAndTransforms = entry.getKey();
+			final OrthoSliceFX orthoSliceFX = entry.getValue();
+			final OrthoSliceMeshFX mesh = orthoSliceFX.getMesh();
+
+			if (!orthoSliceFX.getIsVisible() || mesh == null)
+				continue;
+
+			final List<MeshView> meshViews = mesh.getMeshViews();
+			final List<RealInterval> meshViewIntervals = mesh.getMeshViewIntervals();
+			for (int i = 0; i < meshViews.size(); ++i)
+			{
+				final MeshView meshView = meshViews.get(i);
+				final RealInterval meshViewInterval = meshViewIntervals.get(i);
+				final RealPoint centerPoint = new RealPoint(3);
+				for (int d = 0; d < meshViewInterval.numDimensions(); ++d)
+					centerPoint.setPosition((meshViewInterval.realMin(d) + meshViewInterval.realMax(d)) / 2, d);
+
+				viewerAndTransforms.viewer().displayToGlobalCoordinates(centerPoint);
+				eyeToWorldTransform.applyInverse(centerPoint, centerPoint);
+				final double distanceFromCamera = centerPoint.getDoublePosition(2);
+
+				// distanceFromCamera with minus because we want the farthest mesh views to come first
+				meshViewsAndPoints.add(new ValuePair<>(meshView, -distanceFromCamera));
+			}
+		}
+
+		Collections.sort(meshViewsAndPoints, Comparator.comparingDouble(Pair::getB));
+
+		// NOTE: JavaFX renders children of a group based on the order in which they are added.
+		final List<MeshView> newChildren = meshViewsAndPoints.stream().map(Pair::getA).collect(Collectors.toList());
+		group.getChildren().setAll(newChildren);
+	}
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSlicesManager.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSlicesManager.java
@@ -74,8 +74,7 @@ public class OrthoSlicesManager
 					centerPoint.setPosition((meshViewInterval.realMin(d) + meshViewInterval.realMax(d)) / 2, d);
 
 				viewerAndTransforms.viewer().displayToGlobalCoordinates(centerPoint);
-				eyeToWorldTransform.applyInverse(centerPoint, centerPoint);
-				final double distanceFromCamera = centerPoint.getDoublePosition(2);
+				final double distanceFromCamera = Geom3DUtils.distanceFromCamera(eyeToWorldTransform, centerPoint);
 
 				// distanceFromCamera with minus because we want the farthest mesh views to come first
 				meshViewsAndPoints.add(new ValuePair<>(meshView, -distanceFromCamera));

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSlicesManager.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSlicesManager.java
@@ -52,7 +52,7 @@ public class OrthoSlicesManager
 	private void updateMeshViews()
 	{
 		assert Platform.isFxApplicationThread();
-		final AffineTransform3D eyeToWorldTransform = eyeToWorldTransformProperty.get().copy();
+		final AffineTransform3D eyeToWorldTransform = eyeToWorldTransformProperty.get();
 		final List<Pair<MeshView, Double>> meshViewsAndPoints = new ArrayList<>();
 		for (final Map.Entry<ViewerAndTransforms, OrthoSliceFX> entry : this.map.entrySet())
 		{
@@ -86,7 +86,6 @@ public class OrthoSlicesManager
 
 		// NOTE: JavaFX renders children of a group based on the order in which they are added.
 		final List<MeshView> newChildren = meshViewsAndPoints.stream().map(Pair::getA).collect(Collectors.toList());
-
 		group.getChildren().setAll(newChildren);
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSlicesManager.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSlicesManager.java
@@ -4,30 +4,34 @@ import javafx.application.Platform;
 import javafx.beans.property.ObjectProperty;
 import javafx.scene.Group;
 import javafx.scene.shape.MeshView;
-import net.imglib2.RealInterval;
-import net.imglib2.RealPoint;
 import net.imglib2.realtransform.AffineTransform3D;
-import net.imglib2.util.Pair;
-import net.imglib2.util.ValuePair;
+import net.imglib2.realtransform.Scale3D;
+import net.imglib2.util.LinAlgHelpers;
 import org.janelia.saalfeldlab.fx.ortho.OrthogonalViews;
 import org.janelia.saalfeldlab.fx.ortho.OrthogonalViews.ViewerAndTransforms;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 public class OrthoSlicesManager
 {
+	private static final int CLOSEST_Z_INDEX = -1;
+	private static final int MIDDLE_Z_INDEX = 0;
+	private static final int FARTHEST_Z_INDEX = 1;
+
 	private final Group group = new Group();
 
 	private final Map<ViewerAndTransforms, OrthoSliceFX> map = new HashMap<>();
 
 	private final ObjectProperty<AffineTransform3D> eyeToWorldTransformProperty;
 
+	private final OrthogonalViews<?> views;
+
 	public OrthoSlicesManager(
 			final Group scene,
 			final OrthogonalViews<?> views,
 			final ObjectProperty<AffineTransform3D> eyeToWorldTransformProperty)
 	{
+		this.views = views;
 		this.eyeToWorldTransformProperty = eyeToWorldTransformProperty;
 
 		map.put(views.topLeft(), new OrthoSliceFX(views.topLeft().viewer()));
@@ -46,45 +50,117 @@ public class OrthoSlicesManager
 	}
 
 	/**
-	 * To display transparent orthoslices correctly, the {@link MeshView}s representing their quarters
-	 * need to be sorted by the distance to the camera (from the farthest to the closest).
+	 * To display transparent orthoslices correctly, the {@link MeshView}s representing their quadrants
+	 * need to be ordered from the farthest to the closest with respect to the camera orientation.
 	 */
 	private void updateMeshViews()
 	{
 		assert Platform.isFxApplicationThread();
 		final AffineTransform3D eyeToWorldTransform = eyeToWorldTransformProperty.get();
-		final List<Pair<MeshView, Double>> meshViewsAndPoints = new ArrayList<>();
+
+		final Map<ViewerAndTransforms, MeshView[][]> orthosliceQuadrants = new HashMap<>();
+		final Map<ViewerAndTransforms, Boolean> orthosliceFront = new HashMap<>();
+
+		// Find out which side of each orthoslice we are currently seeing
 		for (final Map.Entry<ViewerAndTransforms, OrthoSliceFX> entry : this.map.entrySet())
 		{
-			final ViewerAndTransforms viewerAndTransforms = entry.getKey();
+			final ViewerAndTransforms viewer = entry.getKey();
 			final OrthoSliceFX orthoSliceFX = entry.getValue();
 			final OrthoSliceMeshFX mesh = orthoSliceFX.getMesh();
 
-			if (!orthoSliceFX.getIsVisible() || mesh == null)
-				continue;
+			final MeshView[][] quadrants = {
+					{mesh.getMeshViews().get(0), mesh.getMeshViews().get(1)},
+					{mesh.getMeshViews().get(2), mesh.getMeshViews().get(3)}
+			};
+			orthosliceQuadrants.put(viewer, quadrants);
 
-			final List<MeshView> meshViews = mesh.getMeshViews();
-			final List<RealInterval> meshViewIntervals = mesh.getMeshViewIntervals();
-			for (int i = 0; i < meshViews.size(); ++i)
+			// Flip is needed for XZ and YZ views because we want top-left quadrants of each orthoslice
+			// to be located in the octant where they all are facing towards the camera
+			final Scale3D flipTransform = new Scale3D(1, 1, viewer == views.topLeft() ? 1 : -1);
+
+			final AffineTransform3D orthosliceCenterToCameraTransform = new AffineTransform3D();
+			orthosliceCenterToCameraTransform
+					.preConcatenate(flipTransform)
+					.preConcatenate(orthoSliceFX.getWorldTransform())
+					.preConcatenate(eyeToWorldTransform.inverse());
+
+			final double[] orthoslicePoint = {0, 0, 0}, orthosliceNormal = {0, 0, 1};
+			orthosliceCenterToCameraTransform.apply(orthoslicePoint, orthoslicePoint);
+			orthosliceCenterToCameraTransform.apply(orthosliceNormal, orthosliceNormal);
+			Arrays.setAll(orthosliceNormal, d -> orthosliceNormal[d] - orthoslicePoint[d]);
+
+			final boolean isFront = LinAlgHelpers.dot(orthoslicePoint, orthosliceNormal) > 0;
+			orthosliceFront.put(viewer, isFront);
+		}
+
+		// Define intersections and relationship between the orthoslices as a two-element array in the following manner:
+		//  [intersection that splits the orthoslice into two columns,
+		//   intersection that splits the orthoslice into two rows]
+		final Map<ViewerAndTransforms, ViewerAndTransforms[]> orthosliceNeighbors = new HashMap<>();
+		orthosliceNeighbors.put(views.topLeft(), new ViewerAndTransforms[] {views.bottomLeft(), views.topRight()});
+		orthosliceNeighbors.put(views.topRight(), new ViewerAndTransforms[] {views.bottomLeft(), views.topLeft()});
+		orthosliceNeighbors.put(views.bottomLeft(), new ViewerAndTransforms[] {views.topLeft(), views.topRight()});
+
+		// Based on which side of each orthoslice we are currently seeing and the relationship between them,
+		// assign an index to each quadrant of each orthoslice. There are three groups of quadrants in total:
+		// 1) three quadrants that are closest to the camera (one in each orthoslice)
+		// 2) three quadrants that are farthest from the camera (one in each orthoslice)
+		// 3) other quadrants (their order does not matter as they do not intersect)
+		final Map<ViewerAndTransforms, int[][]> quadrantZIndices = new HashMap<>();
+		for (ViewerAndTransforms viewer : map.keySet())
+		{
+			final int[][] zIndices = {
+					{MIDDLE_Z_INDEX, MIDDLE_Z_INDEX},
+					{MIDDLE_Z_INDEX, MIDDLE_Z_INDEX}
+			};
+			final int[] firstQuadrantIndex = {0, 0};
+			for (int i = 0; i < 2; ++i)
 			{
-				final MeshView meshView = meshViews.get(i);
-				final RealInterval meshViewInterval = meshViewIntervals.get(i);
-				final RealPoint centerPoint = new RealPoint(3);
-				for (int d = 0; d < meshViewInterval.numDimensions(); ++d)
-					centerPoint.setPosition((meshViewInterval.realMin(d) + meshViewInterval.realMax(d)) / 2, d);
+				// Shift the index of the closest quadrant if the neighboring orthoslice
+				// along the corresponding dimension is visible from the back
+				final ViewerAndTransforms neighbor = orthosliceNeighbors.get(viewer)[i];
+				if (!orthosliceFront.get(neighbor))
+					++firstQuadrantIndex[i];
+			}
 
-				viewerAndTransforms.viewer().displayToGlobalCoordinates(centerPoint);
-				final double distanceFromCamera = Geom3DUtils.distanceFromCamera(eyeToWorldTransform, centerPoint);
+			// Mark the found quadrant as closest and the opposite one as farthest
+			zIndices[firstQuadrantIndex[0]][firstQuadrantIndex[1]] = CLOSEST_Z_INDEX;
+			zIndices[(firstQuadrantIndex[0] + 1) % 2][(firstQuadrantIndex[1] + 1) % 2] = FARTHEST_Z_INDEX;
+			quadrantZIndices.put(viewer, zIndices);
+		}
 
-				// distanceFromCamera with minus because we want the farthest mesh views to come first
-				meshViewsAndPoints.add(new ValuePair<>(meshView, -distanceFromCamera));
+		// Collect the indexed quadrants into three distinct groups
+		final List<MeshView> closestQuadrants = new ArrayList<>(), middleQuadrants = new ArrayList<>(), farthestQuadrants = new ArrayList<>();
+		for (ViewerAndTransforms viewer : map.keySet())
+		{
+			for (int r = 0; r < 2; ++r) {
+				for (int c = 0; c < 2; ++c) {
+					final MeshView quadrant = orthosliceQuadrants.get(viewer)[r][c];
+					final int zIndex = quadrantZIndices.get(viewer)[r][c];
+					switch (zIndex) {
+						case CLOSEST_Z_INDEX:
+							closestQuadrants.add(quadrant);
+							break;
+						case MIDDLE_Z_INDEX:
+							middleQuadrants.add(quadrant);
+							break;
+						case FARTHEST_Z_INDEX:
+							farthestQuadrants.add(quadrant);
+							break;
+						default:
+							assert false;
+							break;
+					}
+				}
 			}
 		}
 
-		Collections.sort(meshViewsAndPoints, Comparator.comparingDouble(Pair::getB));
-
-		// NOTE: JavaFX renders children of a group based on the order in which they are added.
-		final List<MeshView> newChildren = meshViewsAndPoints.stream().map(Pair::getA).collect(Collectors.toList());
+		// JavaFX renders children of a group based on the order in which they are added.
+		// Add the quadrants from the farthest that need to be rendered first to the closest that need to be rendered last.
+		final List<MeshView> newChildren = new ArrayList<>();
+		newChildren.addAll(farthestQuadrants);
+		newChildren.addAll(middleQuadrants);
+		newChildren.addAll(closestQuadrants);
 		group.getChildren().setAll(newChildren);
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/ViewFrustumCulling.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/ViewFrustumCulling.java
@@ -160,7 +160,7 @@ public class ViewFrustumCulling
 			for (int d = 0; d < block.numDimensions(); ++d)
 				blockCorner.setPosition(cornerIterator.getIntPosition(d) == 0 ? block.realMin(d) : block.realMax(d), d);
 
-			final double distanceFromCamera = Geom3DUtils.distanceFromCamera(transform, blockCorner);
+			final double distanceFromCamera = Geom3DUtils.cameraZPlane(transform, blockCorner);
 			if (distanceFromCamera >= 0)
 				minPositiveDistance = Math.min(distanceFromCamera, minPositiveDistance);
 			else


### PR DESCRIPTION
Adds new slider in OrthoViews settings for controlling transparency of the orthoslices.

Changing the opacity property of `MeshView` didn't have any effect on transparency (only hid the orthoslices when set to 0, otherwise fully opaque), but changing the opacity of the diffuse color in `PhongMaterial` did the trick.