### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ conda install -c conda-forge maven
 ```
 Note that OpenJDK on the `conda-forge` channels does not ship with JavaFX and cannot be used.
 
+#### Installation on Windows 10
+
+Windows user need to specify the exact JDK version
+```
+conda install -c conda-forge openjdk=8.0.152
+```
 
 #### Installation on Linux
 


### PR DESCRIPTION
This fixes the below error. Cause by openjdk v11 when it should be v8. Could apply to linux as well

WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by bdv.fx.viewer.render.BufferExposingWritableImage (file:/C:/Users/madany/Anaconda3/envs/paintera/jgo/org.janelia.saalfeldlab/paintera/0.25.0/paintera-0.25.0.jar) to method javafx.scene.image.Image.setPlatformImage(com.sun.javafx.tk.PlatformImage)
WARNING: Please consider reporting this to the maintainers of bdv.fx.viewer.render.BufferExposingWritableImage
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Exception in Application start method
java.lang.reflect.InvocationTargetException
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at javafx.graphics/com.sun.javafx.application.LauncherImpl.launchApplicationWithArgs(LauncherImpl.java:473)
        at javafx.graphics/com.sun.javafx.application.LauncherImpl.launchApplication(LauncherImpl.java:372)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at java.base/sun.launcher.LauncherHelper$FXHelper.main(LauncherHelper.java:1051)
Caused by: java.lang.RuntimeException: Exception in Application start method
        at javafx.graphics/com.sun.javafx.application.LauncherImpl.launchApplication1(LauncherImpl.java:973)
        at javafx.graphics/com.sun.javafx.application.LauncherImpl.lambda$launchApplication$2(LauncherImpl.java:198)
        at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.NoClassDefFoundError: com/sun/javafx/css/parser/CSSParser
        at de.jensd.fx.glyphs.GlyphIcon.<clinit>(GlyphIcon.java:49)
        at org.janelia.saalfeldlab.paintera.ui.FontAwesome$Companion.withIcon(FontAwesome.kt:11)
        at org.janelia.saalfeldlab.paintera.ui.FontAwesome$Companion.get(FontAwesome.kt:16)
        at org.janelia.saalfeldlab.paintera.BorderPaneWithStatusBars.<init>(BorderPaneWithStatusBars.kt:50)
        at org.janelia.saalfeldlab.paintera.PainteraMainWindow.initProperties(PainteraMainWindow.kt:149)
        at org.janelia.saalfeldlab.paintera.PainteraMainWindow.initProperties(PainteraMainWindow.kt:157)
        at org.janelia.saalfeldlab.paintera.PainteraMainWindow.deserialize(PainteraMainWindow.kt:286)
        at org.janelia.saalfeldlab.paintera.PainteraMainWindow.deserialize(PainteraMainWindow.kt:175)
        at org.janelia.saalfeldlab.paintera.Paintera.start(Paintera.kt:47)
        at javafx.graphics/com.sun.javafx.application.LauncherImpl.lambda$launchApplication1$9(LauncherImpl.java:919)
        at javafx.graphics/com.sun.javafx.application.PlatformImpl.lambda$runAndWait$11(PlatformImpl.java:449)
        at javafx.graphics/com.sun.javafx.application.PlatformImpl.lambda$runLater$9(PlatformImpl.java:418)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at javafx.graphics/com.sun.javafx.application.PlatformImpl.lambda$runLater$10(PlatformImpl.java:417)
        at javafx.graphics/com.sun.glass.ui.InvokeLaterDispatcher$Future.run(InvokeLaterDispatcher.java:96)
        at javafx.graphics/com.sun.glass.ui.win.WinApplication._runLoop(Native Method)
        at javafx.graphics/com.sun.glass.ui.win.WinApplication.lambda$runLoop$3(WinApplication.java:175)
        ... 1 more
Caused by: java.lang.ClassNotFoundException: com.sun.javafx.css.parser.CSSParser
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
        ... 18 more