### PR TITLE
Add ability to export meshes for intersecting sources (synapses)

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/selection/FragmentsInSelectedSegments.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/selection/FragmentsInSelectedSegments.java
@@ -24,6 +24,11 @@ public class FragmentsInSelectedSegments extends ObservableWithListenersList
 		return this.selectedFragments.toArray();
 	}
 
+	public SelectedSegments getSelectedSegments()
+	{
+		return this.activeSegments;
+	}
+
 	private void update()
 	{
 		final TLongHashSet newSelectedFragments = new TLongHashSet();

--- a/src/main/java/org/janelia/saalfeldlab/paintera/meshes/MeshExporter.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/meshes/MeshExporter.java
@@ -1,5 +1,6 @@
 package org.janelia.saalfeldlab.paintera.meshes;
 
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -9,6 +10,7 @@ import java.util.Set;
 
 import net.imglib2.Interval;
 import net.imglib2.util.Intervals;
+import org.janelia.saalfeldlab.fx.ui.Exceptions;
 import org.janelia.saalfeldlab.paintera.meshes.managed.GetBlockListFor;
 import org.janelia.saalfeldlab.paintera.meshes.managed.GetMeshFor;
 import org.janelia.saalfeldlab.util.HashWrapper;
@@ -81,13 +83,22 @@ public abstract class MeshExporter<T>
 				if (verticesAndNormals == null)
 					continue;
 				assert verticesAndNormals.getVertices().length == verticesAndNormals.getNormals().length : "Vertices and normals must have the same size.";
-				save(
-						path,
-						id.toString(),
-						verticesAndNormals.getVertices(),
-						verticesAndNormals.getNormals(),
-						hasFaces(numberOfFaces));
-				numberOfFaces += verticesAndNormals.getVertices().length / 3;
+				try
+				{
+					save(
+							path,
+							id.toString(),
+							verticesAndNormals.getVertices(),
+							verticesAndNormals.getNormals(),
+							hasFaces(numberOfFaces));
+
+					numberOfFaces += verticesAndNormals.getVertices().length / 3;
+				}
+				catch (final IOException e)
+				{
+					Exceptions.exceptionAlert("Mesh exporter", "Couldn't write file", e).show();
+					break;
+				}
 			} catch (final RuntimeException e)
 			{
 				LOG.warn("{} : {}", e.getClass(), e.getMessage());
@@ -98,7 +109,7 @@ public abstract class MeshExporter<T>
 
 	}
 
-	protected abstract void save(String path, String id, float[] vertices, float[] normals, boolean append);
+	protected abstract void save(String path, String id, float[] vertices, float[] normals, boolean append) throws IOException;
 
 	public static boolean hasFaces(final int numberOfFaces)
 	{

--- a/src/main/java/org/janelia/saalfeldlab/paintera/meshes/MeshExporterBinary.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/meshes/MeshExporterBinary.java
@@ -1,50 +1,31 @@
 package org.janelia.saalfeldlab.paintera.meshes;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedOutputStream;
 import java.io.DataOutputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class MeshExporterBinary<T> extends MeshExporter<T>
 {
 	private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
 	@Override
-	protected void save(final String path, final String id, final float[] vertices, final float[] normals, final
-	boolean append)
+	protected void save(final String path, final String id, final float[] vertices, final float[] normals, final boolean append) throws IOException
 	{
 		save(path + ".vertices", vertices, append);
 		save(path + ".normals", normals, append);
 	}
 
-	private void save(final String path, final float[] info, final boolean append)
+	private void save(final String path, final float[] info, final boolean append) throws IOException
 	{
-		try
+		try (final DataOutputStream stream = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(path, append))))
 		{
-			final DataOutputStream stream = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(
-					path,
-					append
-			)));
-			try
-			{
-				for (int i = 0; i < info.length; i++)
-				{
-					stream.writeFloat(info[i]);
-				}
-				stream.close();
-			} catch (final IOException e)
-			{
-				LOG.warn("Couldn't write data to the file {}: {}", path, e.getMessage());
-			}
-		} catch (final FileNotFoundException e)
-		{
-			LOG.warn("Couldn't find file {}: {}", path, e.getMessage());
+			for (int i = 0; i < info.length; i++)
+				stream.writeFloat(info[i]);
 		}
 	}
-
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/meshes/MeshExporterObj.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/meshes/MeshExporterObj.java
@@ -1,24 +1,23 @@
 package org.janelia.saalfeldlab.paintera.meshes;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class MeshExporterObj<T> extends MeshExporter<T>
 {
 	private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
 	@Override
-	protected void save(String path, final String id, final float[] vertices, final float[] normals, final boolean
-			append)
+	protected void save(String path, final String id, final float[] vertices, final float[] normals, final boolean append) throws IOException
 	{
 		path = path + ".obj";
-		try
+
+		try (final FileWriter writer = new FileWriter(path, append))
 		{
-			final FileWriter    writer    = new FileWriter(path, append);
 			final float[]       texCoords = new float[] {0.0f, 0.0f};
 			final StringBuilder sb        = new StringBuilder();
 
@@ -60,18 +59,7 @@ public class MeshExporterObj<T> extends MeshExporter<T>
 						numberOfFaces + 3);
 			}
 
-			try
-			{
-				writer.append(sb.toString());
-				writer.close();
-			} catch (final IOException e)
-			{
-				LOG.warn("Couldn't write data to the file {}: {}", path, e.getMessage());
-			}
-
-		} catch (final IOException e)
-		{
-			LOG.warn("Couldn't open the file {}: {}", path, e.getMessage());
+			writer.append(sb.toString());
 		}
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/meshes/MeshInfo.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/meshes/MeshInfo.java
@@ -1,0 +1,35 @@
+package org.janelia.saalfeldlab.paintera.meshes;
+
+import org.janelia.saalfeldlab.paintera.meshes.managed.MeshManagerWithSingleMesh;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+
+public class MeshInfo<T>
+{
+
+	private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+	private final MeshManagerWithSingleMesh<T> meshManager;
+
+	public MeshInfo(final MeshManagerWithSingleMesh<T> meshManager)
+	{
+		this.meshManager = meshManager;
+	}
+
+	public MeshSettings getMeshSettings()
+	{
+		return meshManager.getSettings();
+	}
+
+	public MeshManagerWithSingleMesh<T> meshManager()
+	{
+		return this.meshManager;
+	}
+
+	public T getKey()
+	{
+		return this.meshManager.getMeshKey();
+	}
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/meshes/SegmentMeshInfo.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/meshes/SegmentMeshInfo.java
@@ -2,8 +2,6 @@ package org.janelia.saalfeldlab.paintera.meshes;
 
 import gnu.trove.set.hash.TLongHashSet;
 import javafx.beans.property.BooleanProperty;
-import javafx.beans.value.ChangeListener;
-import javafx.beans.value.ObservableValue;
 import org.janelia.saalfeldlab.paintera.control.assignment.FragmentSegmentAssignment;
 import org.janelia.saalfeldlab.paintera.meshes.managed.MeshManagerWithAssignmentForSegments;
 import org.slf4j.Logger;
@@ -11,10 +9,8 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Objects;
-import java.util.function.BiConsumer;
 
-public class MeshInfo
-{
+public class SegmentMeshInfo {
 
 	private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
@@ -30,14 +26,13 @@ public class MeshInfo
 
 	private final BooleanProperty isManaged;
 
-	public MeshInfo(
+	public SegmentMeshInfo(
 			final Long segmentId,
 			final MeshSettings meshSettings,
 			final BooleanProperty isManaged,
 			final FragmentSegmentAssignment assignment,
 			final MeshManagerWithAssignmentForSegments meshManager)
 	{
-		super();
 		this.segmentId = segmentId;
 		this.meshSettings = meshSettings;
 		this.isManaged = isManaged;
@@ -57,25 +52,6 @@ public class MeshInfo
 		return this.meshSettings;
 	}
 
-	private class PropagateChanges<U> implements ChangeListener<U>
-	{
-
-		final BiConsumer<MeshGenerator.State, U> apply;
-
-		public PropagateChanges(final BiConsumer<MeshGenerator.State, U> apply)
-		{
-			super();
-			this.apply = apply;
-		}
-
-		@Override
-		public void changed(final ObservableValue<? extends U> observable, final U oldValue, final U newValue)
-		{
-			apply.accept(meshManager.getStateFor(segmentId), newValue);
-		}
-
-	}
-
 	@Override
 	public int hashCode()
 	{
@@ -85,7 +61,7 @@ public class MeshInfo
 	@Override
 	public boolean equals(final Object o)
 	{
-		return o instanceof MeshInfo && Objects.equals(((MeshInfo) o).segmentId, segmentId);
+		return o instanceof SegmentMeshInfo && Objects.equals(((SegmentMeshInfo) o).segmentId, segmentId);
 	}
 
 	public ObservableMeshProgress meshProgress()

--- a/src/main/java/org/janelia/saalfeldlab/paintera/meshes/SegmentMeshInfos.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/meshes/SegmentMeshInfos.java
@@ -10,17 +10,17 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class MeshInfos
+public class SegmentMeshInfos
 {
-	private final ObservableList<MeshInfo> infos = FXCollections.observableArrayList();
+	private final ObservableList<SegmentMeshInfo> infos = FXCollections.observableArrayList();
 
-	private final ObservableList<MeshInfo> readOnlyInfos = FXCollections.unmodifiableObservableList(infos);
+	private final ObservableList<SegmentMeshInfo> readOnlyInfos = FXCollections.unmodifiableObservableList(infos);
 
 	private final ManagedMeshSettings meshSettings;
 
 	private final int numScaleLevels;
 
-	public MeshInfos(
+	public SegmentMeshInfos(
 			final SelectedSegments selectedSegments,
 			final MeshManagerWithAssignmentForSegments meshManager,
 			final ManagedMeshSettings meshSettings,
@@ -33,11 +33,11 @@ public class MeshInfos
 
 		final InvalidationListener updateMeshInfosHandler = obs -> {
 			final long[] segments = selectedSegments.getSelectedSegmentsCopyAsArray();
-			final List<MeshInfo> infos = Arrays
+			final List<SegmentMeshInfo> infos = Arrays
 					.stream(segments)
 					.mapToObj(id -> {
 						final MeshSettings settings = meshSettings.getOrAddMesh(id, true);
-						return new MeshInfo(
+						return new SegmentMeshInfo(
 								id,
 								settings,
 								meshSettings.isManagedProperty(id),
@@ -52,7 +52,7 @@ public class MeshInfos
 		meshSettings.isMeshListEnabledProperty().addListener(updateMeshInfosHandler);
 	}
 
-	public ObservableList<MeshInfo> readOnlyInfos()
+	public ObservableList<SegmentMeshInfo> readOnlyInfos()
 	{
 		return this.readOnlyInfos;
 	}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/serialization/sourcestate/ThresholdingSourceStateDeserializer.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/serialization/sourcestate/ThresholdingSourceStateDeserializer.java
@@ -126,7 +126,7 @@ public class ThresholdingSourceStateDeserializer implements JsonDeserializer<Thr
 						state.getMeshSettings(),
 						context);
 			if (meshesMap.has(MESHES_ENABLED_KEY) && meshesMap.get(MESHES_ENABLED_KEY).isJsonPrimitive())
-				state.setMeshesEnabeld(meshesMap.get(MESHES_ENABLED_KEY).getAsBoolean());
+				state.setMeshesEnabled(meshesMap.get(MESHES_ENABLED_KEY).getAsBoolean());
 		}
 
 		return state;

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/ThresholdingSourceState.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/ThresholdingSourceState.java
@@ -346,8 +346,8 @@ public class ThresholdingSourceState<D extends RealType<D>, T extends AbstractVo
 		return this.meshesEnabled.get();
 	}
 
-	public void setMeshesEnabeld(final boolean isMeshesEnabeld) {
-		this.meshesEnabled.set(isMeshesEnabeld);
+	public void setMeshesEnabled(final boolean isMeshesEnabled) {
+		this.meshesEnabled.set(isMeshesEnabled);
 	}
 
 	public BooleanProperty meshesEnabledProperty() {

--- a/src/main/java/org/janelia/saalfeldlab/paintera/ui/source/mesh/MeshExportResult.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/ui/source/mesh/MeshExportResult.java
@@ -1,0 +1,37 @@
+package org.janelia.saalfeldlab.paintera.ui.source.mesh;
+
+import org.janelia.saalfeldlab.paintera.meshes.MeshExporter;
+
+public class MeshExportResult<T>
+{
+	private final MeshExporter<T> meshExporter;
+
+	private final String filePath;
+
+	private final int scale;
+
+	public MeshExportResult(
+			final MeshExporter<T> meshExporter,
+			final String filePath,
+			final int scale)
+	{
+		this.meshExporter = meshExporter;
+		this.filePath = filePath;
+		this.scale = scale;
+	}
+
+	public MeshExporter<T> getMeshExporter()
+	{
+		return meshExporter;
+	}
+
+	public String getFilePath()
+	{
+		return filePath;
+	}
+
+	public int getScale()
+	{
+		return scale;
+	}
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/ui/source/mesh/MeshExporterDialog.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/ui/source/mesh/MeshExporterDialog.java
@@ -1,0 +1,132 @@
+package org.janelia.saalfeldlab.paintera.ui.source.mesh;
+
+import javafx.beans.binding.Bindings;
+import javafx.beans.binding.BooleanBinding;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.control.*;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+import javafx.stage.DirectoryChooser;
+import org.janelia.saalfeldlab.paintera.meshes.*;
+import org.janelia.saalfeldlab.util.fx.UIUtils;
+
+import java.io.File;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+// TODO: make more uniform with SegmentMeshExporterDialog
+public class MeshExporterDialog<T> extends Dialog<MeshExportResult<T>>
+{
+
+	public enum FILETYPE
+	{
+		obj, binary
+	};
+
+	private final TextField scale;
+
+	private final TextField filePath;
+
+	private MeshExporter<T> meshExporter;
+
+	private ComboBox<String> fileFormats;
+
+	private final BooleanBinding isError;
+
+	public MeshExporterDialog(final MeshInfo meshInfo)
+	{
+		super();
+		this.filePath = new TextField();
+		this.setTitle("Export mesh");
+		this.isError = (Bindings.createBooleanBinding(() -> filePath.getText().isEmpty(), filePath.textProperty()));
+		final MeshSettings settings = meshInfo.getMeshSettings();
+		this.scale = new TextField(Integer.toString(settings.getFinestScaleLevel()));
+		UIUtils.setNumericTextField(scale, settings.getNumScaleLevels() - 1);
+
+		setResultConverter(button -> {
+			if (button.getButtonData().isCancelButton()) { return null; }
+			return new MeshExportResult(
+					meshExporter,
+					filePath.getText(),
+					Integer.parseInt(scale.getText())
+			);
+		});
+
+		createDialog();
+	}
+
+	private void createDialog()
+	{
+		final VBox     vbox     = new VBox();
+		final GridPane contents = new GridPane();
+
+		int row = createCommonDialog(contents);
+
+		final Button button = new Button("Browse");
+		button.setOnAction(event -> {
+			final DirectoryChooser directoryChooser = new DirectoryChooser();
+			final File             directory        = directoryChooser.showDialog(contents.getScene().getWindow());
+			Optional.ofNullable(directory).map(File::getAbsolutePath);
+			filePath.setText(directory.getPath());
+			createMeshExporter(fileFormats.getSelectionModel().getSelectedItem());
+		});
+
+		contents.add(button, 2, row);
+		++row;
+
+		vbox.getChildren().add(contents);
+		this.getDialogPane().setContent(vbox);
+	}
+
+	private int createCommonDialog(final GridPane contents)
+	{
+		int row = 0;
+
+		contents.add(new Label("Scale"), 0, row);
+		contents.add(scale, 1, row);
+		GridPane.setFillWidth(scale, true);
+		++row;
+
+		contents.add(new Label("Format"), 0, row);
+
+		final List<String>           typeNames = Stream.of(FILETYPE.values()).map(FILETYPE::name).collect(Collectors
+				.toList());
+		final ObservableList<String> options   = FXCollections.observableArrayList(typeNames);
+		fileFormats = new ComboBox<>(options);
+		fileFormats.getSelectionModel().select(0);
+		fileFormats.setMinWidth(0);
+		fileFormats.setMaxWidth(Double.POSITIVE_INFINITY);
+		contents.add(fileFormats, 1, row);
+		fileFormats.maxWidth(300);
+		GridPane.setFillWidth(fileFormats, true);
+		GridPane.setHgrow(fileFormats, Priority.ALWAYS);
+
+		++row;
+
+		contents.add(new Label("Save to:"), 0, row);
+		contents.add(filePath, 1, row);
+
+		this.getDialogPane().getButtonTypes().addAll(ButtonType.CANCEL, ButtonType.OK);
+		this.getDialogPane().lookupButton(ButtonType.OK).disableProperty().bind(this.isError);
+
+		return row;
+	}
+
+	private void createMeshExporter(final String filetype)
+	{
+		switch (filetype)
+		{
+			case "binary":
+				meshExporter = new MeshExporterBinary<>();
+				break;
+			case ".obj":
+			default:
+				meshExporter = new MeshExporterObj<>();
+				break;
+		}
+	}
+}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/ui/source/mesh/MeshExporterDialog.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/ui/source/mesh/MeshExporterDialog.java
@@ -27,9 +27,13 @@ public class MeshExporterDialog<T> extends Dialog<MeshExportResult<T>>
 		obj, binary
 	};
 
+	private final MeshInfo<T> meshInfo;
+
 	private final TextField scale;
 
-	private final TextField filePath;
+	private final TextField dirPath;
+
+	private String filePath;
 
 	private MeshExporter<T> meshExporter;
 
@@ -37,12 +41,13 @@ public class MeshExporterDialog<T> extends Dialog<MeshExportResult<T>>
 
 	private final BooleanBinding isError;
 
-	public MeshExporterDialog(final MeshInfo meshInfo)
+	public MeshExporterDialog(final MeshInfo<T> meshInfo)
 	{
 		super();
-		this.filePath = new TextField();
+		this.meshInfo = meshInfo;
+		this.dirPath = new TextField();
 		this.setTitle("Export mesh");
-		this.isError = (Bindings.createBooleanBinding(() -> filePath.getText().isEmpty(), filePath.textProperty()));
+		this.isError = (Bindings.createBooleanBinding(() -> dirPath.getText().isEmpty(), dirPath.textProperty()));
 		final MeshSettings settings = meshInfo.getMeshSettings();
 		this.scale = new TextField(Integer.toString(settings.getFinestScaleLevel()));
 		UIUtils.setNumericTextField(scale, settings.getNumScaleLevels() - 1);
@@ -51,7 +56,7 @@ public class MeshExporterDialog<T> extends Dialog<MeshExportResult<T>>
 			if (button.getButtonData().isCancelButton()) { return null; }
 			return new MeshExportResult(
 					meshExporter,
-					filePath.getText(),
+					filePath,
 					Integer.parseInt(scale.getText())
 			);
 		});
@@ -71,7 +76,8 @@ public class MeshExporterDialog<T> extends Dialog<MeshExportResult<T>>
 			final DirectoryChooser directoryChooser = new DirectoryChooser();
 			final File             directory        = directoryChooser.showDialog(contents.getScene().getWindow());
 			Optional.ofNullable(directory).map(File::getAbsolutePath);
-			filePath.setText(directory.getPath());
+			dirPath.setText(directory.getPath());
+			filePath = directory + "/synapses" + meshInfo.getKey().toString();
 			createMeshExporter(fileFormats.getSelectionModel().getSelectedItem());
 		});
 
@@ -108,7 +114,7 @@ public class MeshExporterDialog<T> extends Dialog<MeshExportResult<T>>
 		++row;
 
 		contents.add(new Label("Save to:"), 0, row);
-		contents.add(filePath, 1, row);
+		contents.add(dirPath, 1, row);
 
 		this.getDialogPane().getButtonTypes().addAll(ButtonType.CANCEL, ButtonType.OK);
 		this.getDialogPane().lookupButton(ButtonType.OK).disableProperty().bind(this.isError);

--- a/src/main/java/org/janelia/saalfeldlab/paintera/ui/source/mesh/MeshExporterDialog.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/ui/source/mesh/MeshExporterDialog.java
@@ -13,8 +13,8 @@ import org.janelia.saalfeldlab.paintera.meshes.*;
 import org.janelia.saalfeldlab.util.fx.UIUtils;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -74,11 +74,13 @@ public class MeshExporterDialog<T> extends Dialog<MeshExportResult<T>>
 		final Button button = new Button("Browse");
 		button.setOnAction(event -> {
 			final DirectoryChooser directoryChooser = new DirectoryChooser();
-			final File             directory        = directoryChooser.showDialog(contents.getScene().getWindow());
-			Optional.ofNullable(directory).map(File::getAbsolutePath);
-			dirPath.setText(directory.getPath());
-			filePath = directory + "/synapses" + meshInfo.getKey().toString();
-			createMeshExporter(fileFormats.getSelectionModel().getSelectedItem());
+			final File directory = directoryChooser.showDialog(contents.getScene().getWindow());
+			if (directory != null)
+			{
+				dirPath.setText(directory.getAbsolutePath());
+				filePath = Paths.get(directory.getAbsolutePath(), "synapses" + meshInfo.getKey().toString()).toString();
+				createMeshExporter(fileFormats.getSelectionModel().getSelectedItem());
+			}
 		});
 
 		contents.add(button, 2, row);

--- a/src/main/java/org/janelia/saalfeldlab/paintera/ui/source/mesh/SegmentMeshExportResult.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/ui/source/mesh/SegmentMeshExportResult.java
@@ -2,7 +2,7 @@ package org.janelia.saalfeldlab.paintera.ui.source.mesh;
 
 import org.janelia.saalfeldlab.paintera.meshes.MeshExporter;
 
-public class ExportResult<T>
+public class SegmentMeshExportResult<T>
 {
 	private final MeshExporter<T> meshExporter;
 
@@ -16,7 +16,7 @@ public class ExportResult<T>
 
 	// TODO: change scale parameter when the interface allows to export
 	// different scales for different meshes at the same time
-	public ExportResult(
+	public SegmentMeshExportResult(
 			final MeshExporter<T> meshExporter,
 			final long[][] fragmentIds,
 			final long[] segmentId,

--- a/src/main/java/org/janelia/saalfeldlab/paintera/ui/source/mesh/SegmentMeshExporterDialog.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/ui/source/mesh/SegmentMeshExporterDialog.java
@@ -14,9 +14,9 @@ import org.janelia.saalfeldlab.paintera.meshes.*;
 import org.janelia.saalfeldlab.util.fx.UIUtils;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -141,16 +141,14 @@ public class SegmentMeshExporterDialog<T> extends Dialog<SegmentMeshExportResult
 		final Button button = new Button("Browse");
 		button.setOnAction(event -> {
 			final DirectoryChooser directoryChooser = new DirectoryChooser();
-			final File             directory        = directoryChooser.showDialog(contents.getScene().getWindow());
-			Optional.ofNullable(directory).map(File::getAbsolutePath);
-			filePath.setText(directory.getPath());
-
-			for (int i = 0; i < segmentIds.length; i++)
+			final File directory = directoryChooser.showDialog(contents.getScene().getWindow());
+			if (directory != null)
 			{
-				filePaths[i] = directory + "/neuron" + segmentIds[i];
+				filePath.setText(directory.getAbsolutePath());
+				for (int i = 0; i < segmentIds.length; i++)
+					filePaths[i] = Paths.get(directory.getAbsolutePath(), "neuron" + segmentIds[i]).toString();
+				createMeshExporter(fileFormats.getSelectionModel().getSelectedItem());
 			}
-
-			createMeshExporter(fileFormats.getSelectionModel().getSelectedItem());
 		});
 
 		contents.add(button, 2, row);
@@ -173,31 +171,27 @@ public class SegmentMeshExporterDialog<T> extends Dialog<SegmentMeshExportResult
 		final Button button = new Button("Browse");
 		button.setOnAction(event -> {
 			final DirectoryChooser directoryChooser = new DirectoryChooser();
-			final File             directory        = directoryChooser.showDialog(contents.getScene().getWindow());
-			Optional.ofNullable(directory).map(File::getAbsolutePath);
-			filePath.setText(directory.getPath());
-
-			// recover selected ids
-			final List<Long> selectedIds = new ArrayList<>();
-
-			if (checkListView.getItems().size() == 0) { return; }
-
-			for (int i = 0; i < checkListView.getItems().size(); i++)
+			final File directory = directoryChooser.showDialog(contents.getScene().getWindow());
+			if (directory != null)
 			{
-				if (checkListView.getItemBooleanProperty(i).get() == true)
-				{
-					selectedIds.add(checkListView.getItems().get(i));
-				}
+				filePath.setText(directory.getAbsolutePath());
+
+				// recover selected ids
+				if (checkListView.getItems().size() == 0)
+					return;
+
+				final List<Long> selectedIds = new ArrayList<>();
+				for (int i = 0; i < checkListView.getItems().size(); i++)
+					if (checkListView.getItemBooleanProperty(i).get())
+						selectedIds.add(checkListView.getItems().get(i));
+
+				segmentIds = selectedIds.stream().mapToLong(l -> l).toArray();
+
+				for (int i = 0; i < selectedIds.size(); i++)
+					filePaths[i] = Paths.get(directory.getAbsolutePath(), "neuron" + selectedIds.get(i)).toString();
+
+				createMeshExporter(fileFormats.getSelectionModel().getSelectedItem());
 			}
-
-			segmentIds = selectedIds.stream().mapToLong(l -> l).toArray();
-
-			for (int i = 0; i < selectedIds.size(); i++)
-			{
-				filePaths[i] = directory + "/neuron" + selectedIds.get(i);
-			}
-
-			createMeshExporter(fileFormats.getSelectionModel().getSelectedItem());
 		});
 
 		contents.add(button, 2, row);

--- a/src/main/java/org/janelia/saalfeldlab/paintera/ui/source/mesh/SegmentMeshExporterDialog.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/ui/source/mesh/SegmentMeshExporterDialog.java
@@ -2,26 +2,15 @@ package org.janelia.saalfeldlab.paintera.ui.source.mesh;
 
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
-import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import javafx.scene.control.Button;
-import javafx.scene.control.ButtonType;
-import javafx.scene.control.ComboBox;
-import javafx.scene.control.Dialog;
-import javafx.scene.control.Label;
-import javafx.scene.control.TextField;
+import javafx.scene.control.*;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javafx.stage.DirectoryChooser;
 import org.controlsfx.control.CheckListView;
-import org.janelia.saalfeldlab.paintera.meshes.MeshExporter;
-import org.janelia.saalfeldlab.paintera.meshes.MeshExporterBinary;
-import org.janelia.saalfeldlab.paintera.meshes.MeshExporterObj;
-import org.janelia.saalfeldlab.paintera.meshes.MeshInfo;
-import org.janelia.saalfeldlab.paintera.meshes.MeshInfos;
-import org.janelia.saalfeldlab.paintera.meshes.MeshSettings;
+import org.janelia.saalfeldlab.paintera.meshes.*;
 import org.janelia.saalfeldlab.util.fx.UIUtils;
 
 import java.io.File;
@@ -31,7 +20,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class MeshExporterDialog<T> extends Dialog<ExportResult<T>>
+public class SegmentMeshExporterDialog<T> extends Dialog<SegmentMeshExportResult<T>>
 {
 
 	public enum FILETYPE
@@ -59,7 +48,7 @@ public class MeshExporterDialog<T> extends Dialog<ExportResult<T>>
 
 	private final BooleanBinding isError;
 
-	public MeshExporterDialog(final MeshInfo meshInfo)
+	public SegmentMeshExporterDialog(final SegmentMeshInfo meshInfo)
 	{
 		super();
 		this.segmentIds = new long[] { meshInfo.segmentId() };
@@ -74,7 +63,7 @@ public class MeshExporterDialog<T> extends Dialog<ExportResult<T>>
 
 		setResultConverter(button -> {
 			if (button.getButtonData().isCancelButton()) { return null; }
-			return new ExportResult(
+			return new SegmentMeshExportResult(
 					meshExporter,
 					fragmentIds,
 					segmentIds,
@@ -87,10 +76,10 @@ public class MeshExporterDialog<T> extends Dialog<ExportResult<T>>
 
 	}
 
-	public MeshExporterDialog(final MeshInfos meshInfos)
+	public SegmentMeshExporterDialog(final SegmentMeshInfos meshInfos)
 	{
 		super();
-		final ObservableList<MeshInfo> meshInfoList = meshInfos.readOnlyInfos();
+		final ObservableList<SegmentMeshInfo> meshInfoList = meshInfos.readOnlyInfos();
 		this.filePath = new TextField();
 		this.setTitle("Export mesh ");
 		this.segmentIds = new long[meshInfoList.size()];
@@ -108,7 +97,7 @@ public class MeshExporterDialog<T> extends Dialog<ExportResult<T>>
 		final ObservableList<Long> ids                  = FXCollections.observableArrayList();
 		for (int i = 0; i < meshInfoList.size(); i++)
 		{
-			final MeshInfo info = meshInfoList.get(i);
+			final SegmentMeshInfo info = meshInfoList.get(i);
 			this.segmentIds[i] = info.segmentId();
 			this.fragmentIds[i] = info.containedFragments();
 			final MeshSettings settings = info.getMeshSettings();
@@ -130,7 +119,7 @@ public class MeshExporterDialog<T> extends Dialog<ExportResult<T>>
 
 		setResultConverter(button -> {
 			if (button.getButtonData().isCancelButton()) { return null; }
-			return new ExportResult<>(
+			return new SegmentMeshExportResult<>(
 					meshExporter,
 					fragmentIds,
 					segmentIds,

--- a/src/main/java/org/janelia/saalfeldlab/paintera/ui/source/mesh/SegmentMeshInfoNode.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/ui/source/mesh/SegmentMeshInfoNode.java
@@ -4,27 +4,16 @@ import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.collections.FXCollections;
 import javafx.scene.Node;
-import javafx.scene.control.Button;
-import javafx.scene.control.CheckBox;
-import javafx.scene.control.ComboBox;
-import javafx.scene.control.Control;
-import javafx.scene.control.Label;
-import javafx.scene.control.TitledPane;
-import javafx.scene.control.Tooltip;
-import javafx.scene.layout.GridPane;
-import javafx.scene.layout.HBox;
-import javafx.scene.layout.Priority;
-import javafx.scene.layout.Region;
-import javafx.scene.layout.VBox;
+import javafx.scene.control.*;
+import javafx.scene.layout.*;
 import javafx.scene.shape.CullFace;
 import javafx.scene.shape.DrawMode;
 import net.imglib2.type.label.LabelMultisetType;
 import org.janelia.saalfeldlab.fx.ui.NumericSliderWithField;
 import org.janelia.saalfeldlab.paintera.data.DataSource;
-import org.janelia.saalfeldlab.paintera.meshes.MeshInfo;
 import org.janelia.saalfeldlab.paintera.meshes.MeshSettings;
+import org.janelia.saalfeldlab.paintera.meshes.SegmentMeshInfo;
 import org.janelia.saalfeldlab.paintera.meshes.ui.MeshSettingsNode;
-import org.janelia.saalfeldlab.paintera.state.LabelSourceStateMeshPaneNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,14 +21,14 @@ import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
 import java.util.Optional;
 
-public class MeshInfoNode
+public class SegmentMeshInfoNode
 {
 
 	private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
 	private final DataSource<?, ?> source;
 
-	private final MeshInfo meshInfo;
+	private final SegmentMeshInfo meshInfo;
 
 	private final CheckBox visibleCheckBox;
 
@@ -78,7 +67,7 @@ public class MeshInfoNode
 
 	private final MeshSettings settings;
 
-	public MeshInfoNode(final DataSource<?, ?> source, final MeshInfo meshInfo)
+	public SegmentMeshInfoNode(final DataSource<?, ?> source, final SegmentMeshInfo meshInfo)
 	{
 		this.source = source;
 		this.meshInfo = meshInfo;
@@ -146,11 +135,11 @@ public class MeshInfoNode
 
 		final Button exportMeshButton = new Button("Export");
 		exportMeshButton.setOnAction(event -> {
-			final MeshExporterDialog<Long>     exportDialog = new MeshExporterDialog<>(meshInfo);
-			final Optional<ExportResult<Long>> result       = exportDialog.showAndWait();
+			final SegmentMeshExporterDialog<Long> exportDialog = new SegmentMeshExporterDialog<>(meshInfo);
+			final Optional<SegmentMeshExportResult<Long>> result = exportDialog.showAndWait();
 			if (result.isPresent())
 			{
-				final ExportResult<Long> parameters = result.get();
+				final SegmentMeshExportResult<Long> parameters = result.get();
 				parameters.getMeshExporter().exportMesh(
 						meshInfo.meshManager().getGetBlockListForLongKey(),
 						meshInfo.meshManager().getGetMeshForLongKey(),

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/meshes/managed/MeshManagerWithSingleMesh.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/meshes/managed/MeshManagerWithSingleMesh.kt
@@ -1,6 +1,5 @@
 package org.janelia.saalfeldlab.paintera.meshes.managed
 
-import javafx.application.Platform
 import javafx.beans.InvalidationListener
 import javafx.beans.property.BooleanProperty
 import javafx.beans.property.ObjectProperty
@@ -18,12 +17,10 @@ import org.janelia.saalfeldlab.paintera.meshes.MeshViewUpdateQueue
 import org.janelia.saalfeldlab.paintera.meshes.MeshWorkerPriority
 import org.janelia.saalfeldlab.paintera.meshes.managed.adaptive.AdaptiveResolutionMeshManager
 import org.janelia.saalfeldlab.paintera.viewer3d.ViewFrustum
-import org.janelia.saalfeldlab.util.NamedThreadFactory
 import org.janelia.saalfeldlab.util.concurrent.HashPriorityQueueBasedTaskExecutor
 import org.slf4j.LoggerFactory
 import java.lang.invoke.MethodHandles
 import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
 
 /**
  * @author Philipp Hanslovsky
@@ -31,15 +28,20 @@ import java.util.concurrent.Executors
  */
 class MeshManagerWithSingleMesh<Key>(
     source: DataSource<*, *>,
-    private val getBlockList: GetBlockListFor<Key>,
-    private val getMeshFor: GetMeshFor<Key>,
+    getBlockList: GetBlockListFor<Key>,
+    getMeshFor: GetMeshFor<Key>,
     viewFrustumProperty: ObservableValue<ViewFrustum>,
     eyeToWorldTransformProperty: ObservableValue<AffineTransform3D>,
     val managers: ExecutorService,
     val workers: HashPriorityQueueBasedTaskExecutor<MeshWorkerPriority>,
-    val meshViewUpdateQueue: MeshViewUpdateQueue<Key>) {
+    meshViewUpdateQueue: MeshViewUpdateQueue<Key>) {
 
-    private var meshKey: Key? = null
+    val getMeshFor = getMeshFor
+    val getBlockList = getBlockList
+
+    var meshKey: Key? = null
+        @Synchronized get
+        @Synchronized private set
 
     private val viewerEnabled: BooleanProperty = SimpleBooleanProperty(false)
     var isViewerEnabled: Boolean

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/IntersectingSourceStatePreferencePaneNode.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/IntersectingSourceStatePreferencePaneNode.kt
@@ -1,6 +1,5 @@
 package org.janelia.saalfeldlab.paintera.state
 
-import javafx.event.ActionEvent
 import javafx.event.EventHandler
 import javafx.geometry.Pos
 import javafx.scene.Node
@@ -11,6 +10,7 @@ import javafx.scene.layout.Region
 import javafx.scene.layout.VBox
 import javafx.stage.Modality
 import org.janelia.saalfeldlab.fx.Buttons
+import org.janelia.saalfeldlab.fx.TitledPaneExtensions
 import org.janelia.saalfeldlab.paintera.ui.PainteraAlerts
 import org.janelia.saalfeldlab.paintera.ui.RefreshButton.createFontAwesome
 
@@ -45,7 +45,7 @@ class IntersectingSourceStatePreferencePaneNode(private val state: IntersectingS
                 "with the check box."
 
             val helpButton = Button("?")
-            helpButton.onAction = EventHandler { e: ActionEvent? -> helpDialog.show() }
+            helpButton.onAction = EventHandler { helpDialog.show() }
             helpButton.alignment = Pos.CENTER
 
             val tpGraphics = HBox(
@@ -56,20 +56,28 @@ class IntersectingSourceStatePreferencePaneNode(private val state: IntersectingS
                 helpButton)
             tpGraphics.alignment = Pos.CENTER
 
-            val tp = TitledPane(null, null)
-            tp.isExpanded = false
-            tp.alignment = Pos.CENTER_RIGHT
-            // Make titled pane title graphics only.
-            // TODO make methods in TitledPaneExtensions.kt @JvmStatic so they can be
-            // TODO called from here instead of re-writing in Java.
-            // Make titled pane title graphics only.
-            // TODO make methods in TitledPaneExtensions.kt @JvmStatic so they can be
-            // TODO called from here instead of re-writing in Java.
-            val regionWidth = tp.widthProperty().subtract(50.0)
-            tpGraphics.prefWidthProperty().bind(regionWidth)
-            tp.text = null
-            tp.graphic = tpGraphics
-            tp.contentDisplay = ContentDisplay.GRAPHIC_ONLY
+            val exportMeshButton = Button("Export")
+            exportMeshButton.setOnAction {
+                // TODO
+//                val exportDialog = MeshExporterDialog<Long>(meshInfo)
+//                val result = exportDialog.showAndWait()
+//                if (result.isPresent) {
+//                    val parameters = result.get()
+//                    parameters.meshExporter.exportMesh(
+//                        manager.getBlockListForLongKey,
+//                        manager.getMeshForLongKey,
+//                        parameters.segmentId.map { it }.toTypedArray(),
+//                        parameters.scale,
+//                        parameters.filePaths)
+//                }
+            }
+
+            val tp = with (TitledPaneExtensions) {
+                TitledPane(null, exportMeshButton)
+                    .also { it.isExpanded = false }
+                    .also { it.graphicsOnly(tpGraphics) }
+                    .also { it.alignment = Pos.CENTER_RIGHT }
+            }
 
             vbox.children.add(tp)
             return vbox

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/IntersectingSourceStatePreferencePaneNode.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/IntersectingSourceStatePreferencePaneNode.kt
@@ -60,7 +60,7 @@ class IntersectingSourceStatePreferencePaneNode(private val state: IntersectingS
             exportMeshButton.setOnAction {
                 val manager = state.meshManager()
                 val meshInfo = MeshInfo(manager)
-                val exportDialog = MeshExporterDialog<TLongHashSet>(meshInfo)
+                val exportDialog = MeshExporterDialog(meshInfo)
                 val result = exportDialog.showAndWait()
                 if (result.isPresent) {
                     val parameters = result.get()

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/IntersectingSourceStatePreferencePaneNode.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/IntersectingSourceStatePreferencePaneNode.kt
@@ -1,6 +1,5 @@
 package org.janelia.saalfeldlab.paintera.state
 
-import gnu.trove.set.hash.TLongHashSet
 import javafx.event.EventHandler
 import javafx.geometry.Pos
 import javafx.scene.Node

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/IntersectingSourceStatePreferencePaneNode.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/IntersectingSourceStatePreferencePaneNode.kt
@@ -4,10 +4,7 @@ import javafx.event.EventHandler
 import javafx.geometry.Pos
 import javafx.scene.Node
 import javafx.scene.control.*
-import javafx.scene.layout.HBox
-import javafx.scene.layout.Priority
-import javafx.scene.layout.Region
-import javafx.scene.layout.VBox
+import javafx.scene.layout.*
 import javafx.stage.Modality
 import org.janelia.saalfeldlab.fx.Buttons
 import org.janelia.saalfeldlab.fx.TitledPaneExtensions
@@ -72,12 +69,13 @@ class IntersectingSourceStatePreferencePaneNode(private val state: IntersectingS
 //                }
             }
 
-            val tp = with (TitledPaneExtensions) {
-                TitledPane(null, exportMeshButton)
-                    .also { it.isExpanded = false }
-                    .also { it.graphicsOnly(tpGraphics) }
-                    .also { it.alignment = Pos.CENTER_RIGHT }
-            }
+            val contents = GridPane()
+            contents.children += exportMeshButton
+
+            val tp = TitledPane(null, contents)
+                .also { it.isExpanded = false }
+                .also { with (TitledPaneExtensions) { it.graphicsOnly(tpGraphics) } }
+                .also { it.alignment = Pos.CENTER_RIGHT }
 
             vbox.children.add(tp)
             return vbox

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/IntersectingSourceStatePreferencePaneNode.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/IntersectingSourceStatePreferencePaneNode.kt
@@ -1,0 +1,77 @@
+package org.janelia.saalfeldlab.paintera.state
+
+import javafx.event.ActionEvent
+import javafx.event.EventHandler
+import javafx.geometry.Pos
+import javafx.scene.Node
+import javafx.scene.control.*
+import javafx.scene.layout.HBox
+import javafx.scene.layout.Priority
+import javafx.scene.layout.Region
+import javafx.scene.layout.VBox
+import javafx.stage.Modality
+import org.janelia.saalfeldlab.fx.Buttons
+import org.janelia.saalfeldlab.paintera.ui.PainteraAlerts
+import org.janelia.saalfeldlab.paintera.ui.RefreshButton.createFontAwesome
+
+class IntersectingSourceStatePreferencePaneNode(private val state: IntersectingSourceState) {
+
+    val node: Node
+        get() {
+            val vbox = SourceState.defaultPreferencePaneNode(state.compositeProperty()).let { if (it is VBox) it else VBox(it) }
+
+            val spacer = Region()
+            HBox.setHgrow(spacer, Priority.ALWAYS)
+            spacer.minWidth = 0.0
+
+            val enabledCheckBox = CheckBox()
+            enabledCheckBox.selectedProperty().bindBidirectional(state.meshesEnabledProperty())
+            enabledCheckBox.tooltip = Tooltip("Toggle meshes on/off. " +
+                "If meshes are disabled in the underlying label source, " +
+                "meshes for this source are disabled, too.")
+
+            val refreshButton = Buttons.withTooltip(null, "Refresh Meshes", EventHandler { state.refreshMeshes() })
+            val reloadSymbol = createFontAwesome(2.0)
+            reloadSymbol.rotate = 45.0
+            refreshButton.graphic = reloadSymbol
+
+
+            val helpDialog = PainteraAlerts.alert(Alert.AlertType.INFORMATION, true)
+            helpDialog.initModality(Modality.NONE)
+            helpDialog.headerText = "Mesh Settings"
+            helpDialog.contentText = "" +
+                "Intersecting sources inherit their mesh settings from the global settings for the " +
+                "underlying label source and cannot be configured explicitly. The meshes can be toggled on/off " +
+                "with the check box."
+
+            val helpButton = Button("?")
+            helpButton.onAction = EventHandler { e: ActionEvent? -> helpDialog.show() }
+            helpButton.alignment = Pos.CENTER
+
+            val tpGraphics = HBox(
+                Label("Meshes"),
+                spacer,
+                enabledCheckBox,
+                refreshButton,
+                helpButton)
+            tpGraphics.alignment = Pos.CENTER
+
+            val tp = TitledPane(null, null)
+            tp.isExpanded = false
+            tp.alignment = Pos.CENTER_RIGHT
+            // Make titled pane title graphics only.
+            // TODO make methods in TitledPaneExtensions.kt @JvmStatic so they can be
+            // TODO called from here instead of re-writing in Java.
+            // Make titled pane title graphics only.
+            // TODO make methods in TitledPaneExtensions.kt @JvmStatic so they can be
+            // TODO called from here instead of re-writing in Java.
+            val regionWidth = tp.widthProperty().subtract(50.0)
+            tpGraphics.prefWidthProperty().bind(regionWidth)
+            tp.text = null
+            tp.graphic = tpGraphics
+            tp.contentDisplay = ContentDisplay.GRAPHIC_ONLY
+
+            vbox.children.add(tp)
+            return vbox
+        }
+}

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/IntersectingSourceStatePreferencePaneNode.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/IntersectingSourceStatePreferencePaneNode.kt
@@ -1,5 +1,6 @@
 package org.janelia.saalfeldlab.paintera.state
 
+import gnu.trove.set.hash.TLongHashSet
 import javafx.event.EventHandler
 import javafx.geometry.Pos
 import javafx.scene.Node
@@ -8,8 +9,10 @@ import javafx.scene.layout.*
 import javafx.stage.Modality
 import org.janelia.saalfeldlab.fx.Buttons
 import org.janelia.saalfeldlab.fx.TitledPaneExtensions
+import org.janelia.saalfeldlab.paintera.meshes.MeshInfo
 import org.janelia.saalfeldlab.paintera.ui.PainteraAlerts
 import org.janelia.saalfeldlab.paintera.ui.RefreshButton.createFontAwesome
+import org.janelia.saalfeldlab.paintera.ui.source.mesh.MeshExporterDialog
 
 class IntersectingSourceStatePreferencePaneNode(private val state: IntersectingSourceState) {
 
@@ -55,18 +58,19 @@ class IntersectingSourceStatePreferencePaneNode(private val state: IntersectingS
 
             val exportMeshButton = Button("Export")
             exportMeshButton.setOnAction {
-                // TODO
-//                val exportDialog = MeshExporterDialog<Long>(meshInfo)
-//                val result = exportDialog.showAndWait()
-//                if (result.isPresent) {
-//                    val parameters = result.get()
-//                    parameters.meshExporter.exportMesh(
-//                        manager.getBlockListForLongKey,
-//                        manager.getMeshForLongKey,
-//                        parameters.segmentId.map { it }.toTypedArray(),
-//                        parameters.scale,
-//                        parameters.filePaths)
-//                }
+                val manager = state.meshManager()
+                val meshInfo = MeshInfo(manager)
+                val exportDialog = MeshExporterDialog<TLongHashSet>(meshInfo)
+                val result = exportDialog.showAndWait()
+                if (result.isPresent) {
+                    val parameters = result.get()
+                    parameters.meshExporter.exportMesh(
+                        manager.getBlockList,
+                        manager.getMeshFor,
+                        meshInfo.key,
+                        parameters.scale,
+                        parameters.filePath)
+                }
             }
 
             val contents = GridPane()

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/LabelSourceStateMeshPaneNode.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/LabelSourceStateMeshPaneNode.kt
@@ -20,13 +20,13 @@ import org.janelia.saalfeldlab.fx.TitledPaneExtensions
 import org.janelia.saalfeldlab.fx.util.InvokeOnJavaFXApplicationThread
 import org.janelia.saalfeldlab.paintera.data.DataSource
 import org.janelia.saalfeldlab.paintera.meshes.GlobalMeshProgress
-import org.janelia.saalfeldlab.paintera.meshes.MeshInfo
-import org.janelia.saalfeldlab.paintera.meshes.MeshInfos
+import org.janelia.saalfeldlab.paintera.meshes.SegmentMeshInfo
+import org.janelia.saalfeldlab.paintera.meshes.SegmentMeshInfos
 import org.janelia.saalfeldlab.paintera.meshes.managed.MeshManagerWithAssignmentForSegments
 import org.janelia.saalfeldlab.paintera.meshes.ui.MeshSettingsNode
 import org.janelia.saalfeldlab.paintera.ui.PainteraAlerts
-import org.janelia.saalfeldlab.paintera.ui.source.mesh.MeshExporterDialog
-import org.janelia.saalfeldlab.paintera.ui.source.mesh.MeshInfoNode
+import org.janelia.saalfeldlab.paintera.ui.source.mesh.SegmentMeshExporterDialog
+import org.janelia.saalfeldlab.paintera.ui.source.mesh.SegmentMeshInfoNode
 import org.janelia.saalfeldlab.paintera.ui.source.mesh.MeshProgressBar
 import org.slf4j.LoggerFactory
 import java.lang.invoke.MethodHandles
@@ -38,7 +38,7 @@ typealias TPE = TitledPaneExtensions
 class LabelSourceStateMeshPaneNode(
         private val source: DataSource<*, *>,
         private val manager: MeshManagerWithAssignmentForSegments,
-        private val meshInfos: MeshInfos) {
+        private val meshInfos: SegmentMeshInfos) {
 
 	val node: Node
 		get() = makeNode()
@@ -61,20 +61,20 @@ class LabelSourceStateMeshPaneNode(
 	private class MeshesList(
         private val source: DataSource<*, *>,
         private val manager: MeshManagerWithAssignmentForSegments,
-        private val meshInfos: MeshInfos) {
+        private val meshInfos: SegmentMeshInfos) {
 
 		private class Listener(
             private val source: DataSource<*, *>,
             private val manager: MeshManagerWithAssignmentForSegments,
-            private val meshInfos: MeshInfos,
+            private val meshInfos: SegmentMeshInfos,
             private val meshesBox: Pane,
             private val isMeshListEnabledCheckBox: CheckBox,
-            private val totalProgressBar: MeshProgressBar): ListChangeListener<MeshInfo> {
+            private val totalProgressBar: MeshProgressBar): ListChangeListener<SegmentMeshInfo> {
 
-			val infoNodesCache = FXCollections.observableHashMap<MeshInfo, MeshInfoNode>()
-			val infoNodes = FXCollections.observableArrayList<MeshInfoNode>()
+			val infoNodesCache = FXCollections.observableHashMap<SegmentMeshInfo, SegmentMeshInfoNode>()
+			val infoNodes = FXCollections.observableArrayList<SegmentMeshInfoNode>()
 
-			override fun onChanged(change: ListChangeListener.Change<out MeshInfo>) {
+			override fun onChanged(change: ListChangeListener.Change<out SegmentMeshInfo>) {
 				while (change.next())
 					if (change.wasRemoved())
 						change.removed.forEach { infoNodesCache.remove(it) }
@@ -86,12 +86,12 @@ class LabelSourceStateMeshPaneNode(
 			}
 
 			private fun populateInfoNodes() {
-				val infoNodes = this.meshInfos.readOnlyInfos().map { MeshInfoNode(source, it) }
+				val infoNodes = this.meshInfos.readOnlyInfos().map { SegmentMeshInfoNode(source, it) }
 				LOG.debug("Setting info nodes: {}: ", infoNodes)
 				this.infoNodes.setAll(infoNodes)
 				val exportMeshButton = Button("Export all")
 				exportMeshButton.setOnAction { _ ->
-					val exportDialog = MeshExporterDialog<Long>(meshInfos)
+					val exportDialog = SegmentMeshExporterDialog<Long>(meshInfos)
 					val result = exportDialog.showAndWait()
 					if (result.isPresent) {
 						val parameters = result.get()

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/LabelSourceStatePreferencePaneNode.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/LabelSourceStatePreferencePaneNode.kt
@@ -27,7 +27,7 @@ import org.janelia.saalfeldlab.paintera.data.DataSource
 import org.janelia.saalfeldlab.paintera.data.mask.MaskedSource
 import org.janelia.saalfeldlab.paintera.data.mask.exception.CannotClearCanvas
 import org.janelia.saalfeldlab.paintera.meshes.ManagedMeshSettings
-import org.janelia.saalfeldlab.paintera.meshes.MeshInfos
+import org.janelia.saalfeldlab.paintera.meshes.SegmentMeshInfos
 import org.janelia.saalfeldlab.paintera.meshes.managed.MeshManagerWithAssignmentForSegments
 import org.janelia.saalfeldlab.paintera.stream.HighlightingStreamConverter
 import org.janelia.saalfeldlab.paintera.stream.HighlightingStreamConverterConfigNode
@@ -57,7 +57,7 @@ class LabelSourceStatePreferencePaneNode(
 			val nodes = arrayOf(
                 HighlightingStreamConverterConfigNode(converter).node,
                 SelectedIdsNode(selectedIds, assignment, selectedSegments).node,
-                LabelSourceStateMeshPaneNode(source, meshManager, MeshInfos(selectedSegments, meshManager, meshSettings, source.numMipmapLevels)).node,
+                LabelSourceStateMeshPaneNode(source, meshManager, SegmentMeshInfos(selectedSegments, meshManager, meshSettings, source.numMipmapLevels)).node,
                 AssignmentsNode(assignment).node,
                 if (source is MaskedSource && brushProperties != null) MaskedSourceNode(source, brushProperties).node else null)
 			box.children.addAll(nodes.filterNotNull())


### PR DESCRIPTION
Adds new `Export` button under the `Meshes` tab in the menu of an intersecting source.

After selecting the output directory, the meshes will be stored in a file `synapses{segment_ids}.obj` (or `.bin`), so that the filename will include the current selection of segments that generate the synapse meshes of the intersecting source.