### PR TITLE
fix ESC to exit nested tool in ShapeInterpolation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 		<main-class>org.janelia.saalfeldlab.paintera.Paintera</main-class>
 		<app.name>Paintera</app.name>
 		<app.package>paintera</app.package>
-		<app.version>1.10.3</app.version>
+		<app.version>1.10.4</app.version>
 
 		<jvm.modules>javafx.base,javafx.controls,javafx.fxml,javafx.media,javafx.swing,javafx.web,javafx.graphics,java.naming,java.management,java.sql</jvm.modules>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/modes/ShapeInterpolationMode.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/control/modes/ShapeInterpolationMode.kt
@@ -221,14 +221,18 @@ class ShapeInterpolationMode<D : IntegerType<D>>(val controller: ShapeInterpolat
 				//  know to do this.
 				//  The following is a hack for now until the cause of the issues can be resolved. For future notes, it appears to be when
 				//  asking the KeyTracker if the trigger key matches the current key state, and it erroneously returns false, even when
-				//  the KeyEvent.code matches.
-				KEY_PRESSED {
-					onAction { event ->
-						val triggers = listOf(SHAPE_INTERPOLATION__SELECT_FIRST_SLICE, SHAPE_INTERPOLATION__SELECT_LAST_SLICE, SHAPE_INTERPOLATION__SELECT_PREVIOUS_SLICE, SHAPE_INTERPOLATION__SELECT_NEXT_SLICE)
-						if (triggers.any { it.primaryCombination.match(event) })
-							event?.consume()
-					}
-				}
+                //  the KeyEvent.code matches.
+                KEY_PRESSED {
+                    verify { event ->
+                        val triggers = listOf(
+                            SHAPE_INTERPOLATION__SELECT_FIRST_SLICE,
+                            SHAPE_INTERPOLATION__SELECT_LAST_SLICE,
+                            SHAPE_INTERPOLATION__SELECT_PREVIOUS_SLICE,
+                            SHAPE_INTERPOLATION__SELECT_NEXT_SLICE
+                        )
+                        triggers.any { it.primaryCombination.match(event) }
+                    }
+                }
 			},
 			painteraDragActionSet("drag activate SAM mode with box", PaintActionType.Paint, ignoreDisable = true, consumeMouseClicked = true) {
 				dragDetectedAction.apply {


### PR DESCRIPTION
avoid accidentally consuming all key events when trying to filter out erroneous slice navigation events