### PR TITLE
ci: installed destination based on matrix.os in github actions

### DIFF
--- a/.github/workflows/maven-build-all-installer.yml
+++ b/.github/workflows/maven-build-all-installer.yml
@@ -51,13 +51,13 @@ jobs:
           cache: 'maven'
       - name: "Build with Maven"
         if: matrix.os != 'macos-latest' && matrix.os != 'macOS-ARM64'
-        run: mvn -B clean install -DskipTests -Pbuild-installer --file pom.xml
+        run: mvn -B clean install -DskipTests -Pbuild-installer -Dmatrix.os=${{ matrix.os }} --file pom.xml
       - name: "Build with Maven (macOS No Signing)"
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
         if: ${{ env.MACOS_CERTIFICATE == null && (matrix.os == 'macos-latest' || matrix.os == 'macOS-ARM64') }}
-        run: mvn -B clean install -DskipTests -Pbuild-installer --file pom.xml
+        run: mvn -B clean install -DskipTests -Pbuild-installer -Dmatrix.os=${{ matrix.os }} --file pom.xml
       - name: Update Automatic Release
         uses: marvinpinto/action-automatic-releases@latest
         if: ${{ env.RELEASE_INSTALLERS }}
@@ -68,6 +68,4 @@ jobs:
           title: ${{ matrix.os }} Development Build
           files: |
             ${{ env.DMG_PATH }}
-            ./target/*.msi
-            ./target/*.dmg
-            ./target/*.deb
+            ./target/installer-${{ matrix.os }}/*

--- a/.github/workflows/maven-build-all-installer.yml
+++ b/.github/workflows/maven-build-all-installer.yml
@@ -51,13 +51,13 @@ jobs:
           cache: 'maven'
       - name: "Build with Maven"
         if: matrix.os != 'macos-latest' && matrix.os != 'macOS-ARM64'
-        run: mvn -B clean install -DskipTests -Pbuild-installer -Dmatrix.os=${{ matrix.os }} --file pom.xml
+        run: mvn -B clean install -DskipTests -Pbuild-installer "-Dmatrix.os=${{ matrix.os }}" --file pom.xml
       - name: "Build with Maven (macOS No Signing)"
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
         if: ${{ env.MACOS_CERTIFICATE == null && (matrix.os == 'macos-latest' || matrix.os == 'macOS-ARM64') }}
-        run: mvn -B clean install -DskipTests -Pbuild-installer -Dmatrix.os=${{ matrix.os }} --file pom.xml
+        run: mvn -B clean install -DskipTests -Pbuild-installer "-Dmatrix.os=${{ matrix.os }}" --file pom.xml
       - name: Update Automatic Release
         uses: marvinpinto/action-automatic-releases@latest
         if: ${{ env.RELEASE_INSTALLERS }}

--- a/pom.xml
+++ b/pom.xml
@@ -985,6 +985,9 @@
 	<profiles>
 		<profile>
 		<id>build-installer</id>
+			<properties>
+				<matrix.os>${os.name}</matrix.os>
+			</properties>
 			<build>
 				<plugins>
 					<plugin>
@@ -1031,6 +1034,7 @@
 									<!--suppress UnresolvedMavenProperty -->
 									<mainJar>${project.build.finalName}.jar</mainJar>
 									<toolName>jpackage</toolName>
+									<dest>${project.build.directory}/installer-${matrix.os}</dest>
 									<writeOutputToLog>true</writeOutputToLog>
 									<writeErrorsToLog>true</writeErrorsToLog>
 									<failOnError>true</failOnError>

--- a/src/packaging/linux/jpackage.txt
+++ b/src/packaging/linux/jpackage.txt
@@ -1,7 +1,7 @@
 --verbose
 --name ${app.name}
 --icon "${project.basedir}/img/icons/icon-draft.png"
---dest "${project.build.directory}"
+--dest "${project.build.directory}/installer-${matrix.os}"
 --main-class ${main-class}
 --input "${project.build.directory}/dependency"
 --runtime-image "${project.build.directory}/jvm-image"

--- a/src/packaging/osx/jpackage.txt
+++ b/src/packaging/osx/jpackage.txt
@@ -1,6 +1,6 @@
 --name ${app.name}
 --icon "${project.basedir}/img/icons/icon-draft.icns"
---dest "${project.build.directory}"
+--dest "${project.build.directory}/installer-${matrix.os}"
 --main-class ${main-class}
 --input "${project.build.directory}/dependency"
 --runtime-image "${project.build.directory}/jvm-image"

--- a/src/packaging/windows/jpackage.txt
+++ b/src/packaging/windows/jpackage.txt
@@ -4,7 +4,7 @@
 --win-menu-group ${windows.vendor}
 --vendor ${windows.vendor}
 --icon "${project.basedir}/img/icons/icon-draft.ico"
---dest "${project.build.directory}"
+--dest "${project.build.directory}/installer-${matrix.os}"
 --main-class ${main-class}
 --input "${project.build.directory}/dependency"
 --runtime-image "${project.build.directory}/jvm-image"


### PR DESCRIPTION
add matrix.os based installer destination to differentiate dmg files from intel vs amd mac