### PR TITLE
build: include runtime deps in the copy-dependencies; used for buildi…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -671,8 +671,7 @@
 							<goal>copy-dependencies</goal>
 						</goals>
 						<configuration>
-							<!-- Include only compile stage dependencies (no test dependencies) -->
-							<includeScope>compile</includeScope>
+							<includeScope>runtime</includeScope>
 							<!-- The JavaFX libraries are bundled into the custom JVM, so we don't want to duplicate
 							them in the bundled app and installer. This command skips all of the JavaFX by groupId. -->
 							<excludeGroupIds>org.openjfx</excludeGroupIds>


### PR DESCRIPTION
…ng installers