### PR TITLE
Set appropriate log levels in SegmentMaskGenerators

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/meshes/cache/SegmentMaskGenerators.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/meshes/cache/SegmentMaskGenerators.java
@@ -87,7 +87,7 @@ public class SegmentMaskGenerators
 
 		public LabelMultisetTypeMask(final TLongSet validLabels)
 		{
-			LOG.info("Creating {} with valid labels: {}", this.getClass().getSimpleName(), validLabels);
+			LOG.debug("Creating {} with valid labels: {}", this.getClass().getSimpleName(), validLabels);
 			this.validLabels = validLabels;
 		}
 
@@ -138,7 +138,7 @@ public class SegmentMaskGenerators
 		public LabelMultisetTypeMaskWithMinLabelRatio(final TLongSet validLabels, final double minLabelRatio, final long numFullResPixels)
 		{
 			assert numFullResPixels > 0;
-			LOG.info(
+			LOG.debug(
 					"Creating {} with min label ratio: {}, numFullResPixels: {}, valid labels: {}",
 					this.getClass().getSimpleName(),
 					validLabels,


### PR DESCRIPTION
I had set them to LOG.info so could see what's happening during development but I had forgotten to re-set them to LOG.info later on.

@igorpisarev I will cut a new release right after merging this PR. I had forgotten to re-set the log levels to DEBUG and I just noticed after the release of `0.23.0`.