### PR TITLE
fix: issus with orthoslice meshes on m1 mac sonoma

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,10 +78,10 @@
 		<n5.version>3.2.0</n5.version>
 		<n5-hdf5.version>2.2.0</n5-hdf5.version>
 		<n5-google-cloud.version>4.1.0</n5-google-cloud.version>
-		<n5-aws-s3.version>4.1.2</n5-aws-s3.version>
-		<n5-zarr.version>1.3.3</n5-zarr.version>
+		<n5-aws-s3.version>4.2.0</n5-aws-s3.version>
+		<n5-zarr.version>1.3.4</n5-zarr.version>
 		<n5-imglib2.version>7.0.0</n5-imglib2.version>
-		<n5-universe.version>1.5.0</n5-universe.version>
+		<n5-universe.version>1.6.0</n5-universe.version>
 		<imglib2-label-multisets.version>0.14.0</imglib2-label-multisets.version>
 
 		<maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>

--- a/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceMeshFX.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/viewer3d/OrthoSliceMeshFX.java
@@ -1,5 +1,6 @@
 package org.janelia.saalfeldlab.paintera.viewer3d;
 
+import javafx.scene.paint.Color;
 import javafx.scene.paint.PhongMaterial;
 import javafx.scene.shape.CullFace;
 import javafx.scene.shape.MeshView;
@@ -10,6 +11,7 @@ import net.imglib2.Point;
 import net.imglib2.RealLocalizable;
 import net.imglib2.RealPoint;
 import net.imglib2.RealPositionable;
+import org.janelia.saalfeldlab.paintera.meshes.Meshes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,6 +57,9 @@ public class OrthoSliceMeshFX {
 	final float[] buf3D = new float[3];
 
 	public OrthoSliceMeshFX(final long[] dimensions, final Affine viewerTransformFX) {
+
+		material.setSpecularColor(Color.TRANSPARENT);
+		material.setSpecularPower(0.0);
 
 		final Point min = new Point(2), max = new Point(dimensions);
 


### PR DESCRIPTION
some underlying platform issue with Apple Metal on M1 Mac Sonoma requires specular color to be specified for correct rendering of phong material meshes see: https://forums.macrumors.com/threads/javafx-mesh-lighting-rendering-errors-macos-14-2-1.2415934/