### PR TITLE
feat: Make sidebar menu visible by default

### DIFF
--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/config/SideBarConfig.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/config/SideBarConfig.kt
@@ -6,7 +6,7 @@ import org.janelia.saalfeldlab.fx.extensions.nonnull
 
 class SideBarConfig {
 
-    val isVisibleProperty = SimpleBooleanProperty(false)
+    val isVisibleProperty = SimpleBooleanProperty(true)
     var isVisible: Boolean by isVisibleProperty.nonnull()
 
     val widthProperty = SimpleDoubleProperty(DEFAULT_WIDTH)


### PR DESCRIPTION
Sidebar menu is now visible by default. Reopening saved paintera projects will remember configuration from last user settings.