### PR TITLE
fix: status bar overlay at the bottom, not the top

### DIFF
--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/BorderPaneWithStatusBars.kt
@@ -64,6 +64,7 @@ class BorderPaneWithStatusBars(paintera: PainteraMainWindow) {
 	private val centerPaneTopRightAlignGroup = Group().also { StackPane.setAlignment(it, Pos.TOP_RIGHT) }
 
 	private val centerPaneBottomAlignGroup = HBox().also {
+		it.alignment = Pos.BOTTOM_LEFT
 		StackPane.setAlignment(it, Pos.BOTTOM_LEFT)
 		it.isFillHeight = false
 		it.mouseTransparentProperty().set(true)

--- a/src/main/kotlin/org/janelia/saalfeldlab/paintera/config/StatusBarConfig.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/paintera/config/StatusBarConfig.kt
@@ -7,8 +7,8 @@ import javafx.beans.property.SimpleObjectProperty
 class StatusBarConfig {
 
 	enum class Mode {
-		OVERLAY,
-		BOTTOM;
+		BOTTOM,
+		OVERLAY;
 
 		fun next() = next(this)
 
@@ -19,7 +19,7 @@ class StatusBarConfig {
 
 	private val _isVisible = SimpleBooleanProperty(true)
 
-	private val _mode = SimpleObjectProperty(Mode.OVERLAY)
+	private val _mode = SimpleObjectProperty(Mode.BOTTOM)
 
 	var isVisible: Boolean
 		get() = _isVisible.get()


### PR DESCRIPTION
feat: default status bar location is bottom, instead of overlay