### PR TITLE
don't exit shape interpolation mode if it's due to disable/enable of AllowedActions

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/actions/AllowedActionsProperty.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/actions/AllowedActionsProperty.java
@@ -17,6 +17,7 @@ public class AllowedActionsProperty extends SimpleObjectProperty<AllowedActions>
   private final BooleanProperty isDisabled = new SimpleBooleanProperty(false);
   private Cursor previousCursor = Cursor.DEFAULT;
   private AllowedActions disabledActions;
+  private boolean currentlyProcessingEnableDisable = false;
 
   public AllowedActionsProperty(final Node ownerNode) {
 
@@ -52,12 +53,16 @@ public class AllowedActionsProperty extends SimpleObjectProperty<AllowedActions>
 
   public void disable() {
 
+	currentlyProcessingEnableDisable = true;
 	isDisabled.set(true);
+	currentlyProcessingEnableDisable = false;
   }
 
   public void enable() {
 
+	currentlyProcessingEnableDisable = true;
 	isDisabled.set(false);
+	currentlyProcessingEnableDisable = false;
   }
 
   private void disableActionsListener(final ObservableValue<? extends Boolean> obs, final Boolean previouslyDisabled, final Boolean disable) {
@@ -77,5 +82,10 @@ public class AllowedActionsProperty extends SimpleObjectProperty<AllowedActions>
 	  set(disabledActions);
 	  disabledActions = null;
 	}
+  }
+
+  public boolean isProcessingEnableDisable() {
+
+	return currentlyProcessingEnableDisable;
   }
 }


### PR DESCRIPTION
To avoid redundant pop-ups, actions are disabled when generating a new label mask, and re-enabled after.

However, shape interpolation creates masks during interpolation mode. This introduced the following bug where shape-interpolation was not possible:

1. Shape interpolation mode is entered on pressing `s`. As a result, a listener is added to the `allowedActionsProperty` that checks if the allowed actions are changed, and if so exits shape interpolation mode.
2. Upon selecting a label, a mask is generated to show which label was selected
3. generating a mask triggers the `allowedActionsProperty.disable()`
4. `disable()` remove the current set of allowed actions and replaces them with an empty set (i.e. no actions are allowed).
5. Since we modified the `allowedActionsProperty`'s contents, the aforementioned listener was triggered, and shape interpolation mode was exited.

The result of this bug is that shape-interpolation was not possible.

This PR resolves this bug. Since we don't want to exit interpolation mode during mask generation, we need to ensure that we are not in the process of enabling/disabling actions. If we are, then don't exit, since it is expected. If we are not enabling/disabling, then we want to proceed as usually, and exit interpolation mode.