### PR TITLE
Optimize orthoslice texture updates

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceFX.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceFX.java
@@ -185,9 +185,10 @@ public class OrthoSliceFX extends ObservableWithListenersList
 				if (newScreenScaleIndex >= textures.length || textures[newScreenScaleIndex] != texture)
 					return;
 
+				final Interval textureImageInterval = new FinalInterval(textureImageSize[0], textureImageSize[1]);
 				final Interval updateInterval = updateIntervals[newScreenScaleIndex] != null
-						? updateIntervals[newScreenScaleIndex]
-						: new FinalInterval(textureImageSize[0], textureImageSize[1]);
+						? Intervals.intersect(updateIntervals[newScreenScaleIndex], textureImageInterval)
+						: textureImageInterval;
 				setTextureOpacityAndShading(texture, updateInterval);
 				updateIntervals[newScreenScaleIndex] = null;
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceFX.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceFX.java
@@ -90,12 +90,18 @@ public class OrthoSliceFX extends ObservableWithListenersList
 		isVisible.addListener(obs -> stateChanged());
 
 		final InvalidationListener textureColorUpdateListener = obs -> {
-			if (currentTextureScreenScaleIndex != -1) {
-				final Texture texture = textures.get(currentTextureScreenScaleIndex);
-				final Interval interval = new FinalInterval(
-						(long) texture.originalImage.getWidth(),
-						(long) texture.originalImage.getHeight());
-				setTextureOpacityAndShading(texture, interval);
+			// Change textures for all scale levels.
+			// If painting is initiated after this, partial updates will be consistent with the rest of the texture image.
+			if (textures == null)
+				return;
+			delayedTextureUpdateExecutor.cancel();
+			for (final Texture texture : textures) {
+				if (texture != null) {
+					final Interval interval = new FinalInterval(
+							(long) texture.originalImage.getWidth(),
+							(long) texture.originalImage.getHeight());
+					setTextureOpacityAndShading(texture, interval);
+				}
 			}
 		};
 


### PR DESCRIPTION
Fixes #395

The changes improve the performance quite a lot on my workstation and my laptop:
* Instead of changing brightness factor and alpha of the texture images on per-pixel basis using JavaFX API, it's now set directly into the buffer of the image (using `BufferExposingWritableImage` similarly to the renderer). Individual pixel updates were too slow because on each update JavaFX notified the listeners that the image has changed.
* These updates are now throttled, so the actual textures will be modified every 50ms.
* For painting, keep track of the affected intervals and update the texture only within that interval.

There is also another version of the fix that performs texture updates on a background thread: https://github.com/saalfeldlab/paintera/tree/optimize-orthoslice-textures-background-thread
But the current state of that branch doesn't improve the performance much because of strict synchronization between the FX thread and the background thread. It should be possible to relax the synchronization, but it's more complicated and error-prone.

I'll merge and release the fixes in this PR, but I'll also keep the background thread version in case it turns out that the current fix is still slow in some circumstances.