### PR TITLE
fix/1.5.1

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/paintera/composition/CompositeProjectorPreMultiply.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/composition/CompositeProjectorPreMultiply.java
@@ -10,6 +10,7 @@ import net.imglib2.Cursor;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.ARGBType;
+import org.janelia.saalfeldlab.bdv.fx.viewer.CompositeSourceSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,7 +60,12 @@ public class CompositeProjectorPreMultiply extends AccumulateProjector<ARGBType,
 
 			final ArrayList<Composite<ARGBType, ARGBType>> activeComposites = new ArrayList<>();
 			for (final var activeSource : sources) {
-				activeComposites.add(composites.get(activeSource.getSpimSource()));
+				final Source<?> compositeSource;
+				if (activeSource instanceof CompositeSourceSupplier)
+					compositeSource = ((CompositeSourceSupplier)activeSource).getCompositeSource();
+				else
+					compositeSource = activeSource.getSpimSource();
+				activeComposites.add(composites.get(compositeSource));
 			}
 
 			projector.setComposites(activeComposites);

--- a/src/main/java/org/janelia/saalfeldlab/paintera/composition/CompositeProjectorPreMultiply.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/composition/CompositeProjectorPreMultiply.java
@@ -10,7 +10,6 @@ import net.imglib2.Cursor;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.ARGBType;
-import org.janelia.saalfeldlab.bdv.fx.viewer.CompositeSourceSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,12 +59,7 @@ public class CompositeProjectorPreMultiply extends AccumulateProjector<ARGBType,
 
 			final ArrayList<Composite<ARGBType, ARGBType>> activeComposites = new ArrayList<>();
 			for (final var activeSource : sources) {
-				final Source<?> compositeSource;
-				if (activeSource instanceof CompositeSourceSupplier)
-					compositeSource = ((CompositeSourceSupplier)activeSource).getCompositeSource();
-				else
-					compositeSource = activeSource.getSpimSource();
-				activeComposites.add(composites.get(compositeSource));
+				activeComposites.add(composites.get(activeSource.getSpimSource()));
 			}
 
 			projector.setComposites(activeComposites);

--- a/src/main/java/org/janelia/saalfeldlab/paintera/meshes/ManagedMeshSettings.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/meshes/ManagedMeshSettings.java
@@ -29,7 +29,7 @@ public class ManagedMeshSettings<K> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-	public static final boolean DEFAULT_IS_MESH_LIST_ENABLED = false;
+	public static final boolean DEFAULT_IS_MESH_LIST_ENABLED = true;
 
 	public static final boolean DEFAULT_ARE_MESHES_ENABLED = true;
 

--- a/src/main/java/org/janelia/saalfeldlab/paintera/meshes/Smooth.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/meshes/Smooth.java
@@ -24,7 +24,7 @@ public class Smooth {
 
 	public static final double DEFAULT_LAMBDA = 1.0;
 
-	public static final int DEFAULT_ITERATIONS = 1;
+	public static final int DEFAULT_ITERATIONS = 5;
 
 	private static boolean isBoundary(
 			final ArrayList<TIntHashSet> vertexTriangleLUT,

--- a/src/main/java/org/janelia/saalfeldlab/paintera/stream/HighlightingStreamConverter.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/stream/HighlightingStreamConverter.java
@@ -14,6 +14,7 @@ import javafx.collections.ObservableMap;
 import javafx.scene.paint.Color;
 import net.imglib2.Volatile;
 import net.imglib2.converter.Converter;
+import net.imglib2.type.label.LabelMultisetType;
 import net.imglib2.type.label.VolatileLabelMultisetType;
 import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.type.numeric.IntegerType;
@@ -125,6 +126,9 @@ public abstract class HighlightingStreamConverter<T>
 
 		LOG.debug("Getting {} for type {}", HighlightingStreamConverter.class.getSimpleName(), t);
 		if (t instanceof VolatileLabelMultisetType) {
+			return (HighlightingStreamConverter<T>)new HighlightingStreamConverterVolatileLabelMultisetType(stream);
+		}
+		if (t instanceof LabelMultisetType) {
 			return (HighlightingStreamConverter<T>)new HighlightingStreamConverterLabelMultisetType(stream);
 		}
 		if (t instanceof Volatile<?> && ((Volatile<?>)t).get() instanceof IntegerType<?>) {

--- a/src/main/java/org/janelia/saalfeldlab/paintera/stream/HighlightingStreamConverterLabelMultisetType.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/stream/HighlightingStreamConverterLabelMultisetType.java
@@ -1,10 +1,9 @@
 package org.janelia.saalfeldlab.paintera.stream;
 
-import net.imglib2.type.label.Label;
-import net.imglib2.type.label.VolatileLabelMultisetType;
+import net.imglib2.type.label.LabelMultisetType;
 import net.imglib2.type.numeric.ARGBType;
 
-public class HighlightingStreamConverterLabelMultisetType extends HighlightingStreamConverter<VolatileLabelMultisetType> {
+public class HighlightingStreamConverterLabelMultisetType extends HighlightingStreamConverter<LabelMultisetType> {
 
 	final static private double ONE_OVER_255 = 1.0 / 255.0;
 
@@ -13,15 +12,9 @@ public class HighlightingStreamConverterLabelMultisetType extends HighlightingSt
 		super(stream);
 	}
 
-	@Override
-	public void convert(final VolatileLabelMultisetType input, final ARGBType output) {
+	@Override public void convert(LabelMultisetType input, ARGBType output) {
 
-		final boolean isValid = input.isValid();
-		if (!isValid) {
-			return;
-		}
-		// entry
-		final var entries = input.get().entrySet();
+		final var entries = input.entrySet();
 		final int numEntries = entries.size();
 		if (numEntries == 0) {
 			final long emptyValue = 0;
@@ -51,5 +44,4 @@ public class HighlightingStreamConverterLabelMultisetType extends HighlightingSt
 			output.set(((aInt << 8 | rInt) << 8 | gInt) << 8 | bInt);
 		}
 	}
-
 }

--- a/src/main/java/org/janelia/saalfeldlab/paintera/stream/HighlightingStreamConverterVolatileLabelMultisetType.java
+++ b/src/main/java/org/janelia/saalfeldlab/paintera/stream/HighlightingStreamConverterVolatileLabelMultisetType.java
@@ -1,0 +1,28 @@
+package org.janelia.saalfeldlab.paintera.stream;
+
+import net.imglib2.type.label.VolatileLabelMultisetType;
+import net.imglib2.type.numeric.ARGBType;
+
+public class HighlightingStreamConverterVolatileLabelMultisetType extends HighlightingStreamConverter<VolatileLabelMultisetType> {
+
+	private final HighlightingStreamConverterLabelMultisetType nonVolatileConverter;
+	public HighlightingStreamConverterVolatileLabelMultisetType(final AbstractHighlightingARGBStream stream) {
+
+		super(stream);
+		nonVolatileConverter = new HighlightingStreamConverterLabelMultisetType(stream);
+	}
+
+	public HighlightingStreamConverterLabelMultisetType getNonVolatileConverter() {
+		return nonVolatileConverter;
+	}
+
+	@Override
+	public void convert(final VolatileLabelMultisetType input, final ARGBType output) {
+
+		final boolean isValid = input.isValid();
+		if (!isValid) {
+			return;
+		}
+		nonVolatileConverter.convert(input.get(), output);
+	}
+}

--- a/src/main/kotlin/org/janelia/saalfeldlab/bdv/fx/viewer/SourceUtils.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/bdv/fx/viewer/SourceUtils.kt
@@ -9,36 +9,58 @@ import net.imglib2.type.numeric.ARGBType
 import org.janelia.saalfeldlab.paintera.data.DataSource
 import org.janelia.saalfeldlab.paintera.stream.HighlightingStreamConverterVolatileLabelMultisetType
 
+//FIXME Caleb: These are both private because imho this is a bit of a hack.
+// We want to Paintera's DataSource implemenet Source over the volatile type,
+// and the corrsponding SourceAndConverter has a convert also over the volatile type
+// This makes it not possible get a non-volatile SourceAndConverter over the DataSource.
+// So what we do here is manually unwrap, but we still want it to play nicely with the
+// volatile renderer, so we need it to "equal" it's volatile version.
+// I think SourceAndConverter has a `volatileConverter` that we should instead be using
+// when we want volatile (most the time) and support a proper non-volatile version without
+// wrapping/unwrapping this way.
+private class UnwrappedDataSource<D>(val dataSource : DataSource<D, *>) : Source<D> {
+	override fun isPresent(t: Int) = dataSource.isPresent(t)
+
+	override fun getSource(t: Int, level: Int) = dataSource.getDataSource(t, level)
+
+	override fun getInterpolatedSource(t: Int, level: Int, method: Interpolation?) = dataSource.getInterpolatedDataSource(t, level, method)
+
+	override fun getSourceTransform(t: Int, level: Int, transform: AffineTransform3D?) {
+		dataSource.getSourceTransform(t, level, transform)
+	}
+
+	override fun getType() = dataSource.dataType
+
+	override fun getName() = dataSource.name
+
+	override fun getVoxelDimensions() = dataSource.voxelDimensions
+
+	override fun getNumMipmapLevels() = dataSource.numMipmapLevels
+
+	override fun hashCode() = dataSource.hashCode()
+
+	override fun equals(other: Any?) = dataSource == ((other as? UnwrappedDataSource<*>)?.dataSource ?: other)
+}
+
+
+private class WrappedSourceAndConverter<D>(val sourceAndConverter : SourceAndConverter<*>, source : Source<D>, converter : Converter<D, ARGBType>) : SourceAndConverter<D>(source, converter) {
+
+	override fun equals(other: Any?): Boolean {
+		return sourceAndConverter == ((other as? WrappedSourceAndConverter<*>)?.sourceAndConverter ?: other)
+	}
+
+	override fun hashCode(): Int {
+		return sourceAndConverter.hashCode()
+	}
+}
+
 internal fun <D : Any> getDataSourceAndConverter(sourceAndConverter: SourceAndConverter<*>): SourceAndConverter<*> {
 	val data = sourceAndConverter.spimSource as? DataSource<D, *> ?: return sourceAndConverter
-	val dataSource = object : Source<D> {
-		override fun isPresent(t: Int) = data.isPresent(t)
-
-		override fun getSource(t: Int, level: Int) = data.getDataSource(t, level)
-
-		override fun getInterpolatedSource(t: Int, level: Int, method: Interpolation?) = data.getInterpolatedDataSource(t, level, method)
-
-		override fun getSourceTransform(t: Int, level: Int, transform: AffineTransform3D?) {
-			data.getSourceTransform(t, level, transform)
-		}
-
-		override fun getType() = data.dataType
-
-		override fun getName() = data.name
-
-		override fun getVoxelDimensions() = data.voxelDimensions
-
-		override fun getNumMipmapLevels() = data.numMipmapLevels
-
-		override fun hashCode() = data.hashCode()
-
-		override fun equals(other: Any?) = data == other
-	}
+	val unwrappedDataSource = UnwrappedDataSource(data)
 
 	val converter = sourceAndConverter.converter.let {
 		(it as? HighlightingStreamConverterVolatileLabelMultisetType)?.nonVolatileConverter ?: it
 	} as Converter<D, ARGBType>
 
-	return SourceAndConverter(dataSource, converter)
-
+	return WrappedSourceAndConverter(sourceAndConverter, unwrappedDataSource, converter)
 }

--- a/src/main/kotlin/org/janelia/saalfeldlab/bdv/fx/viewer/SourceUtils.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/bdv/fx/viewer/SourceUtils.kt
@@ -9,12 +9,8 @@ import net.imglib2.type.numeric.ARGBType
 import org.janelia.saalfeldlab.paintera.data.DataSource
 import org.janelia.saalfeldlab.paintera.stream.HighlightingStreamConverterVolatileLabelMultisetType
 
-interface CompositeSourceSupplier {
-	fun getCompositeSource() : Source<*>
-}
-
 internal fun <D : Any> getDataSourceAndConverter(sourceAndConverter: SourceAndConverter<*>): SourceAndConverter<*> {
-	val data = sourceAndConverter.spimSource as? DataSource<D, *> ?: return  sourceAndConverter
+	val data = sourceAndConverter.spimSource as? DataSource<D, *> ?: return sourceAndConverter
 	val dataSource = object : Source<D> {
 		override fun isPresent(t: Int) = data.isPresent(t)
 
@@ -28,21 +24,21 @@ internal fun <D : Any> getDataSourceAndConverter(sourceAndConverter: SourceAndCo
 
 		override fun getType() = data.dataType
 
-		override fun getName() = sourceAndConverter.spimSource.name
+		override fun getName() = data.name
 
 		override fun getVoxelDimensions() = data.voxelDimensions
 
 		override fun getNumMipmapLevels() = data.numMipmapLevels
+
+		override fun hashCode() = data.hashCode()
+
+		override fun equals(other: Any?) = data == other
 	}
 
 	val converter = sourceAndConverter.converter.let {
 		(it as? HighlightingStreamConverterVolatileLabelMultisetType)?.nonVolatileConverter ?: it
 	} as Converter<D, ARGBType>
 
-	return object : SourceAndConverter<D>(dataSource, converter), CompositeSourceSupplier {
-		override fun getCompositeSource(): Source<*> {
-			return sourceAndConverter.spimSource
-		}
-	}
+	return SourceAndConverter(dataSource, converter)
 
 }

--- a/src/main/kotlin/org/janelia/saalfeldlab/bdv/fx/viewer/SourceUtils.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/bdv/fx/viewer/SourceUtils.kt
@@ -1,0 +1,35 @@
+package org.janelia.saalfeldlab.bdv.fx.viewer
+
+import bdv.viewer.Interpolation
+import bdv.viewer.Source
+import bdv.viewer.SourceAndConverter
+import net.imglib2.converter.Converter
+import net.imglib2.realtransform.AffineTransform3D
+import net.imglib2.type.numeric.ARGBType
+import org.janelia.saalfeldlab.paintera.data.DataSource
+
+internal fun <D : Any> getDataSourceAndConverter(sourceAndConverter: SourceAndConverter<*>): SourceAndConverter<*> {
+	val data = sourceAndConverter.spimSource as? DataSource<D, *> ?: return  sourceAndConverter
+	val dataSource = object : Source<D> {
+		override fun isPresent(t: Int) = data.isPresent(t)
+
+		override fun getSource(t: Int, level: Int) = data.getDataSource(t, level)
+
+		override fun getInterpolatedSource(t: Int, level: Int, method: Interpolation?) = data.getInterpolatedDataSource(t, level, method)
+
+		override fun getSourceTransform(t: Int, level: Int, transform: AffineTransform3D?) {
+			data.getSourceTransform(t, level, transform)
+		}
+
+		override fun getType() = data.dataType
+
+		override fun getName() = sourceAndConverter.spimSource.name
+
+		override fun getVoxelDimensions() = data.voxelDimensions
+
+		override fun getNumMipmapLevels() = data.numMipmapLevels
+	}
+
+	return SourceAndConverter(dataSource, sourceAndConverter.converter as Converter<D, ARGBType>)
+
+}

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/cache/SamEmbeddingLoaderCache.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/cache/SamEmbeddingLoaderCache.kt
@@ -86,9 +86,12 @@ object SamEmbeddingLoaderCache : AsyncCacheWithLoader<RenderUnitState, OnnxTenso
 		}
 
 		override fun handle(now: Long) {
-			if (requestCountDown.getAndDecrement() <= 0) {
+			return
+			/* currently using -1 to indicate no change to the transform */
+			if (requestCountDown.get() == -1) return
+			else if (requestCountDown.getAndDecrement() == 0) {
 				previousJob = load(viewer, globalToViewerTransform, sessionId)
-				requestCountDown.getAndSet(REQUEST_COUNTDOWN)
+				requestCountDown.getAndSet(-1)
 			}
 		}
 

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/cache/SamEmbeddingLoaderCache.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/cache/SamEmbeddingLoaderCache.kt
@@ -17,11 +17,13 @@ import net.imglib2.parallel.TaskExecutors
 import net.imglib2.realtransform.AffineTransform3D
 import org.apache.commons.lang.builder.HashCodeBuilder
 import org.apache.http.HttpException
+import org.apache.http.client.HttpClient
 import org.apache.http.client.config.RequestConfig
 import org.apache.http.client.methods.HttpGet
 import org.apache.http.client.methods.HttpPost
 import org.apache.http.entity.ContentType
 import org.apache.http.entity.mime.MultipartEntityBuilder
+import org.apache.http.impl.client.BasicCookieStore
 import org.apache.http.impl.client.HttpClientBuilder
 import org.apache.http.util.EntityUtils
 import org.janelia.saalfeldlab.bdv.fx.viewer.ViewerPanelFX
@@ -238,6 +240,12 @@ object SamEmbeddingLoaderCache : AsyncCacheWithLoader<RenderUnitState, OnnxTenso
 		return super.load(sessionState)
 	}
 
+	val client: HttpClient = HttpClientBuilder.create()
+					.useSystemProperties()
+					.setDefaultRequestConfig(requestConfig)
+					.setDefaultCookieStore(BasicCookieStore())
+					.build()
+
 	private fun getSessionId(): String {
 		val url =
 			with(paintera.properties.segmentAnythingConfig) {
@@ -248,7 +256,6 @@ object SamEmbeddingLoaderCache : AsyncCacheWithLoader<RenderUnitState, OnnxTenso
 
 		val getSessionId = HttpGet(url)
 
-		val client = HttpClientBuilder.create().useSystemProperties().setDefaultRequestConfig(requestConfig).build()
 		val response = client.execute(getSessionId)
 		return EntityUtils.toString(response.entity!!, Charsets.UTF_8)
 	}
@@ -301,7 +308,7 @@ object SamEmbeddingLoaderCache : AsyncCacheWithLoader<RenderUnitState, OnnxTenso
 
 		val url = with(paintera.properties.segmentAnythingConfig) {
 			with(SegmentAnythingConfig) {
-				val compress = if (compressEncoding) "$COMPRESS_ENCODING_PARAMETER" else ""
+				val compress = if (compressEncoding) COMPRESS_ENCODING_PARAMETER else ""
 				"$serviceUrl/$EMBEDDING_REQUEST_ENDPOINT?$compress"
 			}
 		}

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/cache/SamEmbeddingLoaderCache.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/cache/SamEmbeddingLoaderCache.kt
@@ -89,7 +89,6 @@ object SamEmbeddingLoaderCache : AsyncCacheWithLoader<RenderUnitState, OnnxTenso
 		}
 
 		override fun handle(now: Long) {
-			return
 			/* currently using -1 to indicate no change to the transform */
 			if (requestCountDown.get() == -1) return
 			else if (requestCountDown.getAndDecrement() == 0) {

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/cache/SamEmbeddingLoaderCache.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/cache/SamEmbeddingLoaderCache.kt
@@ -25,6 +25,7 @@ import org.apache.http.entity.mime.MultipartEntityBuilder
 import org.apache.http.impl.client.HttpClientBuilder
 import org.apache.http.util.EntityUtils
 import org.janelia.saalfeldlab.bdv.fx.viewer.ViewerPanelFX
+import org.janelia.saalfeldlab.bdv.fx.viewer.getDataSourceAndConverter
 import org.janelia.saalfeldlab.fx.extensions.LazyForeignValue
 import org.janelia.saalfeldlab.fx.ortho.OrthogonalViews.ViewerAndTransforms
 import org.janelia.saalfeldlab.paintera.PainteraBaseView
@@ -343,7 +344,10 @@ object SamEmbeddingLoaderCache : AsyncCacheWithLoader<RenderUnitState, OnnxTenso
 
 	fun ViewerPanelFX.getSamRenderState(globalToViewerTransform: AffineTransform3D? = null, size: Pair<Long, Long>? = null): RenderUnitState {
 		val activeSourceToSkip = paintera.currentSource?.sourceAndConverter?.spimSource
-		val sacs = state.sources.filterNot { it.spimSource == activeSourceToSkip }.toList()
+		val sacs = state.sources
+			.filterNot { it.spimSource == activeSourceToSkip }
+			.map { sac -> getDataSourceAndConverter<Any> (sac) } // to ensure non-volatile
+			.toList()
 		return RenderUnitState(
 			globalToViewerTransform?.copy() ?: AffineTransform3D().also { state.getViewerTransform(it) },
 			state.timepoint,
@@ -354,8 +358,8 @@ object SamEmbeddingLoaderCache : AsyncCacheWithLoader<RenderUnitState, OnnxTenso
 	}
 
 	private val LOG = KotlinLogging.logger { }
-	private const val HTTP_SUCCESS = 200;
-	private const val HTTP_CANCELLED = 499;
+	private const val HTTP_SUCCESS = 200
+	private const val HTTP_CANCELLED = 499
 }
 
 private data class SessionRenderUnitState(val sessionId: String, val state: RenderUnitState) : RenderUnitState(state.transform, state.timepoint, state.sources, state.width, state.height) {

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/modes/ShapeInterpolationMode.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/modes/ShapeInterpolationMode.kt
@@ -21,6 +21,7 @@ import net.imglib2.type.numeric.integer.UnsignedLongType
 import net.imglib2.util.Intervals
 import net.imglib2.view.IntervalView
 import net.imglib2.view.Views
+import org.janelia.saalfeldlab.bdv.fx.viewer.getDataSourceAndConverter
 import org.janelia.saalfeldlab.control.mcu.MCUButtonControl
 import org.janelia.saalfeldlab.fx.actions.ActionSet
 import org.janelia.saalfeldlab.fx.actions.ActionSet.Companion.installActionSet
@@ -398,6 +399,7 @@ class ShapeInterpolationMode<D : IntegerType<D>>(val controller: ShapeInterpolat
 			val activeSource = activeSourceStateProperty.value!!.sourceAndConverter!!.spimSource
 			val sources = mask.viewer.state.sources
 				.filter { it.spimSource !== activeSource }
+				.map { sac -> getDataSourceAndConverter<Any> (sac) } // to ensure non-volatile
 				.toList()
 
 			val renderState = RenderUnitState(mask.initialGlobalToViewerTransform.copy(), mask.info.time, sources, width.toLong(), height.toLong())

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/tools/paint/PaintBrushTool.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/tools/paint/PaintBrushTool.kt
@@ -251,14 +251,43 @@ open class PaintBrushTool(activeSourceStateProperty: SimpleObjectProperty<Source
 	}
 
 	protected fun getBrushActions() = arrayOf(
-		painteraActionSet("change brush size", PaintActionType.SetBrushSize) {
+		painteraActionSet("change_brush_size", PaintActionType.SetBrushSize) {
 			ScrollEvent.SCROLL {
 				keysExclusive = false
-				name = "change brush size"
+				name = "scroll_brush_size"
 
 				verifyEventNotNull()
 				verify { !it!!.isShiftDown }
 				onAction { paint2D.changeBrushRadius(it!!.deltaY) }
+			}
+			arrayOf(KeyCode.EQUALS, KeyCode.UP, KeyCode.PLUS).map { key ->
+				KEY_PRESSED(key) {
+					keysExclusive = false
+					name = "plus_brush_size"
+					verifyEventNotNull()
+					onAction {
+						paint2D.increaseBrushRadius()
+						if (it?.isShiftDown == true) {
+							paint2D.increaseBrushRadius()
+							paint2D.increaseBrushRadius()
+						}
+					}
+				}
+			}
+
+			arrayOf(KeyCode.MINUS, KeyCode.DOWN).map { key ->
+				KEY_PRESSED(key) {
+					keysExclusive = false
+					name = "minus_brush_size"
+					verifyEventNotNull()
+					onAction {
+						paint2D.decreaseBrushRadius()
+						if (it?.isShiftDown == true) {
+							paint2D.decreaseBrushRadius()
+							paint2D.decreaseBrushRadius()
+						}
+					}
+				}
 			}
 		},
 		painteraActionSet(CHANGE_BRUSH_DEPTH, PaintActionType.SetBrushDepth) {

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/tools/paint/SamTool.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/tools/paint/SamTool.kt
@@ -1010,38 +1010,13 @@ open class SamTool(activeSourceStateProperty: SimpleObjectProperty<SourceState<*
 						composite.set(compositeVal)
 					}.interval(maskAlignedSelectedComponents)
 
-
-				val compositeVolatileMask = originalVolatileBackingImage!!
-					.extendValue(VolatileUnsignedLongType(Label.INVALID))
-					.convertWith(maskAlignedSelectedComponents, VolatileUnsignedLongType(Label.INVALID)) { original, overlay, composite ->
-						val setCompositeVal = {
-							var checkOriginal = false
-							val overlayVal = overlay.get()
-							if (overlayVal == predictionLabel) {
-								composite.get().set(predictionLabel)
-								composite.isValid = true
-							} else checkOriginal = true
-							if (checkOriginal) {
-								if (original.isValid) {
-									composite.set(original)
-									composite.isValid = true
-								} else composite.isValid = false
-								composite.isValid = true
-							}
-						}
-						if (maskPriority == MaskPriority.PREDICTION || !original.isValid) {
-							setCompositeVal()
-						} else {
-							val originalVal = original.get().get()
-							if (originalVal != Label.INVALID) {
-								composite.set(originalVal)
-								composite.isValid = true
-							} else setCompositeVal()
-						}
-					}.interval(maskAlignedSelectedComponents)
+				val compositeMaskAsVolatile = compositeMask.convertRAI(VolatileUnsignedLongType(0L)) { source, output ->
+					output.set(source.get())
+					output.isValid = true
+				}
 
 				paintMask.updateBackingImages(
-					compositeMask to compositeVolatileMask,
+					compositeMask to compositeMaskAsVolatile,
 					writableSourceImages = originalBackingImage to originalVolatileBackingImage
 				)
 

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/meshes/MeshSettings.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/meshes/MeshSettings.kt
@@ -61,7 +61,7 @@ class MeshSettings @JvmOverloads constructor(
 			val maxLevelOfDetail = 10
 
 			@JvmStatic
-			val levelOfDetail = (minLevelOfDetail + maxLevelOfDetail) / 2
+			val levelOfDetail = 8
 		}
 
 		companion object {
@@ -72,7 +72,7 @@ class MeshSettings @JvmOverloads constructor(
 			fun getDefaultCoarsestScaleLevel(numScaleLevels: Int) = numScaleLevels - 1
 
 			@JvmStatic
-			fun getDefaultFinestScaleLevel(numScaleLevels: Int) = numScaleLevels / 2
+			fun getDefaultFinestScaleLevel(numScaleLevels: Int) = 0
 		}
 	}
 

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/ui/dialogs/create/CreateDataset.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/ui/dialogs/create/CreateDataset.kt
@@ -394,6 +394,11 @@ class CreateDataset(private val currentSource: Source<*>?, vararg allSources: So
 			levels.add(level)
 		}
 		provideAbsoluteValues(levels, resolution, dimensions)
+		levels.removeIf { level ->
+			val isFirst = level == levels[0]
+			val tooSmall = level.dimensions.asLongArray().zip(blockSize.asLongArray()).all { (dim, block) -> dim <= block  }
+			!isFirst && tooSmall
+		}
 		mipmapLevels.clear()
 		mipmapLevels += levels
 	}


### PR DESCRIPTION
- **fix: SamCacheLoader should be robust to child job failures**
- **perf: remove scale levels that are too small**
- **fix: don't constantly request new navigation based embeddings**
- **fix: use non-volatile source for SAM render**
- **fix: support rendering of non-volatile LMT**
- **feat: change mesh settings defaults**
- **fix: cancel selectAll from prior attempts**
- **feat: reuse clients, accept cookies**
- **fix: wrap nonvolatile for volatile sam image**
- **fix: better fix for non-volatile data source composite**
- **perf: shape interpolation improvements**
- **fix: ensure unwrapped/wrapped SourceAndConverter for non-volatile data sources play nicely with the sam cache loader**
- **feat: change brush size with keys (minus,down and equals,plus,up)**
