### PR TITLE
Fix/commit triggers

### DIFF
--- a/.github/workflows/maven-build-all-installer.yml
+++ b/.github/workflows/maven-build-all-installer.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macOS-ARM64]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-14]
     runs-on: ${{ matrix.os }}
     env:
       RELEASE_INSTALLERS: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
@@ -50,13 +50,13 @@ jobs:
           java-package: jdk+fx
           cache: 'maven'
       - name: "Build with Maven"
-        if: matrix.os != 'macos-latest' && matrix.os != 'macOS-ARM64'
+        if: matrix.os != 'macos-latest' && matrix.os != 'macos-14'
         run: mvn -B clean install -DskipTests -Pbuild-installer "-Dmatrix.os=${{ matrix.os }}" --file pom.xml
       - name: "Build with Maven (macOS No Signing)"
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
-        if: ${{ env.MACOS_CERTIFICATE == null && (matrix.os == 'macos-latest' || matrix.os == 'macOS-ARM64') }}
+        if: ${{ env.MACOS_CERTIFICATE == null && (matrix.os == 'macos-latest' || matrix.os == 'macos-14') }}
         run: mvn -B clean install -DskipTests -Pbuild-installer "-Dmatrix.os=${{ matrix.os }}" --file pom.xml
       - name: Update Automatic Release
         uses: marvinpinto/action-automatic-releases@latest

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/Paintera.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/Paintera.kt
@@ -21,6 +21,7 @@ import org.janelia.saalfeldlab.fx.extensions.nonnull
 import org.janelia.saalfeldlab.fx.ui.Exceptions
 import org.janelia.saalfeldlab.fx.util.InvokeOnJavaFXApplicationThread
 import org.janelia.saalfeldlab.paintera.config.ScreenScalesConfig
+import org.janelia.saalfeldlab.paintera.data.mask.MaskedSource
 import org.janelia.saalfeldlab.paintera.state.label.ConnectomicsLabelState
 import org.janelia.saalfeldlab.paintera.ui.PainteraAlerts
 import org.janelia.saalfeldlab.paintera.util.logging.LogUtils
@@ -219,16 +220,18 @@ class Paintera : Application() {
 		}
 
 		paintera.baseView.sourceInfo().apply {
-			trackSources().forEach { source ->
-				(getState(source) as? ConnectomicsLabelState)?.let { state ->
-					val responseButton = state.promptForCommitIfNecessary(paintera.baseView) { index, name ->
-						"""
-						Closing current Paintera project.
-						Uncommitted changes to the canvas will be lost for source $index: $name if skipped.
-						Uncommitted changes to the fragment-segment-assigment will be stored in the Paintera project (if any)
-						but can be committed to the data backend, as well
-						""".trimIndent()
-					}
+			trackSources()
+				.filterIsInstance(MaskedSource::class.java)
+				.forEach { source ->
+					(getState(source) as? ConnectomicsLabelState)?.let { state ->
+						val responseButton = state.promptForCommitIfNecessary(paintera.baseView) { index, name ->
+							"""
+							Closing current Paintera project.
+							Uncommitted changes to the canvas will be lost for source $index: $name if skipped.
+							Uncommitted changes to the fragment-segment-assigment will be stored in the Paintera project (if any)
+							but can be committed to the data backend, as well
+							""".trimIndent()
+						}
 
 					when (responseButton) {
 						ButtonType.OK -> Unit

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/label/CommitHandler.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/label/CommitHandler.kt
@@ -23,7 +23,7 @@ class CommitHandler<S : SourceState<*, *>>(private val state: S, private val fra
 
 	internal fun makeActionSet(bindings: NamedKeyCombination.CombinationMap, paintera: PainteraBaseView) =
 		painteraActionSet(LabelSourceStateKeys.COMMIT_DIALOG, MenuActionType.CommitCanvas) {
-			KEY_PRESSED(bindings, LabelSourceStateKeys.COMMIT_DIALOG) {
+			KEY_PRESSED ( bindings, LabelSourceStateKeys.COMMIT_DIALOG, keysExclusive = true) {
 				onAction { showCommitDialog(state, paintera.sourceInfo().indexOf(state.dataSource), true, fragmentSegmentAssignmentState = fragmentProvider()) }
 			}
 		}

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/label/ConnectomicsLabelState.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/label/ConnectomicsLabelState.kt
@@ -215,22 +215,22 @@ class ConnectomicsLabelState<D : IntegerType<D>, T>(
 
 	private val globalActions = listOf(
 		ActionSet("Connectomics Label State Global Actions") {
-			KEY_PRESSED(keyBindings, LabelSourceStateKeys.REFRESH_MESHES) {
+			KEY_PRESSED(keyBindings, LabelSourceStateKeys.REFRESH_MESHES, keysExclusive = true) {
 				onAction {
 					refreshMeshes()
 					LOG.debug("Key event triggered refresh meshes")
 				}
 			}
-			KEY_PRESSED(keyBindings, LabelSourceStateKeys.TOGGLE_NON_SELECTED_LABELS_VISIBILITY) {
+			KEY_PRESSED(keyBindings, LabelSourceStateKeys.TOGGLE_NON_SELECTED_LABELS_VISIBILITY, keysExclusive = true) {
 				onAction {
 					showOnlySelectedInStreamToggle.toggleNonSelectionVisibility()
 					paintera.baseView.orthogonalViews().requestRepaint()
 				}
 			}
-			KEY_PRESSED(keyBindings, LabelSourceStateKeys.ARGB_STREAM_INCREMENT_SEED) {
+			KEY_PRESSED ( keyBindings, LabelSourceStateKeys.ARGB_STREAM_INCREMENT_SEED, keysExclusive = true) {
 				onAction { streamSeedSetter.incrementStreamSeed() }
 			}
-			KEY_PRESSED(keyBindings, LabelSourceStateKeys.ARGB_STREAM_DECREMENT_SEED) {
+			KEY_PRESSED(keyBindings, LabelSourceStateKeys.ARGB_STREAM_DECREMENT_SEED, keysExclusive = true) {
 				onAction { streamSeedSetter.decrementStreamSeed() }
 			}
 		},

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/ui/menus/PainteraMenuItems.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/ui/menus/PainteraMenuItems.kt
@@ -81,7 +81,7 @@ enum class PainteraMenuItems(
 				TOGGLE_STATUS_BAR_MODE to EventHandler<ActionEvent> { properties.statusBarConfig.cycleModes() },
 				TOGGLE_SIDE_BAR_MENU_ITEM to EventHandler<ActionEvent> { properties.sideBarConfig.toggleIsVisible() },
 				TOGGLE_TOOL_BAR_MENU_ITEM to EventHandler<ActionEvent> { properties.toolBarConfig.toggleIsVisible() },
-				QUIT to EventHandler<ActionEvent> { askAndQuit() },
+				QUIT to EventHandler<ActionEvent> { doSaveAndQuit() },
 				CYCLE_FORWARD to EventHandler<ActionEvent> { baseView.sourceInfo().incrementCurrentSourceIndex() },
 				CYCLE_BACKWARD to EventHandler<ActionEvent> { baseView.sourceInfo().decrementCurrentSourceIndex() },
 				TOGGLE_VISIBILITY to EventHandler<ActionEvent> {


### PR DESCRIPTION
The previous bump to [SaalFX 1.1.0](https://github.com/saalfeldlab/saalfx) introduced [keysExclusive](https://github.com/saalfeldlab/saalfx/commit/7e6ecf7a41ab38100f5b88ee20d97604738d125a#diff-6cd647bc925a27692acfda1173bbca0852db9040bd218587d020b1333fe5fa7eR237) Option for [KeyActions with keyBindings](https://github.com/saalfeldlab/saalfx/commit/7e6ecf7a41ab38100f5b88ee20d97604738d125a#diff-f10b7526d81fb381db82a28b207a8a7bcfd7bfba54aa238d3a8f052494dabe67). The default was false, which was breaking behavior with prior uses of NamedKeyCombinations in Paintera. This fix explicitly sets keysExclusive = true for certain actions. It may be better in the future to have the be the default implementation in SaalFX.