### PR TITLE
Bugfix/0.34.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,7 +554,7 @@ extract-to-scalar
 command extracts the highest resolution scale level of a Paintera dataset as a scalar `uint64`. Dataset. This is useful for using Paintera painted labels (and assignments) in downstream processing, e.g. classifier training. Optionally, the `fragment-segment-assignment` can be considered and additional assignments can be added (versions `0.8.0` and later). See `extract-to-scalar --help` for more details. The `paintera-conversion-helper` is installed with Paintera when installed through [conda](#conda) or [pip](#pip) but may need to be updated to support this feature.
 
 
-## Technical Notes
+# Technical Notes
 
 This section will expand in detail some of the technical aspect of some Paintera features that may be useful to understand.
 #### 2D Viewer-Aligned Painting

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/modes/PaintLabelMode.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/modes/PaintLabelMode.kt
@@ -170,7 +170,6 @@ object PaintLabelMode : AbstractToolMode() {
                 activeSourceStateProperty.get()?.dataSource as? MaskedSource<out IntegerType<*>, *> != null
             }
             onAction {
-                disableUnfocusedViewers()
                 switchTool(samTool)
             }
         }
@@ -178,7 +177,6 @@ object PaintLabelMode : AbstractToolMode() {
             verify { activeSourceStateProperty.get() is ConnectomicsLabelState<*, *> }
             verify { activeTool is SamTool }
             onAction {
-                enableAllViewers()
                 switchTool(defaultTool)
             }
         }
@@ -188,7 +186,6 @@ object PaintLabelMode : AbstractToolMode() {
             filter = true
             consume = false
             onAction {
-                enableAllViewers()
                 switchTool(defaultTool)
             }
         }

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/paint/PaintClickOrDragController.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/paint/PaintClickOrDragController.kt
@@ -326,9 +326,8 @@ class PaintClickOrDragController(
 				paintIntervalInMask
 			}.onSuccess { _, task ->
 				val paintIntervalInMask = task.get()
-				val globalPaintInterval = extendAndTransformBoundingBox(paintIntervalInMask, initialGlobalToMaskTransform.inverse(), .5)
 				maskInterval = paintIntervalInMask union maskInterval
-				paintera.orthogonalViews().requestRepaint(globalPaintInterval)
+                requestRepaint(paintIntervalInMask)
 			}.submit()
 		}
 

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/paint/ViewerMask.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/paint/ViewerMask.kt
@@ -25,6 +25,7 @@ import org.janelia.saalfeldlab.paintera.data.mask.MaskInfo
 import org.janelia.saalfeldlab.paintera.data.mask.MaskedSource
 import org.janelia.saalfeldlab.paintera.data.mask.SourceMask
 import org.janelia.saalfeldlab.paintera.paintera
+import org.janelia.saalfeldlab.paintera.util.IntervalHelpers
 import org.janelia.saalfeldlab.paintera.util.IntervalHelpers.Companion.asRealInterval
 import org.janelia.saalfeldlab.paintera.util.IntervalHelpers.Companion.extendBy
 import org.janelia.saalfeldlab.paintera.util.IntervalHelpers.Companion.smallestContainingInterval
@@ -385,7 +386,7 @@ class ViewerMask private constructor(
 
     fun requestRepaint(intervalOverMask: Interval? = null) {
         intervalOverMask?.let {
-            val globalInterval = initialGlobalToMaskTransform.inverse().estimateBounds(it)
+            val globalInterval = IntervalHelpers.extendAndTransformBoundingBox(intervalOverMask, initialGlobalToMaskTransform.inverse(), .5)
             paintera.baseView.orthogonalViews().requestRepaint(globalInterval)
         } ?: paintera.baseView.orthogonalViews().requestRepaint()
     }

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/tools/paint/SamTool.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/tools/paint/SamTool.kt
@@ -71,6 +71,8 @@ import org.janelia.saalfeldlab.labels.Label
 import org.janelia.saalfeldlab.paintera.DeviceManager
 import org.janelia.saalfeldlab.paintera.PainteraBaseView
 import org.janelia.saalfeldlab.paintera.control.actions.PaintActionType
+import org.janelia.saalfeldlab.paintera.control.modes.PaintLabelMode
+import org.janelia.saalfeldlab.paintera.control.modes.ShapeInterpolationMode
 import org.janelia.saalfeldlab.paintera.control.modes.ToolMode
 import org.janelia.saalfeldlab.paintera.control.paint.ViewerMask
 import org.janelia.saalfeldlab.paintera.control.paint.ViewerMask.Companion.createViewerMask
@@ -135,13 +137,10 @@ open class SamTool(activeSourceStateProperty: SimpleObjectProperty<SourceState<*
             }
 
             return button.also {
+                it.userData = this
                 it.disableProperty().bind(paintera.baseView.isDisabledProperty)
                 it.styleClass += "toolbar-button"
-                it.tooltip = Tooltip(
-                    keyTrigger?.let { keys ->
-                        "$name: ${KeyTracker.keysToString(*keys.toTypedArray())}"
-                    } ?: name
-                )
+                it.tooltip = Tooltip( "$name: ${KeyTracker.keysToString(*keyTrigger.toTypedArray())}" )
             }
         }
 
@@ -236,6 +235,9 @@ open class SamTool(activeSourceStateProperty: SimpleObjectProperty<SourceState<*
     private var predictionImagePngOutputStream = PipedOutputStream(predictionImagePngInputStream)
     override fun activate() {
         super.activate()
+        if (mode !is ShapeInterpolationMode<*>) {
+            PaintLabelMode.disableUnfocusedViewers()
+        }
         controlMode = false
         threshold = 5.0
         setCurrentLabelToSelection()
@@ -294,6 +296,10 @@ open class SamTool(activeSourceStateProperty: SimpleObjectProperty<SourceState<*
         originalScales = null
         viewerMask = null
         controlMode = false
+        if (mode !is ShapeInterpolationMode<*>) {
+            PaintLabelMode.enableAllViewers()
+        }
+
         super.deactivate()
     }
 


### PR DESCRIPTION
Fix a few things:
- Retry SAM prediction when onnxruntime fails in a particular recoverable way
- refresh only over necessary region during SAM prediction
- don't flood fill into background with click-select flood fill in shape interpolation (fill2d tool still allows it)
- more robust enable/disable viewer logic for SAM prediction