### PR TITLE
Multi-point prompt for auto-sam, create scalar label source, fixes

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/ui/dialogs/create/MipMapLevel.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/ui/dialogs/create/MipMapLevel.java
@@ -18,6 +18,7 @@ import org.janelia.saalfeldlab.fx.ui.SpatialField;
 
 public class MipMapLevel {
 
+	final public SimpleBooleanProperty isLabelMultisetProperty = new SimpleBooleanProperty(true);
 
 	final SpatialField<LongProperty> baseDimensions;
 	final SpatialField<IntegerProperty> relativeDownsamplingFactors;
@@ -80,7 +81,14 @@ public class MipMapLevel {
 			mipMapRow.getChildren().add(new VBox(resolutionHeader, resolution.getNode()));
 			mipMapRow.getChildren().add(new VBox(dimensionHeader, dimensions.getNode()));
 		}
-		mipMapRow.getChildren().add(new VBox(maxEntriesHeader, maxNumberOfEntriesPerSet.getTextField()));
+		final VBox numEntriesRow = new VBox(maxEntriesHeader, maxNumberOfEntriesPerSet.getTextField());
+
+		isLabelMultisetProperty.subscribe(isLabelMultiset -> {
+			if (isLabelMultiset)
+				mipMapRow.getChildren().add(numEntriesRow);
+			else
+				mipMapRow.getChildren().remove(numEntriesRow);
+		});
 
 		mipMapRow.setPadding(new Insets(0, 10.0, 0, 10.0));
 		mipMapRow.spacingProperty().setValue(10.0);

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/ShapeInterpolationController.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/ShapeInterpolationController.kt
@@ -276,6 +276,7 @@ class ShapeInterpolationController<D : IntegerType<D>>(
 	}
 
 	fun togglePreviewMode() {
+		freezeInterpolation = false
 		preview = !preview
 		if (preview) interpolateBetweenSlices(false)
 		else updateSliceAndInterpolantsCompositeMask()
@@ -298,6 +299,7 @@ class ShapeInterpolationController<D : IntegerType<D>>(
 
 	@Synchronized
 	fun interpolateBetweenSlices(replaceExistingInterpolants: Boolean) {
+		if (freezeInterpolation) return
 		if (slicesAndInterpolants.slices.size < 2) {
 			updateSliceAndInterpolantsCompositeMask()
 			isBusy = false
@@ -468,9 +470,13 @@ class ShapeInterpolationController<D : IntegerType<D>>(
 		refreshMeshes()
 	}
 
+	private val freezeInterpolationProperty = SimpleBooleanProperty(false)
+	var freezeInterpolation: Boolean by freezeInterpolationProperty.nonnull()
+
 
 	@Throws(MaskInUse::class)
 	private fun setCompositeMask(includeInterpolant: Boolean = preview) {
+		if (freezeInterpolation) return
 		synchronized(source) {
 			source.resetMasks(false)
 			/* If preview is on, hide all except the first and last fill mask */

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/modes/ShapeInterpolationMode.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/modes/ShapeInterpolationMode.kt
@@ -462,7 +462,8 @@ class ShapeInterpolationMode<D : IntegerType<D>>(val controller: ShapeInterpolat
 	internal fun addSelection(
 		selectionIntervalOverMask: Interval,
 		globalTransform: AffineTransform3D = paintera.baseView.manager().transform,
-		viewerMask: ViewerMask = controller.currentViewerMask!!
+		viewerMask: ViewerMask = controller.currentViewerMask!!,
+		replaceExistingSlice : Boolean = false
 	): SamSliceInfo? {
 		val globalToViewerTransform = viewerMask.initialGlobalToMaskTransform
 		val sliceDepth = controller.depthAt(globalToViewerTransform)
@@ -492,7 +493,7 @@ class ShapeInterpolationMode<D : IntegerType<D>>(val controller: ShapeInterpolat
 			}
 		}
 
-		val slice = controller.addSelection(selectionIntervalOverMask, globalTransform = globalTransform, viewerMask = viewerMask) ?: return null
+		val slice = controller.addSelection(selectionIntervalOverMask, replaceExistingSlice, globalTransform, viewerMask) ?: return null
 		return cacheLoadSamSliceInfo(sliceDepth).apply {
 			sliceInfo = slice
 		}

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/tools/paint/SamTool.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/tools/paint/SamTool.kt
@@ -564,7 +564,7 @@ open class SamTool(activeSourceStateProperty: SimpleObjectProperty<SourceState<*
 				KEY_PRESSED(CANCEL) {
 					name = "exit SAM tool"
 					graphic = { GlyphScaleView(FontAwesomeIconView().apply { styleClass += "reject" }).apply { styleClass += "ignore-disable" } }
-					onAction { mode?.switchTool(mode.defaultTool) }
+					onAction { cancelAction() }
 				}
 			},
 
@@ -653,6 +653,10 @@ open class SamTool(activeSourceStateProperty: SimpleObjectProperty<SourceState<*
 				}
 			}
 		)
+	}
+
+	protected open fun cancelAction() {
+		mode?.switchTool(mode.defaultTool)
 	}
 
 	private fun resetPromptAndPrediction() {

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/tools/paint/SamTool.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/tools/paint/SamTool.kt
@@ -797,14 +797,16 @@ open class SamTool(activeSourceStateProperty: SimpleObjectProperty<SourceState<*
 				maskedSource.applyMask(currentMask, sourceInterval.smallestContainingInterval, MaskedSource.VALID_LABEL_CHECK)
 				viewerMask = null
 			} else {
+				val predictionMaxInterval = originalWritableBackingImage!!.intersect( maskInterval)
 				LoopBuilder
-					.setImages(originalWritableBackingImage!!.interval(maskInterval), currentMask.viewerImg.wrappedSource.interval(maskInterval))
+					.setImages(originalWritableBackingImage!!.interval(predictionMaxInterval), currentMask.viewerImg.wrappedSource.interval(predictionMaxInterval))
 					.multiThreaded()
 					.forEachPixel { originalImage, currentImage ->
 						originalImage.set(currentImage.get())
 					}
+				val volatilePredictionMaxInterval = originalWritableVolatileBackingImage!!.intersect(maskInterval)
 				LoopBuilder
-					.setImages(originalWritableVolatileBackingImage!!.interval(maskInterval), currentMask.volatileViewerImg.wrappedSource.interval(maskInterval))
+					.setImages(originalWritableVolatileBackingImage!!.interval(volatilePredictionMaxInterval), currentMask.volatileViewerImg.wrappedSource.interval(volatilePredictionMaxInterval))
 					.multiThreaded()
 					.forEachPixel { originalImage, currentImage ->
 						originalImage.isValid = currentImage.isValid

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/tools/shapeinterpolation/ShapeInterpolationSAMTool.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/tools/shapeinterpolation/ShapeInterpolationSAMTool.kt
@@ -46,6 +46,11 @@ internal class ShapeInterpolationSAMTool(private val controller: ShapeInterpolat
 		requestPrediction(info.prediction)
 	}
 
+	override fun cancelAction() {
+		shapeInterpolationMode.switchTool(shapeInterpolationMode.defaultTool)
+		controller.setMaskOverlay()
+	}
+
 	override fun applyPrediction() {
 		lastPrediction?.apply {
 			/* cache the prediction. lock the cached slice, since this was applied manually */

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/tools/shapeinterpolation/ShapeInterpolationSAMTool.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/tools/shapeinterpolation/ShapeInterpolationSAMTool.kt
@@ -36,15 +36,13 @@ internal class ShapeInterpolationSAMTool(private val controller: ShapeInterpolat
 		shapeInterpolationMode.samSliceCache[controller.currentDepth] ?: let { SamEmbeddingLoaderCache.cancelPendingRequests() }
 
 		val info = shapeInterpolationMode.cacheLoadSamSliceInfo(controller.currentDepth)
-		if (!info.preGenerated)
-			temporaryPrompt = false
-		else
-			controller.deleteSliceAt(controller.currentDepth)
+		if (info.preGenerated) controller.deleteSliceAt(controller.currentDepth)
 
 		maskedSource?.resetMasks(false)
 		viewerMask = controller.getMask()
 		super.activate()
 
+		if (!info.preGenerated) temporaryPrompt = false
 		requestPrediction(info.prediction)
 	}
 

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/tools/shapeinterpolation/ShapeInterpolationTool.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/tools/shapeinterpolation/ShapeInterpolationTool.kt
@@ -159,8 +159,8 @@ internal class ShapeInterpolationTool(
 		val samSliceInfo = shapeInterpolationMode.cacheLoadSamSliceInfo(depth)
 
 		if (!newPrediction && refresh) {
-			controller.getInterpolationImg(samSliceInfo.globalToViewerTransform, closest = true)?.getPositionAtMaxDistance()?.let { (x, y) ->
-				samSliceInfo.updatePrediction(x, y)
+			controller.getInterpolationImg(samSliceInfo.globalToViewerTransform, closest = true)?.getComponentMaxDistancePosition()?.let { positions ->
+				samSliceInfo.updatePrediction(positions)
 			}
 		}
 

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/tools/shapeinterpolation/ShapeInterpolationTool.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/tools/shapeinterpolation/ShapeInterpolationTool.kt
@@ -288,7 +288,8 @@ internal class ShapeInterpolationTool(
 							val remainingRequest = SimpleIntegerProperty().apply {
 								addListener { _, _, remaining ->
 									if (remaining == 0) {
-										depths.forEach { requestSamPrediction(it, refresh = true) }
+										controller.freezeInterpolation = false
+										controller.setMaskOverlay()
 
 										depths.sort()
 										/* eagerly request the next embeddings */
@@ -303,6 +304,7 @@ internal class ShapeInterpolationTool(
 							/* Do the prediction */
 							sortedSliceDepths.zipWithNext { before, after -> (before + after) / 2.0 }.forEach {
 								depths += it
+								controller.freezeInterpolation = true
 								remainingRequest.value++
 								requestSamPrediction(it) {
 									remainingRequest.value--

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/metadata/MetadataState.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/metadata/MetadataState.kt
@@ -132,7 +132,7 @@ open class SingleScaleMetadataState(
 }
 
 
-open class MultiScaleMetadataState constructor(
+open class MultiScaleMetadataState (
 	override val n5ContainerState: N5ContainerState,
 	final override val metadata: SpatialMultiscaleMetadata<N5SpatialDatasetMetadata>
 ) : MetadataState by SingleScaleMetadataState(n5ContainerState, metadata[0]) {
@@ -140,7 +140,10 @@ open class MultiScaleMetadataState constructor(
 	private val highestResMetadata: N5SpatialDatasetMetadata = metadata[0]
 	final override var transform: AffineTransform3D = metadata.spatialTransform3d()
 	final override var isLabelMultiset: Boolean = metadata[0].isLabelMultiset
-	override var isLabel: Boolean = isLabel(highestResMetadata.attributes.dataType) || isLabelMultiset
+	override var isLabel: Boolean = when {
+		metadata is N5PainteraLabelMultiScaleGroup -> metadata.isLabel
+		else -> isLabel(highestResMetadata.attributes.dataType) || isLabelMultiset
+	}
 	override var resolution: DoubleArray = transform.run { doubleArrayOf(get(0, 0), get(1, 1), get(2, 2)) }
 	override var translation: DoubleArray = transform.translation
 	override var group: String = metadata.path


### PR DESCRIPTION

features:
- If multiple connected components are found during auto-SAM in ShapeInterpolation, generate a prompt point per component
- create scalar label sources
- replace auto sam slices completely (instead of adding to them) when manually entering SAM at an auto-sam-only slice

fix:
- refresh interpolation when exiting manual SAM tool
- don't refresh interpolation untill all bisect slices are done during bisect all
- invalidate SAM request key if cancelled
- ignore `null` property value during serialization/deserialization
- 