### PR TITLE
build: bump pom; remove blosc step from actions and add blosc-java dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install Blosc
-        run: sudo apt install -y libblosc1
-
       - name: Cache m2 folder
         uses: actions/cache@v4
         env:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>43.0.0</version>
+		<version>44.0.0</version>
 	</parent>
 
 	<groupId>org.janelia.saalfeldlab</groupId>
@@ -214,6 +214,13 @@
 			<groupId>se.sawano.java</groupId>
 			<artifactId>alphanumeric-comparator</artifactId>
 			<version>${alphanumeric-comparator.version}</version>
+		</dependency>
+
+		<!-- add blosc-java so we don't need to install blosc separately -->
+		<dependency>
+			<groupId>com.scalableminds</groupId>
+			<artifactId>blosc-java</artifactId>
+			<version>0.3-1.21.6</version>
 		</dependency>
 
 		<!--		logging -->


### PR DESCRIPTION
Add blosc-java dependency as a jar dependency. Avoids the need for separate blosc install per-platform 