### PR TITLE
Bugfix/shape interpolation exit

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/control/ShapeInterpolationMode.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/control/ShapeInterpolationMode.java
@@ -369,6 +369,7 @@ public class ShapeInterpolationMode<D extends IntegerType<D>> {
 	paintera.allowedActionsProperty().removeListener(modeSwitchListener);
 	modeSwitchListener = null;
 
+	paintera.allowedActionsProperty().enable();
 	paintera.allowedActionsProperty().set(lastAllowedActions);
 	lastAllowedActions = null;
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceStatePaintHandler.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceStatePaintHandler.java
@@ -207,8 +207,13 @@ public class LabelSourceStatePaintHandler<T extends IntegerType<T>> {
 			  LOG.trace("Hiding brush overlay!");
 			  paint2D.hideBrushOverlay();
 			},
-			event -> paintera.allowedActionsProperty().get().isAllowed(PaintActionType.Paint) && event.getCode().equals(KeyCode.SPACE) && !keyTracker
-					.areKeysDown(KeyCode.SPACE)));
+			event -> {
+			  /* Sometimes we are  disabled (i.e. UI is blocked due to painting) but the user releases the SPACE key. when done being busy, we want to no longer
+			   * have the brush overlay (unless they press space again). To the end, always allow the brush overlay to be hidden, regardless of PAINT being allowed or not. */
+			  boolean releasedSpace = event.getCode().equals(KeyCode.SPACE) && !keyTracker.areKeysDown(KeyCode.SPACE);
+			  final var hideNotAllowed = !paintera.allowedActionsProperty().get().isAllowed(PaintActionType.Paint) && releasedSpace;
+			  return event.getCode().equals(KeyCode.SPACE) && !keyTracker.areKeysDown(KeyCode.SPACE);
+			}));
 
 	handler.addOnScroll(EventFX.SCROLL(
 			"change brush size",


### PR DESCRIPTION
Fix a few tiny issues:
- return UI control when finishing interpolation
- remove brush overlay when SPACE is released while `disabled`