### PR TITLE
fix: stop translation from occurring during erase

### DIFF
--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/modes/NavigationControlMode.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/modes/NavigationControlMode.kt
@@ -9,7 +9,7 @@ import javafx.scene.input.KeyEvent.KEY_PRESSED
 import javafx.scene.input.ScrollEvent
 import net.imglib2.realtransform.AffineTransform3D
 import org.janelia.saalfeldlab.fx.actions.*
-import org.janelia.saalfeldlab.fx.extensions.LazyForeignValue
+import org.janelia.saalfeldlab.fx.extensions.LazyForeignMap
 import org.janelia.saalfeldlab.fx.extensions.invoke
 import org.janelia.saalfeldlab.fx.extensions.nonnullVal
 import org.janelia.saalfeldlab.paintera.NavigationKeys
@@ -89,10 +89,8 @@ object NavigationTool : ViewerTool() {
         }
     }
 
-
-    override val actionSets by LazyForeignValue({ activeViewerAndTransforms }) { viewerAndTransforms ->
+    override val actionSets by LazyForeignMap({ activeViewerAndTransforms }) { viewerAndTransforms ->
         viewerAndTransforms?.run {
-
             val viewerTransform = AffineTransform3D().apply {
                 viewer().addTransformListener { set(it) }
             }

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/modes/ShapeInterpolationMode.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/modes/ShapeInterpolationMode.kt
@@ -232,9 +232,8 @@ class ShapeInterpolationTool(val controller: ShapeInterpolationController<*>, ke
 
     private val baseView = paintera.baseView
 
-    override val actionSets: List<ActionSet> = mutableListOf(
-        shapeInterpolationActions(keyCombinations),
-        *NavigationTool.actionSets.toTypedArray()
+    override val actionSets: List<ActionSet> = listOf(
+        shapeInterpolationActions(keyCombinations)
     )
 
     override fun activate() {

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/tools/Tool.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/tools/Tool.kt
@@ -39,7 +39,6 @@ abstract class ViewerTool : Tool {
 
     override fun activate() {
         activeViewerProperty.bind(paintera.baseView.orthogonalViews().currentFocusHolder())
-//        activeViewerAndTransforms?.viewer()?.let { installInto(it) }
     }
 
     override fun deactivate() {


### PR DESCRIPTION
A bug was discovered where right-click and drag to erase would also cause the orthoslice to translate in the xy plane, as if you where not in Paint Mode. This was caused when the Viewer lost focus (from clicking off Paintera, or minimizing) during Shape Interpolation Mode. When this occurred, the active viewer was `null` and so the navigation actions would not be removed from the previous viewer, and would persist when the window was maximized again. 

The solution changes the `LazyForeignValue` which only contains a single item, to a `LazyForeignMap` which retains the ActionSets from the previous Viewer, even when it is no longer active. This means when we do finally remove the ActionSets, they are the same instances we installed initially, not a new copy. 