### PR TITLE
bump n5-imglib2 version to fix hdf5 offset parsing bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5-imglib2</artifactId>
-			<version>4.1.1</version>
+			<version>4.2.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>


### PR DESCRIPTION
This n5-imglib2 bump solves an issue where certain hd5f files where not having their offset metadata parsed properly. 