### PR TITLE
1.3.1

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/bdv/fx/viewer/render/MultiResolutionRendererGeneric.java
+++ b/src/main/java/org/janelia/saalfeldlab/bdv/fx/viewer/render/MultiResolutionRendererGeneric.java
@@ -529,7 +529,7 @@ public class MultiResolutionRendererGeneric<T> {
 			// if rendering was not cancelled...
 			if (success) {
 				if (createProjector) {
-					if (currentScreenScaleIndex >= screenImages.size())
+					if (currentScreenScaleIndex >= screenImages.size() || reuseBufferScreenScale >= screenImages.size())
 						return -1;
 					final ArrayDeque<T> buffers = screenImages.get(currentScreenScaleIndex);
 					final T renderTarget = doubleBuffered ? buffers.pop() : buffers.peek();

--- a/src/main/java/org/janelia/saalfeldlab/bdv/fx/viewer/render/MultiResolutionRendererGeneric.java
+++ b/src/main/java/org/janelia/saalfeldlab/bdv/fx/viewer/render/MultiResolutionRendererGeneric.java
@@ -529,6 +529,8 @@ public class MultiResolutionRendererGeneric<T> {
 			// if rendering was not cancelled...
 			if (success) {
 				if (createProjector) {
+					if (currentScreenScaleIndex >= screenImages.size())
+						return -1;
 					final ArrayDeque<T> buffers = screenImages.get(currentScreenScaleIndex);
 					final T renderTarget = doubleBuffered ? buffers.pop() : buffers.peek();
 					final T unusedBuffer = display.setBufferedImageAndTransform(renderTarget, currentProjectorTransform);

--- a/src/main/java/org/janelia/saalfeldlab/bdv/fx/viewer/render/PainterThreadFx.java
+++ b/src/main/java/org/janelia/saalfeldlab/bdv/fx/viewer/render/PainterThreadFx.java
@@ -45,27 +45,28 @@ public final class PainterThreadFx extends Thread {
 		while (this.isRunning) {
 			boolean paint;
 			synchronized (this) {
-				paint = this.pleaseRepaint;
-				this.pleaseRepaint = false;
+				paint = pleaseRepaint;
+				pleaseRepaint = false;
 			}
 
 			if (paint) {
 				try {
-					this.paintable.paint();
+					paintable.paint();
 				} catch (RejectedExecutionException var5) {
 				}
 			}
 
 			synchronized (this) {
 				try {
-					if (this.isRunning && !this.pleaseRepaint) {
-						this.wait();
+					if (isRunning && !pleaseRepaint) {
+						wait();
 					}
-					continue;
+					if (isRunning)
+						continue;
 				} catch (InterruptedException var7) {
+					System.out.println(Thread.currentThread().getName() + " interrupted");
 				}
 			}
-
 			return;
 		}
 	}
@@ -73,8 +74,8 @@ public final class PainterThreadFx extends Thread {
 	public void requestRepaint() {
 
 		synchronized (this) {
-			this.pleaseRepaint = true;
-			this.notify();
+			pleaseRepaint = true;
+			notify();
 		}
 	}
 
@@ -85,12 +86,10 @@ public final class PainterThreadFx extends Thread {
 
 	public void stopRendering() {
 
-		synchronized (this) {
-			LOG.debug("Stop rendering now!");
-			this.isRunning = false;
-			this.notify();
-			LOG.debug("Notified on this ({})", this);
-		}
+		LOG.debug("Stop rendering now!");
+		isRunning = false;
+		interrupt();
+		LOG.debug("Notified on this ({})", this);
 	}
 
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/data/mask/MaskedSource.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/data/mask/MaskedSource.java
@@ -779,6 +779,8 @@ public class MaskedSource<D extends RealType<D>, T extends Type<T>> implements D
 			if (!canResetMask)
 				throw new MaskInUse("Cannot reset the mask.");
 
+			var mask = getCurrentMask();
+			if (mask != null && mask.shutdown != null) mask.shutdown.run();
 			setCurrentMask(null);
 			this.isBusy.set(true);
 		}

--- a/src/main/java/org/janelia/saalfeldlab/paintera/id/IdService.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/id/IdService.java
@@ -105,6 +105,11 @@ public interface IdService {
 		return randomTemps.findFirst().getAsLong();
 	}
 
+	static boolean isTemporary(final long id) {
+
+		return id > FIRST_TEMPORARY_ID && id < LAST_TEMPORARY_ID;
+	}
+
 	class IdServiceNotProvided implements IdService {
 
 		@Override

--- a/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceStateIdSelectorHandler.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/state/LabelSourceStateIdSelectorHandler.java
@@ -185,6 +185,12 @@ public class LabelSourceStateIdSelectorHandler {
 		};
 	}
 
+	public long activateCurrentOrNext() {
+		if (selectedIds.isLastSelectionValid())
+			return selectedIds.getLastSelection();
+		else return nextId(true);
+	}
+
 	public long nextId() {
 
 		return nextId(true);

--- a/src/main/java/org/janelia/saalfeldlab/paintera/stream/AbstractHighlightingARGBStream.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/stream/AbstractHighlightingARGBStream.java
@@ -74,7 +74,7 @@ public abstract class AbstractHighlightingARGBStream extends ObservableWithListe
 			Constants.DEFAULT_CAPACITY,
 			Constants.DEFAULT_LOAD_FACTOR,
 			Label.INVALID,
-			0
+			-1
 	);
 
 	public AbstractHighlightingARGBStream(
@@ -295,8 +295,10 @@ public abstract class AbstractHighlightingARGBStream extends ObservableWithListe
 	public void specifyColorExplicitly(final long segmentId, final int color, final boolean overrideAlpha) {
 
 		this.explicitlySpecifiedColors.put(segmentId, color);
-		if (overrideAlpha)
-			this.overrideAlpha.put(segmentId, 1);
+		if (overrideAlpha) {
+			var alpha = color >>> 24;
+			this.overrideAlpha.put(segmentId, alpha);
+		}
 		clearCache();
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/stream/AbstractHighlightingARGBStream.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/stream/AbstractHighlightingARGBStream.java
@@ -70,7 +70,7 @@ public abstract class AbstractHighlightingARGBStream extends ObservableWithListe
 	private final BooleanProperty colorFromSegmentId = new SimpleBooleanProperty();
 
 	protected final TLongIntHashMap explicitlySpecifiedColors = new TLongIntHashMap();
-	protected final TLongIntHashMap overrideAlpha = new TLongIntHashMap(
+	public final TLongIntHashMap overrideAlpha = new TLongIntHashMap(
 			Constants.DEFAULT_CAPACITY,
 			Constants.DEFAULT_LOAD_FACTOR,
 			Label.INVALID,

--- a/src/main/java/org/janelia/saalfeldlab/paintera/stream/AbstractSaturatedHighlightingARGBStream.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/stream/AbstractSaturatedHighlightingARGBStream.java
@@ -72,16 +72,18 @@ abstract public class AbstractSaturatedHighlightingARGBStream extends AbstractHi
 		} else if (lockedSegments.isLocked(segmentId) && hideLockedSegments) {
 			argb = argb & 0x00ffffff;
 		} else {
-			if (overrideAlpha.get(assigned) != 1) {
-				var a = alpha;
+			int alphaOverride = overrideAlpha.get(assigned);
+			int actualAlpha = alpha;
+			if (alphaOverride == overrideAlpha.getNoEntryValue()) {
 				if (isActiveSegment) {
 					if (isActiveFragment(fragmentId))
-						a = activeFragmentAlpha;
+						actualAlpha = activeFragmentAlpha;
 					else
-						a = activeSegmentAlpha;
+						actualAlpha = activeSegmentAlpha;
 				}
-				argb = argb & 0x00ffffff | a;
-			}
+			} else
+				actualAlpha = alphaOverride << 24;
+			argb = argb & 0x00ffffff | actualAlpha;
 		}
 
 		return argb;

--- a/src/main/java/org/janelia/saalfeldlab/util/n5/N5Data.java
+++ b/src/main/java/org/janelia/saalfeldlab/util/n5/N5Data.java
@@ -800,7 +800,7 @@ public class N5Data {
 			throw new IOException(String.format("Unique labels group `%s' exists in container `%s' -- conflict likely.", uniqueLabelsGroup, container));
 
 		n5.setAttribute(group, N5Helpers.PAINTERA_DATA_KEY, pd);
-		n5.setAttribute(group, N5Helpers.MAX_ID_KEY, 1L);
+		n5.setAttribute(group, N5Helpers.MAX_ID_KEY, 0L);
 
 		final String dataGroup = String.format("%s/data", group);
 		n5.createGroup(dataGroup);

--- a/src/main/java/org/janelia/saalfeldlab/util/n5/N5Data.java
+++ b/src/main/java/org/janelia/saalfeldlab/util/n5/N5Data.java
@@ -828,15 +828,16 @@ public class N5Data {
 
 			final String dataset = String.format(scaleDatasetPattern, scaleLevel);
 			final String uniqeLabelsDataset = String.format(scaleUniqueLabelsPattern, scaleLevel);
-			n5.createDataset(dataset, scaledDimensions, blockSize, DataType.UINT8, new GzipCompression());
-			n5.createDataset(uniqeLabelsDataset, scaledDimensions, blockSize, DataType.UINT64, new GzipCompression());
 
 			if (labelMultisetType) {
+				n5.createDataset(dataset, scaledDimensions, blockSize, DataType.UINT8, new GzipCompression());
 				final int maxNum = downscaledLevel < 0 ? -1 : maxNumEntries[downscaledLevel];
 				n5.setAttribute(dataset, N5Helpers.MAX_NUM_ENTRIES_KEY, maxNum);
 				n5.setAttribute(dataset, N5Helpers.IS_LABEL_MULTISET_KEY, true);
-			}
+			} else
+				n5.createDataset(dataset, scaledDimensions, blockSize, DataType.UINT64, new GzipCompression());
 
+			n5.createDataset(uniqeLabelsDataset, scaledDimensions, blockSize, DataType.UINT64, new GzipCompression());
 			if (scaleLevel != 0) {
 				n5.setAttribute(dataset, N5Helpers.DOWNSAMPLING_FACTORS_KEY, accumulatedFactors);
 				n5.setAttribute(uniqeLabelsDataset, N5Helpers.DOWNSAMPLING_FACTORS_KEY, accumulatedFactors);

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/cache/SamEmbeddingLoaderCache.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/cache/SamEmbeddingLoaderCache.kt
@@ -198,6 +198,7 @@ object SamEmbeddingLoaderCache : AsyncCacheWithLoader<RenderUnitState, OnnxTenso
 			result.image?.let { img ->
 				ImageIO.write(SwingFXUtils.fromFXImage(img, null), "png", predictionImagePngOutputStream)
 				predictionImagePngOutputStream.close()
+				sharedQueue.shutdown()
 				imageRenderer.stopRendering()
 			}
 		}

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/ShapeInterpolationController.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/ShapeInterpolationController.kt
@@ -666,6 +666,7 @@ class ShapeInterpolationController<D : IntegerType<D>>(
 
 			/* Replace old slice info */
 			slicesAndInterpolants.removeSlice(oldSlice)
+			oldSlice.mask.shutdown?.run()
 
 			val newSlice = SliceInfo(
 				newMask,

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/modes/ShapeInterpolationMode.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/modes/ShapeInterpolationMode.kt
@@ -130,6 +130,7 @@ class ShapeInterpolationMode<D : IntegerType<D>>(val controller: ShapeInterpolat
 
 	override fun exit() {
 		super.exit()
+
 		SamEmbeddingLoaderCache.stopNavigationBasedRequests()
 		SamEmbeddingLoaderCache.invalidateAll()
 		paintera.baseView.disabledPropertyBindings.remove(controller)
@@ -560,8 +561,35 @@ internal class SamSliceCache : HashMap<Float, SamSliceInfo>() {
 	operator fun minusAssign(key: Double) {
 		remove(key.toFloat())
 	}
+
 	operator fun minusAssign(key: Float) {
 		remove(key)
+	}
+
+	override fun clear() {
+		values.forEach {
+			it.mask.shutdown?.run()
+		}
+		super.clear()
+	}
+
+	override fun remove(key: Float): SamSliceInfo? {
+		return super.remove(key)?.also {
+			it.mask.shutdown?.run()
+		}
+	}
+
+	override fun remove(key: Float, value: SamSliceInfo): Boolean {
+		return if (super.remove(key, value)) {
+			value.mask.shutdown?.run()
+			true
+		} else false
+	}
+
+	override fun put(key: Float, value: SamSliceInfo): SamSliceInfo? {
+		return super.put(key, value)?.also {
+			it.mask.shutdown?.run()
+		}
 	}
 }
 

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/modes/ShapeInterpolationMode.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/modes/ShapeInterpolationMode.kt
@@ -131,6 +131,7 @@ class ShapeInterpolationMode<D : IntegerType<D>>(val controller: ShapeInterpolat
 	override fun exit() {
 		super.exit()
 		SamEmbeddingLoaderCache.stopNavigationBasedRequests()
+		SamEmbeddingLoaderCache.invalidateAll()
 		paintera.baseView.disabledPropertyBindings.remove(controller)
 		controller.resetFragmentAlpha()
 		activeViewerProperty.removeListener(toolTriggerListener)

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/label/ConnectomicsLabelState.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/label/ConnectomicsLabelState.kt
@@ -156,8 +156,9 @@ class ConnectomicsLabelState<D : IntegerType<D>, T>(
 
 	override fun getIntersectableMask(): DataSource<BoolType, Volatile<BoolType>> = labelToBooleanFragmentMaskSource(this)
 
-	private val idSelectorHandler =
-		LabelSourceStateIdSelectorHandler(source, idService, selectedIds, fragmentSegmentAssignment, lockedSegments, meshManager::refreshMeshes)
+	private val idSelectorHandler = LabelSourceStateIdSelectorHandler(source, idService, selectedIds, fragmentSegmentAssignment, lockedSegments, meshManager::refreshMeshes).also {
+		it.activateCurrentOrNext()
+	}
 
 	private val mergeDetachHandler = LabelSourceStateMergeDetachHandler(source, selectedIds, fragmentSegmentAssignment, idService)
 

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/label/ConnectomicsLabelState.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/state/label/ConnectomicsLabelState.kt
@@ -81,18 +81,8 @@ import java.lang.invoke.MethodHandles
 import java.lang.reflect.Type
 import java.util.concurrent.ExecutorService
 import java.util.function.*
-import kotlin.collections.List
-import kotlin.collections.Map
-import kotlin.collections.any
-import kotlin.collections.asSequence
 import kotlin.collections.component1
 import kotlin.collections.component2
-import kotlin.collections.forEach
-import kotlin.collections.isEmpty
-import kotlin.collections.isNotEmpty
-import kotlin.collections.listOf
-import kotlin.collections.map
-import kotlin.collections.toTypedArray
 
 class ConnectomicsLabelState<D : IntegerType<D>, T>(
 	override val backend: ConnectomicsLabelBackend<D, T>,
@@ -571,6 +561,7 @@ class ConnectomicsLabelState<D : IntegerType<D>, T>(
         const val CONVERTER                       = "converter"
         const val CONVERTER_SEED                  = "seed"
 		const val CONVERTER_USER_SPECIFIED_COLORS = "userSpecifiedColors"
+		const val BACKGROUND_ID_VISIBLE          = "backgroundIdVisible"
         const val INTERPOLATION                   = "interpolation"
         const val IS_VISIBLE                      = "isVisible"
         const val RESOLUTION                      = "resolution"
@@ -593,8 +584,13 @@ class ConnectomicsLabelState<D : IntegerType<D>, T>(
 				map.add(MANAGED_MESH_SETTINGS, context[state.meshManager.managedSettings])
 				map.add(COMPOSITE, context.withClassInfo(state.composite))
 				JsonObject().let { m ->
-					m.addProperty(CONVERTER_SEED, state.converter.seedProperty().get())
-					state.converter.userSpecifiedColors().asJsonObject()?.let { m.add(CONVERTER_USER_SPECIFIED_COLORS, it) }
+					state.converter.apply {
+						m.addProperty(CONVERTER_SEED, seedProperty().get())
+						if (stream.overrideAlpha.get(Label.BACKGROUND) != stream.overrideAlpha.noEntryValue) m.addProperty(BACKGROUND_ID_VISIBLE, false)
+
+						userSpecifiedColors().asJsonObject()?.let { m.add(CONVERTER_USER_SPECIFIED_COLORS, it) }
+
+					}
 					map.add(CONVERTER, m)
 				}
 				map.add(INTERPOLATION, context[state.interpolation])
@@ -667,6 +663,7 @@ class ConnectomicsLabelState<D : IntegerType<D>, T>(
 								converter.apply {
 									get<JsonObject>(CONVERTER_USER_SPECIFIED_COLORS) { it.toColorMap().forEach { (id, c) -> state.converter.setColor(id, c) } }
 									get<Long>(CONVERTER_SEED) { seed -> state.converter.seedProperty().set(seed) }
+									if (get<Boolean>(BACKGROUND_ID_VISIBLE) == false) stream.overrideAlpha.put(Label.BACKGROUND, 0)
 								}
 							}
 

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/stream/HighlightingStreamConverterConfigNode.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/stream/HighlightingStreamConverterConfigNode.kt
@@ -170,10 +170,11 @@ class HighlightingStreamConverterConfigNode(private val converter: HighlightingS
 
 			val backgroundIdVisible = CheckBox("Background ID (0) Visible ")
 			backgroundIdVisible.tooltip = Tooltip( "Make the background ID visible" )
-			backgroundIdVisible.selectedProperty().subscribe { visible ->
-				if (visible) {
+			val backgroundIsVisible = converter.getStream().overrideAlpha.get(BACKGROUND) != 0
+			backgroundIdVisible.selectedProperty().set(backgroundIsVisible)
+			backgroundIdVisible.selectedProperty().addListener { obs, oldv, visible ->
+				if (visible)
 					converter.getStream().overrideAlpha.remove(BACKGROUND)
-				}
 				else
 					converter.getStream().overrideAlpha.put(BACKGROUND, 0)
 				converter.getStream().clearCache()

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/stream/HighlightingStreamConverterConfigNode.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/stream/HighlightingStreamConverterConfigNode.kt
@@ -14,6 +14,7 @@ import javafx.scene.layout.VBox
 import javafx.scene.paint.Color
 import javafx.stage.Modality
 import javafx.util.converter.NumberStringConverter
+import net.imglib2.type.label.Label.*
 import org.janelia.saalfeldlab.fx.Labels
 import org.janelia.saalfeldlab.fx.extensions.TitledPaneExtensions
 import org.janelia.saalfeldlab.fx.ui.NamedNode
@@ -117,7 +118,7 @@ class HighlightingStreamConverterConfigNode(private val converter: HighlightingS
 				event.consume()
 				try {
 					val id = parseLong(addIdField.text)
-					converter.setColor(id, addColorPicker.value, true)
+					converter.setColor(id, addColorPicker.value)
 					addIdField.text = ""
 				} catch (e: NumberFormatException) {
 					LOG.error("Not a valid long/integer format: {}", addIdField.text)
@@ -129,13 +130,10 @@ class HighlightingStreamConverterConfigNode(private val converter: HighlightingS
 			hideLockedSegments.selectedProperty().bindBidirectional(converter.hideLockedSegmentsProperty())
 			contents.children.add(hideLockedSegments)
 
-			val colorFromSegmentId = CheckBox("Color From segment Id.")
-			colorFromSegmentId.tooltip = Tooltip(
-				"Generate fragment color from segment id (on) or fragment id (off)"
-			)
+			val colorFromSegmentId = CheckBox("Color From segment ID.")
+			colorFromSegmentId.tooltip = Tooltip( "Generate fragment color from segment ID (on) or fragment ID (off)" )
 			colorFromSegmentId.selectedProperty().bindBidirectional(colorFromSegment)
 			contents.children.add(colorFromSegmentId)
-
 
 			val colorContents = GridPane()
 			colorContents.hgap = 5.0
@@ -168,6 +166,21 @@ class HighlightingStreamConverterConfigNode(private val converter: HighlightingS
 			}
 			colorsMap.addListener(colorsChanged)
 			colorsChanged.onChanged(null)
+
+
+			val backgroundIdVisible = CheckBox("Background ID (0) Visible ")
+			backgroundIdVisible.tooltip = Tooltip( "Make the background ID visible" )
+			backgroundIdVisible.selectedProperty().subscribe { visible ->
+				if (visible) {
+					converter.getStream().overrideAlpha.remove(BACKGROUND)
+				}
+				else
+					converter.getStream().overrideAlpha.put(BACKGROUND, 0)
+				converter.getStream().clearCache()
+			}
+			contents.children.add(backgroundIdVisible)
+
+
 			contents.children.add(colorPane)
 
 


### PR DESCRIPTION
Add Background Visible Toggle

some performance improvements, largely around better cleanup of resources, especially old threads

- shutdown old `ViewerMask`s that aren't submitted
- invalidate SAM embeddings when leaving SI
- interrupt `painterThread`s from outdated `RenderUnit`s
- don't load meshes for temporary IDs
- use Dispatchers.IO for SAM prediction task

