### PR TITLE
1.10.3 shape interpolation bug fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -415,7 +415,7 @@
 		<dependency>
 			<groupId>de.jensd</groupId>
 			<artifactId>fontawesomefx-commons</artifactId>
-			<version>11.0</version>
+			<version>9.1.2</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.openjfx</groupId>
@@ -438,7 +438,7 @@
 		<dependency>
 			<groupId>de.jensd</groupId>
 			<artifactId>fontawesomefx-controls</artifactId>
-			<version>11.0</version>
+			<version>9.1.2</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.openjfx</groupId>
@@ -465,7 +465,7 @@
 		<dependency>
 			<groupId>de.jensd</groupId>
 			<artifactId>fontawesomefx-fontawesome</artifactId>
-			<version>4.7.0-11</version>
+			<version>4.7.0-9.1.2</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.openjfx</groupId>

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/ShapeInterpolationController.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/ShapeInterpolationController.kt
@@ -68,6 +68,8 @@ import java.util.function.Supplier
 import kotlin.math.absoluteValue
 import kotlin.math.sqrt
 
+private val EMPTY_3D_INTERVAL = Intervals.createMinSize(0, 0, 0, 0, 0, 0)
+
 class ShapeInterpolationController<D : IntegerType<D>>(
 	val source: MaskedSource<D, *>,
 	private val refreshMeshes: () -> Unit,
@@ -492,7 +494,7 @@ class ShapeInterpolationController<D : IntegerType<D>>(
 						.extendValue(Label.INVALID)
 						.interpolateNearestNeighbor()
 						.affineReal(initialGlobalToMaskTransform.inverse())
-						.realInterval(slice.globalBoundingBox!!)
+						.realInterval(slice.globalBoundingBox ?: EMPTY_3D_INTERVAL)
 				}
 			}
 			val invalidLabel = UnsignedLongType(Label.INVALID)

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/ShapeInterpolationController.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/ShapeInterpolationController.kt
@@ -35,7 +35,6 @@ import net.imglib2.type.numeric.real.FloatType
 import net.imglib2.type.volatiles.VolatileUnsignedLongType
 import net.imglib2.util.ConstantUtils
 import net.imglib2.util.Intervals
-import net.imglib2.util.Util
 import net.imglib2.view.ExtendedRealRandomAccessibleRealInterval
 import net.imglib2.view.IntervalView
 import net.imglib2.view.Views
@@ -353,35 +352,44 @@ class ShapeInterpolationController<D : IntegerType<D>>(
 		Last
 	}
 
-	//TODO Caleb: Controller should not move, let the tool/mode do that
-	fun editSelection(choice: EditSelectionChoice) {
+	private var currentMovementToTargetSlice : Pair<Job, SliceInfo>? = null
+
+	//TODO Caleb: Controller should not handle moving, let the tool/mode do that
+	fun editSelection(choice: EditSelectionChoice, slice: SliceInfo? = null) {
+
+		val fromSlice = currentMovementToTargetSlice?.let { (job, curTargetSlice) ->
+			currentMovementToTargetSlice = null
+			job.cancel()
+			controllerState = ControllerState.Select
+			curTargetSlice
+		} ?: slice
+
 		val slices = slicesAndInterpolants.slices
-		when (choice) {
+		val depth = fromSlice?.globalTransform?.let { depthAt(it) } ?: currentDepth
+		val targetSlice = when (choice) {
 			EditSelectionChoice.First -> slices.getOrNull(0) /* move to first */
-			EditSelectionChoice.Previous -> slicesAndInterpolants.previousSlice(currentDepth)
-				?: slices.getOrNull(0) /* move to previous, or first if none */
-			EditSelectionChoice.Next -> slicesAndInterpolants.nextSlice(currentDepth)
-				?: slices.getOrNull(slices.size - 1) /* move to next, or last if none */
+			EditSelectionChoice.Previous -> slicesAndInterpolants.previousSlice(depth) ?: slices.getOrNull(0) /* move to previous, or first if none */
+			EditSelectionChoice.Next -> slicesAndInterpolants.nextSlice(depth) ?: slices.getOrNull(slices.size - 1) /* move to next, or last if none */
 			EditSelectionChoice.Last -> slices.getOrNull(slices.size - 1) /* move to last */
-		}?.let { slice ->
-			moveToSlice(slice)
-		}
+		} ?: return
+
+
+		currentMovementToTargetSlice = moveToSlice(targetSlice) to targetSlice
 	}
 
-	fun moveTo(globalTransform: AffineTransform3D) {
-		InvokeOnJavaFXApplicationThread {
-			paintera().manager().apply {
-				setTransform(globalTransform, Duration(300.0)) {
+	fun moveTo(globalTransform: AffineTransform3D) = InvokeOnJavaFXApplicationThread {
+		paintera().manager().apply {
+			setTransform(globalTransform, Duration(300.0)) {
+				if (isActive)
 					transform = globalTransform
 					controllerState = ControllerState.Select
-				}
 			}
 		}
 	}
 
-	private fun moveToSlice(sliceInfo: SliceInfo) {
+	private fun moveToSlice(sliceInfo: SliceInfo): Job {
 		controllerState = ControllerState.Moving
-		moveTo(sliceInfo.globalTransform)
+		return moveTo(sliceInfo.globalTransform)
 	}
 
 	@JvmOverloads

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/modes/ShapeInterpolationMode.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/modes/ShapeInterpolationMode.kt
@@ -214,6 +214,21 @@ class ShapeInterpolationMode<D : IntegerType<D>>(val controller: ShapeInterpolat
 				keyPressEditSelectionAction(EditSelectionChoice.Last, SHAPE_INTERPOLATION__SELECT_LAST_SLICE)
 				keyPressEditSelectionAction(EditSelectionChoice.Previous, SHAPE_INTERPOLATION__SELECT_PREVIOUS_SLICE)
 				keyPressEditSelectionAction(EditSelectionChoice.Next, SHAPE_INTERPOLATION__SELECT_NEXT_SLICE)
+				//FIXME Caleb: There is a bug when navigating slices quickly that occasionally the correct action above will not
+				//  trigger. When the arrows keys are the expected trigger, this then triggers the parent/sibling nodes focuse traversal
+				//  and causes the focus to escape the active orthoslice. When this happens it appears that shape interpolation
+				//  no longer is working, since the arrow keys do nothing. you can manually re-focuse the orthoslice, but you need to
+				//  know to do this.
+				//  The following is a hack for now until the cause of the issues can be resolved. For future notes, it appears to be when
+				//  asking the KeyTracker if the trigger key matches the current key state, and it erroneously returns false, even when
+				//  the KeyEvent.code matches.
+				KEY_PRESSED {
+					onAction { event ->
+						val triggers = listOf(SHAPE_INTERPOLATION__SELECT_FIRST_SLICE, SHAPE_INTERPOLATION__SELECT_LAST_SLICE, SHAPE_INTERPOLATION__SELECT_PREVIOUS_SLICE, SHAPE_INTERPOLATION__SELECT_NEXT_SLICE)
+						if (triggers.any { it.primaryCombination.match(event) })
+							event?.consume()
+					}
+				}
 			},
 			painteraDragActionSet("drag activate SAM mode with box", PaintActionType.Paint, ignoreDisable = true, consumeMouseClicked = true) {
 				dragDetectedAction.apply {

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/modes/ShapeInterpolationMode.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/modes/ShapeInterpolationMode.kt
@@ -30,8 +30,6 @@ import org.controlsfx.control.Notifications
 import org.janelia.saalfeldlab.bdv.fx.viewer.getDataSourceAndConverter
 import org.janelia.saalfeldlab.control.mcu.MCUButtonControl
 import org.janelia.saalfeldlab.fx.actions.*
-import org.janelia.saalfeldlab.fx.actions.ActionSet.Companion.installActionSet
-import org.janelia.saalfeldlab.fx.actions.ActionSet.Companion.removeActionSet
 import org.janelia.saalfeldlab.fx.midi.MidiButtonEvent
 import org.janelia.saalfeldlab.fx.midi.MidiToggleEvent
 import org.janelia.saalfeldlab.fx.midi.ToggleAction
@@ -46,7 +44,6 @@ import org.janelia.saalfeldlab.paintera.cache.HashableTransform.Companion.hashab
 import org.janelia.saalfeldlab.paintera.cache.SamEmbeddingLoaderCache
 import org.janelia.saalfeldlab.paintera.cache.SamEmbeddingLoaderCache.calculateTargetSamScreenScaleFactor
 import org.janelia.saalfeldlab.paintera.control.ShapeInterpolationController
-import org.janelia.saalfeldlab.paintera.control.ShapeInterpolationController.ControllerState.Moving
 import org.janelia.saalfeldlab.paintera.control.ShapeInterpolationController.EditSelectionChoice
 import org.janelia.saalfeldlab.paintera.control.actions.AllowedActions
 import org.janelia.saalfeldlab.paintera.control.actions.MenuActionType
@@ -320,28 +317,24 @@ class ShapeInterpolationMode<D : IntegerType<D>>(val controller: ShapeInterpolat
 						with(controller) {
 							MidiButtonEvent.BUTTON_PRESSED(9) {
 								name = "midi go to first slice"
-								verify { controllerState != Moving }
 								verify { activeTool !is SamTool }
 								onAction { editSelection(EditSelectionChoice.First) }
 
 							}
 							MidiButtonEvent.BUTTON_PRESSED(10) {
 								name = "midi go to previous slice"
-								verify { controllerState != Moving }
 								verify { activeTool !is SamTool }
 								onAction { editSelection(EditSelectionChoice.Previous) }
 
 							}
 							MidiButtonEvent.BUTTON_PRESSED(11) {
 								name = "midi go to next slice"
-								verify { controllerState != Moving }
 								verify { activeTool !is SamTool }
 								onAction { editSelection(EditSelectionChoice.Next) }
 
 							}
 							MidiButtonEvent.BUTTON_PRESSED(12) {
 								name = "midi go to last slice"
-								verify { controllerState != Moving }
 								verify { activeTool !is SamTool }
 								onAction { editSelection(EditSelectionChoice.Last) }
 							}
@@ -417,7 +410,7 @@ class ShapeInterpolationMode<D : IntegerType<D>>(val controller: ShapeInterpolat
 						{ GlyphScaleView(FontAwesomeIconView().also { it.styleClass += "interpolation-last-slice" }) }
 					}
 				}
-				verify { controllerState != Moving && activeTool is ShapeInterpolationTool }
+				verify { activeTool is ShapeInterpolationTool }
 				onAction { editSelection(choice) }
 				handleException {
 					exitShapeInterpolation(false)

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/modes/ShapeInterpolationMode.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/modes/ShapeInterpolationMode.kt
@@ -531,7 +531,9 @@ class ShapeInterpolationMode<D : IntegerType<D>>(val controller: ShapeInterpolat
 
 		/* IF slice exists at depth AND transform is different THEN delete until first non-pregenerated slices */
 		samSliceCache[sliceDepth]?.sliceInfo?.let {
-			if (it.mask.initialGlobalToViewerTransform.hashable() != viewerMask.initialGlobalToViewerTransform.hashable()) {
+			val diffTransform = it.mask.initialGlobalToViewerTransform.hashable() != viewerMask.initialGlobalToViewerTransform.hashable()
+			val diffMask = it.maskBoundingBox != selectionIntervalOverMask
+			if (diffTransform || diffMask) {
 				val depths = samSliceCache.keys.toList().sorted()
 				val depthIdx = depths.indexOf(sliceDepth.toFloat())
 				for (idx in depthIdx - 1 downTo 0) {


### PR DESCRIPTION
bug fixes:
1. correctly invalidate eager SAM prediction slice when updating adjacent slices bounding boxes in shape interpolation
2. fix handling of empty slices in shape interpolation (empty slices are slices with no valid ID, or an empty bounding box)
3. better handling of rapid slice navigation in shape interpolation